### PR TITLE
Node Backup: added CLI/API endpoint to perform extraction of token information of a DID from quorum node

### DIFF
--- a/client/node_sync.go
+++ b/client/node_sync.go
@@ -1,0 +1,18 @@
+package client
+
+import (
+	"github.com/rubixchain/rubixgoplatform/core/model"
+	"github.com/rubixchain/rubixgoplatform/setup"
+)
+
+func (c *Client) NodeSync(did string) (*model.NodeSyncResponse, error) {
+	nodeSyncRequest := &model.NodeSyncRequest{
+		Did: did,
+	}
+	var nodeSyncResponse model.NodeSyncResponse
+	err := c.sendJSONRequest("POST", setup.APINodeSync, nil, nodeSyncRequest, &nodeSyncResponse)
+	if err != nil {
+		return nil, err
+	}
+	return &nodeSyncResponse, nil
+}

--- a/command/command.go
+++ b/command/command.go
@@ -77,7 +77,7 @@ const (
 	GetTokenBlock                  string = "gettokenblock"
 	GetSmartContractData           string = "getsmartcontractdata"
 	ReleaseAllLockedTokensCmd      string = "releaseAllLockedTokens"
-	NodeSyncCmd                    string = "restoreNodeSync"
+	NodeSyncCmd                    string = "nodeSync"
 	CheckQuorumStatusCmd           string = "checkQuorumStatus"
 )
 

