### PR TITLE
Added column for peer DID type in DIDPeerTable

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -519,6 +519,7 @@ func (c *Core) SetupDID(reqID string, didStr string) (did.DIDCrypto, error) {
 	}
 }
 
+// Initializes the did in it's corresponding did mode (basic/ light)
 func (c *Core) SetupForienDID(didStr string) (did.DIDCrypto, error) {
 	err := c.FetchDID(didStr)
 	if err != nil {
@@ -526,17 +527,45 @@ func (c *Core) SetupForienDID(didStr string) (did.DIDCrypto, error) {
 		return nil, err
 	}
 
-	return did.InitDIDBasic(didStr, c.didDir, nil), nil
-
+	// Fetching peer's did type from PeerDIDTable using GetPeerDIDType function
+	// and own did type from DIDTable using GetDID function
+	didtype, err := c.w.GetPeerDIDType(didStr)
+	if err != nil {
+		dt, err1 := c.w.GetDID(didStr)
+		if err1 != nil {
+			return nil, fmt.Errorf("couldn't fetch did type")
+		}
+		didtype = dt.Type
+	}
+	return c.InitialiseDID(didStr, didtype)
 }
 
+// Initializes the quorum in it's corresponding did mode (basic/ light)
 func (c *Core) SetupForienDIDQuorum(didStr string) (did.DIDCrypto, error) {
 	err := c.FetchDID(didStr)
 	if err != nil {
 		return nil, err
 	}
-	return did.InitDIDQuorumc(didStr, c.didDir, ""), nil
 
+	// Fetching peer's did type from PeerDIDTable using GetPeerDIDType function
+	// and own did type from DIDTable using GetDID function
+	didtype, err := c.w.GetPeerDIDType(didStr)
+	if err != nil {
+		dt, err1 := c.w.GetDID(didStr)
+		if err1 != nil {
+			return nil, fmt.Errorf("couldn't fetch did type")
+		}
+		didtype = dt.Type
+	}
+
+	switch didtype {
+	case did.BasicDIDMode:
+		return did.InitDIDQuorumc(didStr, c.didDir, ""), nil
+	case did.LightDIDMode:
+		return did.InitDIDQuorum_Lt(didStr, c.didDir, ""), nil
+	default:
+		return nil, fmt.Errorf("invalid did type")
+	}
 }
 
 func (c *Core) FetchDID(did string) error {
@@ -565,4 +594,20 @@ func (c *Core) FetchDID(did string) error {
 
 func (c *Core) GetPeerID() string {
 	return c.peerID
+}
+
+// Initializes the did in it's corresponding did mode (basic/ light)
+func (c *Core) InitialiseDID(didStr string, didType int) (did.DIDCrypto, error) {
+	err := c.FetchDID(didStr)
+	if err != nil {
+		return nil, err
+	}
+	switch didType {
+	case did.LightDIDMode:
+		return did.InitDIDLight(didStr, c.didDir, nil), nil
+	case did.BasicDIDMode:
+		return did.InitDIDBasic(didStr, c.didDir, nil), nil
+	default:
+		return nil, fmt.Errorf("invalid did type, couldn't initialise")
+	}
 }

--- a/core/did.go
+++ b/core/did.go
@@ -214,11 +214,17 @@ func (c *Core) registerDID(reqID string, did string) error {
 	if err != nil {
 		return fmt.Errorf("register did, failed to do signature")
 	}
+
+	dt, err := c.w.GetDID(did)
+	if err != nil {
+		return fmt.Errorf("DID does not exist")
+	}
 	pm := &PeerMap{
 		PeerID:    c.peerID,
 		DID:       did,
 		Signature: sig,
 		Time:      t,
+		DIDType:   dt.Type,
 	}
 	err = c.publishPeerMap(pm)
 	if err != nil {

--- a/core/peer.go
+++ b/core/peer.go
@@ -18,6 +18,7 @@ const (
 type PeerMap struct {
 	PeerID    string `json:"peer_id"`
 	DID       string `json:"did"`
+	DIDType   int    `json:"did_type"`
 	Signature []byte `json:"signature"`
 	Time      string `json:"time"`
 }
@@ -48,7 +49,7 @@ func (c *Core) peerCallback(peerID string, topic string, data []byte) {
 		return
 	}
 	h := util.CalculateHashString(m.PeerID+m.DID+m.Time, "SHA3-256")
-	dc, err := c.SetupForienDID(m.DID)
+	dc, err := c.InitialiseDID(m.DID, m.DIDType)
 	if err != nil {
 		return
 	}
@@ -56,7 +57,7 @@ func (c *Core) peerCallback(peerID string, topic string, data []byte) {
 	if err != nil || !st {
 		return
 	}
-	c.w.AddDIDPeerMap(m.DID, m.PeerID)
+	c.w.AddDIDPeerMap(m.DID, m.PeerID, m.DIDType)
 }
 
 func (c *Core) peerStatus(req *ensweb.Request) *ensweb.Result {

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -301,14 +301,6 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 	tid := util.HexToStr(util.CalculateHash(sc.GetBlock(), "SHA3-256"))
 	lastCharTID := string(tid[len(tid)-1])
 
-	//Fetching sign version
-	sigVers := dc.GetSignVersion()
-
-	//Appending "1" at the beginning of Transaction ID as a symbol of PKI sign version
-	if sigVers == did.PkiVersion {
-		tid = "1" + tid
-	}
-
 	ql := c.qm.GetQuorum(cr.Type, lastCharTID) //passing lastCharTID as a parameter. Made changes in GetQuorum function to take 2 arguments
 	if ql == nil || len(ql) < MinQuorumRequired {
 		c.log.Error("Failed to get required quorums")


### PR DESCRIPTION
Added a new column 'did_type' in DIDPeerTable, so that any node can fetch registered peer did and peer did type from it's database. This is required while validating token ownership of the sender, when all the quorums needs to be initialised in their corresponding DID modes for a non-genesis block.