### PR TITLE
Change return in wallet mode to "Peerid.Did" form.

### DIFF
--- a/command/did.go
+++ b/command/did.go
@@ -145,6 +145,7 @@ func (cmd *Command) CreateDID() {
 		DIDImgFileName: cmd.didImgFile,
 		PubImgFile:     cmd.pubImgFile,
 		PubKeyFile:     cmd.pubKeyFile,
+		PeerID:         cmd.peerID,
 	}
 	msg, status := cmd.c.CreateDID(&cfg)
 	if !status {

--- a/did/did.go
+++ b/did/did.go
@@ -222,6 +222,10 @@ func (d *DID) CreateDID(didCreate *DIDCreate) (string, error) {
 	t2 := time.Now()
 	dif := t2.Sub(t1)
 	fmt.Printf("DID : %s, Time to create DID & Keys : %v", did, dif)
+	if didCreate.Type == WalletDIDMode {
+		return didCreate.PeerID + "." + did, nil
+	}
+
 	return did, nil
 }
 

--- a/did/model.go
+++ b/did/model.go
@@ -33,6 +33,7 @@ type DIDCreate struct {
 	PubImgFile     string `json:"pub_img_file"`
 	PrivImgFile    string `json:"priv_img_file"`
 	PubKeyFile     string `json:"pub_key_file"`
+	PeerID         string `json:"peer_id"`
 }
 
 type DIDSignature struct {


### PR DESCRIPTION
The return string in wallet mode is changed to the format PeerId.Did.