### PR TITLE
Fixed error occurring while trying to transfer RBT with fractional value component, but sender only possessing sufficient whole RBT tokens

### DIFF
--- a/core/token.go
+++ b/core/token.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/rubixchain/rubixgoplatform/block"
@@ -348,7 +349,7 @@ func (c *Core) GetRequiredTokens(did string, txnAmount float64) ([]wallet.Token,
 		//serach for the required whole amount
 		wholeTokens, remWhole, err := c.w.GetWholeTokens(did, wholeValue)
 		if err != nil && err.Error() != "no records found" {
-			defer c.w.ReleaseTokens(wholeTokens)
+			c.w.ReleaseTokens(wholeTokens)
 			c.log.Error("failed to search for whole tokens", "err", err)
 			return nil, 0.0, err
 		}
@@ -368,12 +369,17 @@ func (c *Core) GetRequiredTokens(did string, txnAmount float64) ([]wallet.Token,
 			}
 			c.log.Debug("No more whole token left in wallet , rest of needed amt ", reqAmt)
 			allPartTokens, err := c.w.GetAllPartTokens(did)
-			if err != nil && err.Error() != "no records found" {
-				c.log.Error("failed to search for part tokens", "err", err)
-				return nil, 0.0, err
-			}
-			if len(allPartTokens) == 0 {
-				c.log.Error("No part Tokens found , This wallet is empty", "err", err)
+			if err != nil {
+				// In GetAllPartTokens, we first check if there are any part tokens present in
+				// TokensTable. Now there could be a situation, where there aren't any part tokens
+				// and it Should not error out, but proceed further. The "no records found" error string
+				// is usually received from the Read() method the db.
+				// Hence, in this case, we simply return with whatever values requiredTokens and reqAmt holds
+				if strings.Contains(err.Error(), "no records found") {
+					return requiredTokens, reqAmt, nil
+				}
+				c.w.ReleaseTokens(wholeTokens)
+				c.log.Error("failed to lock part tokens", "err", err)
 				return nil, 0.0, err
 			}
 			var sum float64
@@ -382,6 +388,7 @@ func (c *Core) GetRequiredTokens(did string, txnAmount float64) ([]wallet.Token,
 				sum = floatPrecision(sum, MaxDecimalPlaces)
 			}
 			if sum < reqAmt {
+				c.w.ReleaseTokens(wholeTokens)
 				c.log.Error("There are no Whole tokens and the exisitng decimal balance is not sufficient for the transfer, please use smaller amount")
 				return nil, 0.0, fmt.Errorf("there are no whole tokens and the exisitng decimal balance is not sufficient for the transfer, please use smaller amount")
 			}

--- a/core/transfer.go
+++ b/core/transfer.go
@@ -87,6 +87,7 @@ func (c *Core) initiateRBTTransfer(reqID string, req *model.RBTTransferRequest) 
 
 	reqTokens, remainingAmount, err := c.GetRequiredTokens(did, req.TokenCount)
 	if err != nil {
+		c.w.ReleaseTokens(reqTokens)
 		c.log.Error("Failed to get tokens", "err", err)
 		resp.Message = "Insufficient tokens or tokens are locked or " + err.Error()
 		return resp


### PR DESCRIPTION
## Issue

Suppose the sender has 2 whole RBT tokens. The error occurred when they attempted to send 1.5 RBT.

Error Log:

```
2024-04-18T17:34:43.917+0530 [ERROR] Main.Core.wallet: Failed to get tokens: err="no records found"
2024-04-18T17:34:43.917+0530 [ERROR] Main.Core: No part Tokens found , This wallet is empty: err="no records found"
2024-04-18T17:34:43.918+0530 [ERROR] Main.Core: Failed to get tokens: err="no records found"
```

Upon analysis, it was observed that the function `GetAllPartTokens` was throwing back an error if there was no part tokens found in `TokensTable`. However, in case of transferring 1.5 RBT, the sender already has ample balance for a successful transfer and hence it should not throw an error

## Fix

While handling error from `GetAllPartTokens`, we check if the error string contains the value `no records found`. If yes, then the `requiredToken` and `reqAmt` are returned without any error. If no, then an error is thrown. In this way, we deal with `reqAmt` in later stages where the creation of Part tokens occurs.

