### PR TITLE
adding and removing explorer URLs to config file

### DIFF
--- a/client/explorer.go
+++ b/client/explorer.go
@@ -1,0 +1,39 @@
+package client
+
+import (
+	"github.com/rubixchain/rubixgoplatform/core/model"
+	"github.com/rubixchain/rubixgoplatform/setup"
+)
+
+func (c *Client) AddExplorer(links []string) (string, bool) {
+	m := model.ExplorerLinks{
+		Links: links,
+	}
+	var rm model.BasicResponse
+	err := c.sendJSONRequest("POST", setup.APIAddExplorer, nil, &m, &rm)
+	if err != nil {
+		return err.Error(), false
+	}
+	return rm.Message, rm.Status
+}
+
+func (c *Client) RemoveExplorer(links []string) (string, bool) {
+	m := model.ExplorerLinks{
+		Links: links,
+	}
+	var rm model.BasicResponse
+	err := c.sendJSONRequest("POST", setup.APIRemoveExplorer, nil, &m, &rm)
+	if err != nil {
+		return err.Error(), false
+	}
+	return rm.Message, rm.Status
+}
+
+func (c *Client) GetAllExplorer() ([]string, string, bool) {
+	var rm model.ExplorerResponse
+	err := c.sendJSONRequest("GET", setup.APIGetAllExplorer, nil, nil, &rm)
+	if err != nil {
+		return nil, err.Error(), false
+	}
+	return rm.Result.Links, rm.Message, rm.Status
+}