--- a/command/command.go
+++ b/command/command.go
@@ -77,6 +77,7 @@ const (
 	GetTokenBlock                  string = "gettokenblock"
 	GetSmartContractData           string = "getsmartcontractdata"
 	ReleaseAllLockedTokensCmd      string = "releaseAllLockedTokens"
+	NodeSyncCmd                    string = "restoreNodeSync"
 )
 
 var commands = []string{VersionCmd,
@@ -121,6 +122,7 @@ var commands = []string{VersionCmd,
 	DumpSmartContractTokenChainCmd,
 	GetTokenBlock,
 	GetSmartContractData,
+	NodeSyncCmd,
 }
 var commandsHelp = []string{"To get tool version",
 	"To get help",
@@ -163,7 +165,9 @@ var commandsHelp = []string{"To get tool version",
 	"This command will subscribe to a smart contract token",
 	"This command will dump the smartcontract token chain",
 	"This command gets token block",
-	"This command gets the smartcontract data from latest block"}
+	"This command gets the smartcontract data from latest block",
+	"This command restores the token information for a DID from quorums",
+}
 
 type Command struct {
 	cfg                config.Config
@@ -570,6 +574,8 @@ func Run(args []string) {
 		cmd.executeSmartcontract()
 	case ReleaseAllLockedTokensCmd:
 		cmd.releaseAllLockedTokens()
+	case NodeSyncCmd:
+		cmd.nodeSync()
 	default:
 		cmd.log.Error("Invalid command")
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -169,6 +169,7 @@ var commandsHelp = []string{"To get tool version",
 	"This command gets token block",
 	"This command gets the smartcontract data from latest block",
 	"This command restores the token information for a DID from quorums",
+	"This command checks the status of the Quorum",
 }
 
 type Command struct {

--- a/command/node_sync.go
+++ b/command/node_sync.go
@@ -1,0 +1,22 @@
+package command
+
+import "fmt"
+
+func (cmd *Command) nodeSync() {
+	if cmd.did == "" {
+		cmd.log.Error("DID is required to get its token information")
+		return
+	}
+	cmd.log.Info(fmt.Sprintf("Node sync for DID %v has started", cmd.did))
+
+	nodeSyncResponse, err := cmd.c.NodeSync(cmd.did)
+	if err != nil {
+		cmd.log.Error(fmt.Sprintf("Failed to sync node for DID %v, err: %v", cmd.did, err))
+		return
+	}
+	if !nodeSyncResponse.Status {
+		cmd.log.Error(fmt.Sprintf("Failed to sync node for DID %v, cause: %v", cmd.did, nodeSyncResponse.Message))
+		return
+	}
+	cmd.log.Info(fmt.Sprintf("Node sync for DID %v has been completed successfully", cmd.did))
+}

--- a/core/core.go
+++ b/core/core.go
@@ -46,6 +46,7 @@ const (
 	APIGetTokenNumber         string = "/api/get-token-number"
 	APIGetMigratedTokenStatus string = "/api/get-Migrated-token-status"
 	APISyncDIDArbitration     string = "/api/sync-did-arbitration"
+	APIGetTokensByDID         string = "/api/get-tokens-by-did"
 )
 
 const (

--- a/core/model/diagnostic.go
+++ b/core/model/diagnostic.go
@@ -1,5 +1,24 @@
 package model
 
+import "github.com/rubixchain/rubixgoplatform/core/wallet"
+
+type NodeSyncRequest struct {
+	Did string
+}
+
+type NodeSyncResponse struct {
+	BasicResponse
+}
+
+type GetTokensByDIDRequest struct {
+	Did string
+}
+
+type GetTokensByDIDResponse struct {
+	BasicResponse
+	Tokens []*wallet.Token
+}
+
 type TCDumpRequest struct {
 	Token   string
 	BlockID string

--- a/core/node_sync.go
+++ b/core/node_sync.go
@@ -263,15 +263,15 @@ func (c *Core) getTokensByDID(req *ensweb.Request) *ensweb.Result {
 		Tokens: make([]*wallet.Token, 0),
 	}
 
-	var restoreNodeSyncRequest *model.GetTokensByDIDRequest
-	err := c.l.ParseJSON(req, &restoreNodeSyncRequest)
+	var getTokensByDIDRequest *model.GetTokensByDIDRequest
+	err := c.l.ParseJSON(req, &getTokensByDIDRequest)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to parse json request, err: %v", err.Error())
 		c.log.Error(errMsg)
 		response.Message = errMsg
 		return c.l.RenderJSON(req, &response, http.StatusOK)
 	}
-	did := restoreNodeSyncRequest.Did
+	did := getTokensByDIDRequest.Did
 
 	c.log.Info(fmt.Sprintf("Retreiving whole and part tokens for did %v...", did))
 

--- a/core/node_sync.go
+++ b/core/node_sync.go
@@ -1,0 +1,406 @@
+package core
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/rubixchain/rubixgoplatform/block"
+	"github.com/rubixchain/rubixgoplatform/core/model"
+	"github.com/rubixchain/rubixgoplatform/core/wallet"
+	tkn "github.com/rubixchain/rubixgoplatform/token"
+	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
+	"github.com/rubixchain/rubixgoplatform/wrapper/helper/strutil"
+)
+
+// tokenStatusBasedOnTestnetStatus returns whole or part token id based
+// on testnet flag
+func tokenStatusBasedOnTestnetStatus(token *wallet.Token, isTestnet bool) int {
+	var tokenType int
+	if token.TokenValue == 1.0 {
+		tokenType = tkn.RBTTokenType
+		if isTestnet {
+			tokenType = tkn.TestTokenType
+		}
+	} else {
+		tokenType = tkn.PartTokenType
+		if isTestnet {
+			tokenType = tkn.TestPartTokenType
+		}
+	}
+
+	return tokenType
+}
+
+// filterTokenList takes in quorum tokens and TokensTable tokens, filters and returns in the following categories:
+//
+// - quorumTokensUnique: These are tokens, fetched from quorum, which are NOT present in the TokensTable.
+//
+// - tokensTableUnique: These are tokens from TokensTable, which are NOT present in the tokens list fetched from quorum.
+//
+// - quorumTokensPresentInTokensTable: These are tokens, fetched from quorum, which are present in the TokensTable.
+func filterTokenList(quorumTokens []wallet.Token, tokensTableTokens []wallet.Token) ([]wallet.Token, []wallet.Token, []wallet.Token) {
+	quorumTokensUnique := make([]wallet.Token, 0)
+	tokensTableUnique := make([]wallet.Token, 0)
+	quorumTokensPresentInTokensTable := make([]wallet.Token, 0)
+
+	tknTableMap := make(map[string]wallet.Token)
+	quorumMap := make(map[string]wallet.Token)
+
+	for _, token := range tokensTableTokens {
+		tknTableMap[token.TokenID] = token
+	}
+
+	for _, token := range quorumTokens {
+		quorumMap[token.TokenID] = token
+	}
+
+	for _, token := range quorumTokens {
+		_, exists := tknTableMap[token.TokenID]
+		if !exists {
+			quorumTokensUnique = append(quorumTokensUnique, token)
+		} else {
+			quorumTokensPresentInTokensTable = append(quorumTokensPresentInTokensTable, token)
+		}
+	}
+
+	for _, token := range tokensTableTokens {
+		_, exists := quorumMap[token.TokenID]
+		if !exists {
+			tokensTableUnique = append(tokensTableUnique, token)
+		}
+	}
+
+	return quorumTokensUnique, tokensTableUnique, quorumTokensPresentInTokensTable
+}
+
+func (c *Core) NodeSync(nodeSyncRequest *model.NodeSyncRequest) *model.NodeSyncResponse {
+	nodeSyncResponse := &model.NodeSyncResponse{
+		BasicResponse: model.BasicResponse{
+			Status: false,
+		},
+	}
+	c.log.Info("Node sync for DID %v has started")
+	// TODO(Arnab): Current assumption is that zeroth index of the node will
+	// be selected, as only this node will have the balance and rest won't
+	// It's also because pledging quorum only has the the latest information,
+	// while the rest of quorums do not.
+	quorumList := c.qm.GetQuorum(2, "")
+	quorumPeerAddress := quorumList[0]
+
+	quorumPeer, err := c.getPeer(quorumPeerAddress)
+	if err != nil {
+		errMsg := fmt.Sprintf("Receiver not connected, err: %v", err.Error())
+		nodeSyncResponse.Message = errMsg
+		c.log.Error(errMsg)
+		return nodeSyncResponse
+	}
+	defer quorumPeer.Close()
+
+	// We are fetching a list of RBT tokens which are owned by the DID
+	var getTokensByDIDResponse *model.GetTokensByDIDResponse
+	jsonRequestErr := quorumPeer.SendJSONRequest("POST", APIGetTokensByDID, nil, nodeSyncRequest, &getTokensByDIDResponse, true)
+	if jsonRequestErr != nil {
+		errMsg := fmt.Sprintf("unable to send request, err: %v", jsonRequestErr)
+		c.log.Error(errMsg)
+		nodeSyncResponse.Message = errMsg
+		return nodeSyncResponse
+	}
+	if !getTokensByDIDResponse.Status {
+		errMsg := fmt.Sprintf("unable to get tokens owned by %v from quorum %v, err: %v", nodeSyncRequest.Did, quorumPeerAddress, nodeSyncResponse.Message)
+		c.log.Error(errMsg)
+		return nodeSyncResponse
+	}
+
+	tokensFromQuorum := getTokensByDIDResponse.Tokens
+	tokensFromQuorumCopy := make([]wallet.Token, len(tokensFromQuorum))
+	for k, v := range tokensFromQuorum {
+		tokensFromQuorumCopy[k] = *v
+	}
+
+	var tokensFromTokensTable []wallet.Token = make([]wallet.Token, 0)
+	tokensFromTokensTable, err = c.w.GetAllTokens(nodeSyncRequest.Did)
+	if err != nil && !strings.Contains(err.Error(), "no records found") {
+		errMsg := fmt.Sprintf("unable to fetch tokens from TokensTable of DID: %v, err: %v", nodeSyncRequest.Did, err)
+		nodeSyncResponse.Message = errMsg
+		c.log.Error(errMsg)
+		return nodeSyncResponse
+	}
+
+	tokensFromQuorumNotPresentInTokensTable, tokensFromTokensTableNotPresentWithQuorums, quorumTokensPresentInTokensTable := filterTokenList(tokensFromQuorumCopy, tokensFromTokensTable)
+
+	// Process TokensTable tokens which are not present in fetched quorum list
+	for _, token := range tokensFromTokensTableNotPresentWithQuorums {
+		tokenType := tokenStatusBasedOnTestnetStatus(&token, c.testNet)
+
+		switch token.TokenStatus {
+		case wallet.TokenIsFree:
+			err := c.syncTokenChainFrom(quorumPeer, "", token.TokenID, tokenType)
+			// Proceed with TokenTable update if the token chain sync is successful
+			if err == nil {
+				c.log.Info(fmt.Sprintf("Token chain syncing of %v has been successful. Proceeding to change the status to Transferred", token.TokenID))
+				t := token
+				t.TokenStatus = wallet.TokenIsTransferred
+				err = c.w.UpdateToken(&t)
+				if err != nil {
+					errMsg := fmt.Sprintf("unable to update whole token info, err: %v", err)
+					nodeSyncResponse.Message = errMsg
+					c.log.Error(errMsg)
+					return nodeSyncResponse
+				}
+			} else {
+				// In case of part token and generated test whole RBT token, it could either have been transferred or
+				// it could be with the owner. This information is not straightforward as generated token's information
+				// is not with the quorums. Hence 
+				if strings.Contains(err.Error(), "Token chain block does not exist") {
+					c.log.Info(fmt.Sprintf("unable to fetch token chain for token: %v, proceeding to check if local peer is the provider", token.TokenID))
+					peers, err := c.GetDHTddrs(token.TokenID)
+					if err != nil {
+						errMsg := fmt.Sprintf("error occurred while fetching providers for token %v, err: %v", token.TokenID, err)
+						nodeSyncResponse.Message = errMsg
+						c.log.Error(errMsg)
+						return nodeSyncResponse
+					}
+
+					localPeerFound := false
+					for _, peer := range peers {
+						// Check if local peer is a provider of the token
+						// No need for token status change from current Free state
+						if peer == c.peerID {
+							c.log.Info(fmt.Sprintf("local peer is the provider for the token: %v, skipping any status change and token chain sync for it", token.TokenID))
+							localPeerFound = true
+							break
+						}
+					}
+
+					if !localPeerFound {
+						c.log.Info(fmt.Sprintf("local peer not found in provider list for token: %v, setting its status to Transferred and skipping token chain sync", token.TokenID))
+						t := token
+						t.TokenStatus = wallet.TokenIsTransferred
+						err = c.w.UpdateToken(&t)
+						if err != nil {
+							errMsg := fmt.Sprintf("unable to update token info of %v, err: %v", t.TokenID, err)
+							nodeSyncResponse.Message = errMsg
+							c.log.Error(errMsg)
+							return nodeSyncResponse
+						}
+					}
+				} else {
+					errMsg := fmt.Sprintf("unable to sync token chain for token %v, err: %v", token.TokenID, err)
+					nodeSyncResponse.Message = errMsg
+					c.log.Error(errMsg)
+					return nodeSyncResponse
+				}
+			}
+		}
+	}
+
+	// Process tokens fetched from quorums which are not present in TokensTable
+	for _, token := range tokensFromQuorumNotPresentInTokensTable {
+		tokenType := tokenStatusBasedOnTestnetStatus(&token, c.testNet)
+
+		err := c.syncTokenChainFrom(quorumPeer, "", token.TokenID, tokenType)
+		if err != nil {
+			errMsg := fmt.Sprintf("unable to sync token chain, err: %v", err)
+			nodeSyncResponse.Message = errMsg
+			c.log.Error(errMsg)
+			return nodeSyncResponse
+		}
+
+		err = c.w.AddToken(&token)
+		if err != nil {
+			errMsg := fmt.Sprintf("unable to add token info, err: %v", err)
+			nodeSyncResponse.Message = errMsg
+			c.log.Error(errMsg)
+			return nodeSyncResponse
+		}
+	}
+
+	// Process tokens fetched from quorum which are present in TokensTable
+	for _, token := range quorumTokensPresentInTokensTable {
+		tokenType := tokenStatusBasedOnTestnetStatus(&token, c.testNet)
+
+		err = c.syncTokenChainFrom(quorumPeer, "", token.TokenID, tokenType)
+		if err != nil {
+			errMsg := fmt.Sprintf("unable to sync token chain for token, err: %v", err)
+			nodeSyncResponse.Message = errMsg
+			c.log.Error(errMsg)
+			return nodeSyncResponse
+		}
+
+		tknFromTokenTable, err := c.w.ReadToken(token.TokenID)
+		if err != nil {
+			errMsg := fmt.Sprintf("unable to read token info, err: %v", err)
+			nodeSyncResponse.Message = errMsg
+			c.log.Error(errMsg)
+			return nodeSyncResponse
+		}
+
+		// Only update if there is a difference in Token Statuses
+		if tknFromTokenTable.TokenStatus != token.TokenStatus {
+			t := token
+			t.TokenStatus = wallet.TokenIsFree
+			err = c.w.UpdateToken(&t)
+			if err != nil {
+				errMsg := fmt.Sprintf("unable to update token info, err: %v", err)
+				nodeSyncResponse.Message = errMsg
+				c.log.Error(errMsg)
+				return nodeSyncResponse
+			}
+		}
+
+	}
+
+	nodeSyncResponse.BasicResponse.Status = true
+	return nodeSyncResponse
+}
+
+func (c *Core) getTokensByDID(req *ensweb.Request) *ensweb.Result {
+	response := model.GetTokensByDIDResponse{
+		BasicResponse: model.BasicResponse{
+			Status: false,
+		},
+		Tokens: make([]*wallet.Token, 0),
+	}
+
+	var restoreNodeSyncRequest *model.GetTokensByDIDRequest
+	err := c.l.ParseJSON(req, &restoreNodeSyncRequest)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed to parse json request, err: %v", err.Error())
+		c.log.Error(errMsg)
+		response.Message = errMsg
+		return c.l.RenderJSON(req, &response, http.StatusOK)
+	}
+	did := restoreNodeSyncRequest.Did
+
+	c.log.Info(fmt.Sprintf("Retreiving whole and part tokens for did %v...", did))
+
+	// var tokens []*wallet.Token
+	wholeTokens, err := c.searchWholeTokens(did)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed while searching for whole tokens: %v", err.Error())
+		c.log.Error(errMsg)
+		response.Message = errMsg
+		return c.l.RenderJSON(req, &response, http.StatusOK)
+	}
+	response.Tokens = append(response.Tokens, wholeTokens...)
+
+	partTokens, err := c.searchPartTokens(did)
+	if err != nil {
+		errMsg := fmt.Sprintf("failed while searching for part tokens: %v", err.Error())
+		c.log.Error(errMsg)
+		response.Message = errMsg
+		return c.l.RenderJSON(req, &response, http.StatusOK)
+	}
+	response.Tokens = append(response.Tokens, partTokens...)
+
+	response.Status = true
+	return c.l.RenderJSON(req, &response, http.StatusOK)
+}
+
+// search whole tokens
+func (c *Core) searchWholeTokens(did string) ([]*wallet.Token, error) {
+	var tokenList []*wallet.Token
+
+	tokenType := tkn.RBTTokenType
+	if c.testNet {
+		tokenType = tkn.TestTokenType
+	}
+
+	wholeTokenKeys, err := c.w.GetAllTokenKeys(tokenType)
+	if err != nil {
+		return []*wallet.Token{}, err
+	}
+	wholeTokenHashes := c.getTokenHashesFromKeys(wholeTokenKeys)
+	for _, tokenHash := range wholeTokenHashes {
+		blk := c.w.GetLatestTokenBlock(tokenHash, tokenType)
+		if blk == nil {
+			return nil, fmt.Errorf("failed to sync restored node: unable to fetch latest block")
+		}
+
+		currentOwnerOfToken := blk.GetOwner()
+
+		if did == currentOwnerOfToken {
+			var tokenStatus int
+			if blk.GetTransType() == block.TokenBurntType {
+				tokenStatus = wallet.TokenIsBurnt
+			} else {
+				tokenStatus = wallet.TokenIsFree
+			}
+
+			token := &wallet.Token{
+				TokenID:     tokenHash,
+				TokenValue:  1.0,
+				DID:         did,
+				TokenStatus: tokenStatus,
+			}
+			tokenList = append(tokenList, token)
+		}
+	}
+
+	return tokenList, nil
+}
+
+// search part tokens
+func (c *Core) searchPartTokens(did string) ([]*wallet.Token, error) {
+	var tokenList []*wallet.Token
+
+	tokenType := tkn.PartTokenType
+	if c.testNet {
+		tokenType = tkn.TestPartTokenType
+	}
+	partTokenKeys, err := c.w.GetAllTokenKeys(tokenType)
+	if err != nil {
+		return []*wallet.Token{}, err
+	}
+
+	partTokenHashes := c.getTokenHashesFromKeys(partTokenKeys)
+	for _, tokenHash := range partTokenHashes {
+		blk := c.w.GetLatestTokenBlock(tokenHash, tokenType)
+		if blk == nil {
+			return nil, fmt.Errorf("failed to sync restored node: unable to fetch latest block")
+		}
+
+		currentOwnerOfToken := blk.GetOwner()
+		if did == currentOwnerOfToken {
+			genesisBlock := c.w.GetGenesisTokenBlock(tokenHash, tokenType)
+			parent, _, err := genesisBlock.GetParentDetials(tokenHash)
+			if err != nil {
+				return nil, fmt.Errorf("failed to sync restored node: unable to fetch parent details block")
+			}
+
+			var partTokenValue float64 = genesisBlock.GetTokenValue()
+
+			var tokenStatus int
+			if blk.GetTransType() == block.TokenBurntType {
+				tokenStatus = wallet.TokenIsBurnt
+			} else {
+				tokenStatus = wallet.TokenIsFree
+			}
+
+			token := &wallet.Token{
+				TokenID:       tokenHash,
+				TokenValue:    partTokenValue,
+				ParentTokenID: parent,
+				DID:           did,
+				TokenStatus:   tokenStatus,
+			}
+			tokenList = append(tokenList, token)
+		}
+	}
+
+	return tokenList, nil
+}
+
+func (c *Core) getTokenHashesFromKeys(keys []string) []string {
+	var tokenHashes []string
+
+	for _, key := range keys {
+		keyElems := strings.Split(key, "-")
+		tokenHash := keyElems[1]
+		tokenHashes = append(tokenHashes, tokenHash)
+	}
+
+	tokenHashes = strutil.RemoveDuplicates(tokenHashes, false)
+	return tokenHashes
+}

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -150,6 +150,7 @@ func (c *Core) QuroumSetup() {
 	c.l.AddRoute(APIUpdatePledgeToken, "POST", c.updatePledgeToken)
 	c.l.AddRoute(APISignatureRequest, "POST", c.signatureRequest)
 	c.l.AddRoute(APISendReceiverToken, "POST", c.updateReceiverToken)
+	c.l.AddRoute(APIGetTokensByDID, "POST", c.getTokensByDID)
 	if c.arbitaryMode {
 		c.l.AddRoute(APIMapDIDArbitration, "POST", c.mapDIDArbitration)
 		c.l.AddRoute(APICheckDIDArbitration, "GET", c.chekDIDArbitration)

--- a/core/wallet/node_sync.go
+++ b/core/wallet/node_sync.go
@@ -1,0 +1,50 @@
+package wallet
+
+import (
+	"fmt"
+
+	"github.com/syndtr/goleveldb/leveldb/util"
+	tkn "github.com/rubixchain/rubixgoplatform/token"
+)
+
+func (w *Wallet) GetAllTokenKeys(tokenType int) ([]string, error) {
+	var tokenKeys []string
+
+	db := w.getChainDB(tokenType)
+	if db == nil {
+		return tokenKeys, fmt.Errorf("failed get all blocks, invalid token type")
+	}
+
+	iter := db.NewIterator(util.BytesPrefix([]byte(tcsPrefixForNodeSync(tokenType))), nil)
+	defer iter.Release()
+	for iter.Next() {
+		key := string(iter.Key())
+		tokenKeys = append(tokenKeys, key)
+	}
+
+	return tokenKeys, nil
+}
+
+
+func tcsPrefixForNodeSync(tokenType int) string {
+	tt := "wt"
+	switch tokenType {
+	case tkn.RBTTokenType:
+		tt = WholeTokenType
+	case tkn.PartTokenType:
+		tt = PartTokenType
+	case tkn.TestPartTokenType:
+		tt = TestPartTokenType
+	case tkn.NFTTokenType:
+		tt = NFTType
+	case tkn.TestNFTTokenType:
+		tt = TestNFTType
+	case tkn.TestTokenType:
+		tt = TestTokenType
+	case tkn.DataTokenType:
+		tt = DataTokenType
+	case tkn.SmartContractTokenType:
+		tt = SmartContractTokenType
+	}
+	return tt + "-"
+}

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -575,3 +575,13 @@ func (w *Wallet) ReleaseAllLockedTokens() error {
 	}
 	return nil
 }
+
+func (w *Wallet) AddToken(token *Token) error {
+	w.l.Lock()
+	defer w.l.Unlock()
+	err := w.s.Write(TokenStorage, token)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/server/node_sync.go
+++ b/server/node_sync.go
@@ -8,11 +8,11 @@ import (
 )
 
 func (s *Server) APINodeSync(req *ensweb.Request) *ensweb.Result {
-	var restoreNodeSyncRequest model.NodeSyncRequest
-	err := s.ParseJSON(req, &restoreNodeSyncRequest)
+	var nodeSyncRequest model.NodeSyncRequest
+	err := s.ParseJSON(req, &nodeSyncRequest)
 	if err != nil {
 		return s.BasicResponse(req, false, "Invalid input", nil)
 	}
-	resp := s.c.NodeSync(&restoreNodeSyncRequest)
+	resp := s.c.NodeSync(&nodeSyncRequest)
 	return s.RenderJSON(req, resp, http.StatusOK)
 }

--- a/server/node_sync.go
+++ b/server/node_sync.go
@@ -1,0 +1,18 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/rubixchain/rubixgoplatform/core/model"
+	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
+)
+
+func (s *Server) APINodeSync(req *ensweb.Request) *ensweb.Result {
+	var restoreNodeSyncRequest model.NodeSyncRequest
+	err := s.ParseJSON(req, &restoreNodeSyncRequest)
+	if err != nil {
+		return s.BasicResponse(req, false, "Invalid input", nil)
+	}
+	resp := s.c.NodeSync(&restoreNodeSyncRequest)
+	return s.RenderJSON(req, resp, http.StatusOK)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -155,6 +155,7 @@ func (s *Server) RegisterRoutes() {
 	s.AddRoute(setup.APIGetTxnByNode, "GET", s.AuthHandle(s.APIGetTxnByNode, true, s.AuthError, false))
 	s.AddRoute(setup.APIRemoveTokenChainBlock, "POST", s.AuthHandle(s.APIRemoveTokenChainBlock, true, s.AuthError, false))
 	s.AddRoute(setup.APIReleaseAllLockedTokens, "GET", s.AuthHandle(s.APIReleaseAllLockedTokens, true, s.AuthError, false))
+	s.AddRoute(setup.APINodeSync, "POST", s.AuthHandle(s.APINodeSync, true, s.AuthError, false))
 }
 
 func (s *Server) ExitFunc() error {

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -62,6 +62,7 @@ const (
 	APIGetTxnByNode                     string = "/api/get-by-node"
 	APIRemoveTokenChainBlock            string = "/api/remove-token-chain-block"
 	APIReleaseAllLockedTokens           string = "/api/release-all-locked-tokens"
+	APINodeSync                         string = "/api/node-sync"
 )
 
 // jwt.RegisteredClaims


### PR DESCRIPTION
## Description

This PR intendeds to add a CLI/API endpoint that would sync with Quorum node fetch the latest token information for a DID and update the `TokensTable` and sync the Token chain accordingly. Since this is focused on Type 2 quorums for now, the assumption is that the first quorum (0th index) will always be the pledging quorum.

Following is the command to sync tokens for a DID:

```
./rubixgoplatform nodeSync -did <DID> -port <Node Server Port>
```

Following is the API endpoint for the Node Sync:

```
POST: /api/node-sync
```

Request JSON Body:

```
{
  "did" : "<DID for which node sync should be done>"
}
```
## Tests Scenarios

The featured was successfully tested on the following Test Scenarios:

**Scenario 1**

_Balance: X -> 0 ; Y -> 0_
 
1. Generate 1 whole RBT for X
2. Transfer 0.3 RBT from X to Y. 
4. Take Backup of X (_1 whole RBT is burnt; 0.3 RBT is transferred; 0.7 RBT is with X_)
5. Transfer 0.3 RBT from Y to X
6. Delete X's node directory and use the backup of A and run the node sync command. It is expected that status of 0.3 RBT should change from `4` to `0`

_Balance: X -> 1  ; Y -> 0_

**Scenario 2**

_Balance: X -> 1 ; Y -> 0_
 
1. Generate 3 whole RBT for X
2. Transfer 3 RBT from X to Y
3. Take Backup of X (_3 whole RBT is transferred_)
4. Transfer 3 RBT from Y to X
5. Delete X's node directory and use the backup of X and run the node sync command. It is exepected that the status of all 3 whole tokens will change from `4` to `0`.

_Balance: X -> 4  ; Y -> 0_

**Scenario 3**

_Balance: X -> 4  ; Y -> 0_
 
1. Take backup of X 

2. Generate 2 RBT for Y and transfer it to X.

3. Delete X's node directory and use the backup of X and run the node sync command. It is expected that TokensTable of X will have the entries of 2 whole generated token.

_Balance: X -> 6 ; Y -> 0_

**Scenario 4**

_Balance: X -> 6 ; Y -> 0_
 
1. Take backup of X
2. Generate 1 RBT for X
3. Delete X's node directory and use the backup of A and run the node sync command. It is expected that we wouldn't be able to recover this generated whole token, because we neither have the information about it in the TokensTable, nor its information is with Quorum.

_Balance: X -> 6 ; Y -> 0_