--- a/command/command.go
+++ b/command/command.go
@@ -44,6 +44,9 @@ const (
 	RemoveBootStrapCmd             string = "removebootstrap"
 	RemoveAllBootStrapCmd          string = "removeallbootstrap"
 	GetAllBootStrapCmd             string = "getallbootstrap"
+	AddExplorerCmd                 string = "addexplorer"
+	RemoveExplorerCmd              string = "removeexplorer"
+	GetAllExplorerCmd              string = "getallexplorer"
 	CreateDIDCmd                   string = "createdid"
 	GetAllDIDCmd                   string = "getalldid"
 	AddQuorumCmd                   string = "addquorum"
@@ -86,6 +89,9 @@ var commands = []string{VersionCmd,
 	RemoveBootStrapCmd,
 	RemoveAllBootStrapCmd,
 	GetAllBootStrapCmd,
+	AddExplorerCmd,
+	RemoveExplorerCmd,
+	GetAllExplorerCmd,
 	CreateDIDCmd,
 	GetAllDIDCmd,
 	AddQuorumCmd,
@@ -129,6 +135,9 @@ var commandsHelp = []string{"To get tool version",
 	"This command will remove bootstrap peers from the configuration",
 	"This command will remove all bootstrap peers from the configuration",
 	"This command will get all bootstrap peers from the configuration",
+	"This command will add explorer link to the configuration",
+	"This command will remove explorer link from the configuration",
+	"This command will get all explorer links from the configuration",
 	"This command will create DID",
 	"This command will get all DID address",
 	"This command will add quorurm list to node",
@@ -181,6 +190,7 @@ type Command struct {
 	port               string
 	peerID             string
 	peers              []string
+	links              []string
 	log                logger.Logger
 	didRoot            bool
 	didType            int
@@ -506,6 +516,12 @@ func Run(args []string) {
 		cmd.removeAllBootStrap()
 	case GetAllBootStrapCmd:
 		cmd.getAllBootStrap()
+	case AddExplorerCmd:
+		cmd.addExplorer()
+	case RemoveExplorerCmd:
+		cmd.removeExplorer()
+	case GetAllExplorerCmd:
+		cmd.getAllExplorer()
 	case CreateDIDCmd:
 		cmd.CreateDID()
 	case GetAllDIDCmd:

--- a/command/explorer.go
+++ b/command/explorer.go
@@ -1,0 +1,38 @@
+package command
+
+func (cmd *Command) addExplorer() {
+	if len(cmd.links) == 0 {
+		cmd.log.Error("links required for Explorer")
+		return
+	}
+	msg, status := cmd.c.AddExplorer(cmd.links)
+
+	if !status {
+		cmd.log.Error("Add Explorer command failed, " + msg)
+	} else {
+		cmd.log.Info("Add Explorer command finished, " + msg)
+	}
+}
+
+func (cmd *Command) removeExplorer() {
+	if len(cmd.links) == 0 {
+		cmd.log.Error("links required for Explorer")
+		return
+	}
+	msg, status := cmd.c.RemoveExplorer(cmd.links)
+	if !status {
+		cmd.log.Error("Remove Explorer command failed, " + msg)
+	} else {
+		cmd.log.Info("Remove Explorer command finished, " + msg)
+	}
+}
+
+func (cmd *Command) getAllExplorer() {
+	links, msg, status := cmd.c.GetAllExplorer()
+	if !status {
+		cmd.log.Error("Get all Explorer command failed, " + msg)
+	} else {
+		cmd.log.Info("Get all Explorer command finished, " + msg)
+		cmd.log.Info("Explorer links", "links", links)
+	}
+}

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -28,6 +28,7 @@ type StorageConfig struct {
 type ConfigData struct {
 	Ports             Ports             `json:"ports"`
 	BootStrap         []string          `json:"bootstrap"`
+	Explorer         	[]string          `json:"explorer"`
 	Services          map[string]string `json:"services"`
 	StorageConfig     StorageConfig     `json:"storage_config"`
 	TestStorageConfig StorageConfig     `json:"test_storage_config"`

--- a/core/core.go
+++ b/core/core.go
@@ -126,6 +126,7 @@ func InitConfig(configFile string, encKey string, node uint16) error {
 					IPFSAPIPort:  (IPFSAPIPort + node),
 				},
 				BootStrap: []string{"/ip4/161.35.169.251/tcp/4001/p2p/12D3KooWPhZEYEw4jG3kSRuwgMEHcVt7KMkm1ui2ddu4fgSgwvDq", "/ip4/103.127.158.120/tcp/4001/p2p/12D3KooWSQ94HRDzFf6W2rp7P8gzP6efZQHTaSU8uaQjskVBHiWP", "/ip4/172.104.191.191/tcp/4001/p2p/12D3KooWFudnWZY1v1m4YXCzDWZSbNt7nvf5F42uzM6vErZ4NwqJ"},
+				Explorer: []string{"deamon-explorer.azurewebsites.net"},
 			},
 		}
 		cfgBytes, err := json.Marshal(cfg)

--- a/core/explorer.go
+++ b/core/explorer.go
@@ -179,6 +179,10 @@ func (c *Core) AddExplorer(links []string) error {
 	return err
 }
 
+func (c *Core) GetAllExplorer() []string {
+	return c.cfg.CfgData.Explorer
+}
+
 func (c *Core) RemoveExplorer(links []string) error {
 	for _, link := range links {
 		newitems := []string{}

--- a/core/explorer.go
+++ b/core/explorer.go
@@ -66,6 +66,7 @@ type ExplorerResponse struct {
 }
 
 func (c *Core) InitRubixExplorer() error {
+	// todo: fetch explorer URL from api_config.json file
 	url := "deamon-explorer.azurewebsites.net"
 	if c.testNet {
 		url = "rubix-deamon-api.ensurity.com"
@@ -165,6 +166,33 @@ func (ec *ExplorerClient) ExplorerDataTransaction(et *ExplorerDataTrans) error {
 	if !er.Status {
 		ec.log.Error("Failed to update explorer with data transaction", "msg", er.Message)
 		return fmt.Errorf("failed to update explorer")
+	}
+	return nil
+}
+
+func (c *Core) AddExplorer(links []string) error {
+	c.cfg.CfgData.Explorer = append(c.cfg.CfgData.Explorer, links...)
+	err := c.updateConfig()
+	if err != nil {
+		return err
+	}
+	return err
+}
+
+func (c *Core) RemoveExplorer(links []string) error {
+	for _, link := range links {
+		newitems := []string{}
+		update := false
+		for _, i := range c.cfg.CfgData.Explorer {
+			if i != link {
+				newitems = append(newitems, i)
+			} else {
+				update = true
+			}
+		}
+		if update {
+			c.cfg.CfgData.Explorer = newitems
+		}
 	}
 	return nil
 }

--- a/core/model/explorer.go
+++ b/core/model/explorer.go
@@ -1,0 +1,13 @@
+package model
+
+// ExplorerLinks
+type ExplorerLinks struct {
+	Links []string `json:"links"`
+}
+
+// ExplorerResponse used as model for the API responses
+type ExplorerResponse struct {
+	Status  bool           `json:"status"`
+	Message string         `json:"message"`
+	Result  ExplorerLinks `json:"result"`
+}

--- a/server/config.go
+++ b/server/config.go
@@ -113,7 +113,16 @@ func (s *Server) APISetupDB(req *ensweb.Request) *ensweb.Result {
 	return s.BasicResponse(req, true, "DB setup done successfully", nil)
 }
 
-// APIAddBootStrap will add bootstrap peers to the configuration
+// APIGetAllExplorer will remove all bootstrap peers from the configuration
+func (s *Server) APIGetAllExplorer(req *ensweb.Request) *ensweb.Result {
+	links := s.c.GetAllExplorer()
+	m := model.ExplorerLinks{
+		Links: links,
+	}
+	return s.BasicResponse(req, true, "Got all the bootstrap peers successfully", m)
+}
+
+// APIAddExplorer will add bootstrap peers to the configuration
 func (s *Server) APIAddExplorer(req *ensweb.Request) *ensweb.Result {
 	var m model.ExplorerLinks
 	err := s.ParseJSON(req, &m)
@@ -127,7 +136,7 @@ func (s *Server) APIAddExplorer(req *ensweb.Request) *ensweb.Result {
 	return s.BasicResponse(req, true, "explorer added successfully", nil)
 }
 
-// APIRemoveBootStrap will remove bootstrap peers from the configuration
+// APIRemoveExplorer will remove bootstrap peers from the configuration
 func (s *Server) APIRemoveExplorer(req *ensweb.Request) *ensweb.Result {
 	var m model.ExplorerLinks
 	err := s.ParseJSON(req, &m)

--- a/server/config.go
+++ b/server/config.go
@@ -112,3 +112,31 @@ func (s *Server) APISetupDB(req *ensweb.Request) *ensweb.Result {
 	}
 	return s.BasicResponse(req, true, "DB setup done successfully", nil)
 }
+
+// APIAddBootStrap will add bootstrap peers to the configuration
+func (s *Server) APIAddExplorer(req *ensweb.Request) *ensweb.Result {
+	var m model.ExplorerLinks
+	err := s.ParseJSON(req, &m)
+	if err != nil {
+		return s.BasicResponse(req, false, "invlid input request", nil)
+	}
+	err = s.c.AddExplorer(m.Links)
+	if err != nil {
+		return s.BasicResponse(req, false, "failed to add explorer, "+err.Error(), nil)
+	}
+	return s.BasicResponse(req, true, "explorer added successfully", nil)
+}
+
+// APIRemoveBootStrap will remove bootstrap peers from the configuration
+func (s *Server) APIRemoveExplorer(req *ensweb.Request) *ensweb.Result {
+	var m model.ExplorerLinks
+	err := s.ParseJSON(req, &m)
+	if err != nil {
+		return s.BasicResponse(req, false, "invlid input request", nil)
+	}
+	err = s.c.RemoveExplorer(m.Links)
+	if err != nil {
+		return s.BasicResponse(req, false, "failed to remove explorer, "+err.Error(), nil)
+	}
+	return s.BasicResponse(req, true, "explorer removed successfully", nil)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -26,6 +26,7 @@ const (
 	APIRemoveBootStrap     string = "/api/remove-bootstrap"
 	APIRemoveAllBootStrap  string = "/api/remove-all-bootstrap"
 	APIGetAllBootStrap     string = "/api/get-all-bootstrap"
+	APIGetAllExplorer     string = "/api/get-all-explorer"
 	APIAddExplorer        string = "/api/add-explorer"
 	APIRemoveExplorer     string = "/api/remove-explorer"
 	APICreateDID           string = "/api/createdid"

--- a/server/server.go
+++ b/server/server.go
@@ -26,6 +26,8 @@ const (
 	APIRemoveBootStrap     string = "/api/remove-bootstrap"
 	APIRemoveAllBootStrap  string = "/api/remove-all-bootstrap"
 	APIGetAllBootStrap     string = "/api/get-all-bootstrap"
+	APIAddExplorer        string = "/api/add-explorer"
+	APIRemoveExplorer     string = "/api/remove-explorer"
 	APICreateDID           string = "/api/createdid"
 	APIGetAllDID           string = "/api/getalldid"
 	APIAddQuorum           string = "/api/addquorum"
@@ -151,6 +153,8 @@ func (s *Server) RegisterRoutes() {
 	s.AddRoute(setup.APIRemoveBootStrap, "POST", s.AuthHandle(s.APIRemoveBootStrap, false, s.AuthError, true))
 	s.AddRoute(setup.APIRemoveAllBootStrap, "POST", s.AuthHandle(s.APIRemoveAllBootStrap, false, s.AuthError, true))
 	s.AddRoute(setup.APIGetAllBootStrap, "GET", s.AuthHandle(s.APIGetAllBootStrap, false, s.AuthError, true))
+	s.AddRoute(setup.APIAddExplorer, "POST", s.AuthHandle(s.APIAddExplorer, false, s.AuthError, true))
+	s.AddRoute(setup.APIRemoveExplorer, "POST", s.AuthHandle(s.APIRemoveExplorer, false, s.AuthError, true))
 	s.AddRoute(setup.APIGetDIDChallenge, "GET", s.APIGetDIDChallenge)
 	s.AddRoute(setup.APIGetDIDAccess, "POST", s.APIGetDIDAccess)
 	s.AddRoute(setup.APICreateDID, "POST", s.APICreateDID)

--- a/server/server.go
+++ b/server/server.go
@@ -153,6 +153,7 @@ func (s *Server) RegisterRoutes() {
 	s.AddRoute(setup.APIRemoveBootStrap, "POST", s.AuthHandle(s.APIRemoveBootStrap, false, s.AuthError, true))
 	s.AddRoute(setup.APIRemoveAllBootStrap, "POST", s.AuthHandle(s.APIRemoveAllBootStrap, false, s.AuthError, true))
 	s.AddRoute(setup.APIGetAllBootStrap, "GET", s.AuthHandle(s.APIGetAllBootStrap, false, s.AuthError, true))
+	s.AddRoute(setup.APIGetAllExplorer, "GET", s.AuthHandle(s.APIGetAllExplorer, false, s.AuthError, true))
 	s.AddRoute(setup.APIAddExplorer, "POST", s.AuthHandle(s.APIAddExplorer, false, s.AuthError, true))
 	s.AddRoute(setup.APIRemoveExplorer, "POST", s.AuthHandle(s.APIRemoveExplorer, false, s.AuthError, true))
 	s.AddRoute(setup.APIGetDIDChallenge, "GET", s.APIGetDIDChallenge)

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -20,6 +20,8 @@ const (
 	APIRemoveBootStrap                  string = "/api/remove-bootstrap"
 	APIRemoveAllBootStrap               string = "/api/remove-all-bootstrap"
 	APIGetAllBootStrap                  string = "/api/get-all-bootstrap"
+	APIAddExplorer                    	string = "/api/add-explorer"
+	APIRemoveExplorer             			string = "/api/remove-explorer"
 	APIGetDIDChallenge                  string = "/api/getdidchallenge"
 	APIGetDIDAccess                     string = "/api/logindid"
 	APICreateDID                        string = "/api/createdid"

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -20,6 +20,7 @@ const (
 	APIRemoveBootStrap                  string = "/api/remove-bootstrap"
 	APIRemoveAllBootStrap               string = "/api/remove-all-bootstrap"
 	APIGetAllBootStrap                  string = "/api/get-all-bootstrap"
+	APIGetAllExplorer                   string = "/api/get-all-explorer"
 	APIAddExplorer                    	string = "/api/add-explorer"
 	APIRemoveExplorer             			string = "/api/remove-explorer"
 	APIGetDIDChallenge                  string = "/api/getdidchallenge"


### PR DESCRIPTION
Introduced two new APIs to add and remove explorer URLs dynamically. These changes were essential since the `api_config.json` file is encrypted, making external modifications impossible. Also updated the `Core` struct to handle an array of explorer URLs.

### Changes
- [x] Added API to add explorer URL.
- [x] Added API to remove explorer URL.
- [ ] Updated `Core` struct to accept an array of explorer URLs .
- [ ] Run batch tests to validate all explorer URLs.

### Motivation
1. Encrypted `api_config.json` prevents any external modifications for security reasons.
2. The need for dynamically updating explorer URLs without compromising security.
3. Keeping changes centralized and secure through APIs.

### Testing
Batch tests will be run to ensure all explorer URLs are functional.