### PR TITLE
hotfix: adding release github action files which were removed while merging PR #151

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+on:
+  push:
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+"
+      - "v[0-9]+.[0-9]+.[0-9]+-rc.[0-9]+"
+
+permissions:
+  contents: write
+  packages: write
+
+jobs:
+  release-binaries-github:
+    name: Release Binaries to Github
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Make release
+        run: |
+          make release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Clean release folder
+        run: |
+          sudo rm -rf dist

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,104 @@
+project_name: rubixgoplatform
+
+env:
+  - CGO_ENABLED=1
+
+before:
+  hooks:
+    - go mod tidy -compat=1.20
+
+builds:
+
+  - id: ubuntu-amd64
+    main: ./
+    binary: rubixgoplatform
+    env:
+      - CC=x86_64-linux-gnu-gcc
+    goos:
+      - linux
+    goarch:
+      - amd64
+
+  - id: ubuntu-arm64
+    main: ./
+    binary: rubixgoplatform
+    env:
+      - CC=aarch64-linux-gnu-gcc
+    goos:
+      - linux
+    goarch:
+      - arm64
+
+  - id: darwin-amd64
+    main: ./
+    binary: rubixgoplatform
+    env:
+      - CC=o64-clang
+      - CGO_LDFLAGS=-L/lib
+    goos:
+      - darwin
+    goarch:
+      - amd64
+
+  - id: darwin-arm64
+    main: ./
+    binary: rubixgoplatform
+    env:
+      - CC=oa64-clang
+      - CGO_LDFLAGS=-L/lib
+    goos:
+      - darwin
+    goarch:
+      - arm64
+
+  - id: windows-amd64
+    main: ./
+    binary: rubixgoplatform
+    env:
+      - CC=x86_64-w64-mingw32-gcc
+    goos:
+      - windows
+    goarch:
+      - amd64
+
+archives:
+  - id: linux-darwin-archive
+    builds:
+      - ubuntu-amd64
+      - ubuntu-arm64
+      - darwin-amd64
+      - darwin-arm64
+    format: tar.gz
+    wrap_in_directory: false
+    name_template: "{{ .Binary }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+
+  - id: windows-archive
+    builds:
+      - windows-amd64
+    format: zip
+    wrap_in_directory: false
+    name_template: "{{ .Binary }}-v{{ .Version }}-{{ .Os }}-{{ .Arch }}"
+
+checksum:
+  name_template: 'checksums.txt'
+  algorithm: sha256
+
+snapshot:
+  name_template: "{{ incpatch .Version }}-next"
+
+changelog:
+  sort: asc
+  filters:
+    exclude:
+      - '^docs:'
+      - '^test:'
+
+release:
+  github:
+    owner: rubixchain
+    name: rubixgoplatform
+
+  draft: false
+  mode: append
+  header: |
+    # Release Notes

--- a/Makefile
+++ b/Makefile
@@ -20,3 +20,25 @@ clean:
 	rm -f linux/rubixgoplatform windows/rubixgoplatform.exe mac/rubixgoplatform
 
 all: compile-linux compile-windows compile-mac
+
+############################ Release ##################################
+
+GORELEASER_VERSION := 1.20
+GORELEASER_IMAGE := ghcr.io/goreleaser/goreleaser-cross:v$(GORELEASER_VERSION)
+
+# Publish binaries to Gitbub. It is used in `release` Github Action Workflow
+ifdef GITHUB_TOKEN
+release:
+	docker run \
+		--rm \
+		-e GITHUB_TOKEN=$(GITHUB_TOKEN) \
+		-v /var/run/docker.sock:/var/run/docker.sock \
+		-v `pwd`:/go/src/rubixgoplatform \
+		-w /go/src/rubixgoplatform \
+		$(GORELEASER_IMAGE) \
+		release \
+		--clean
+else
+release:
+	@echo "Error: GITHUB_TOKEN is not defined. Please define it before running 'make release'."
+endif


### PR DESCRIPTION
This PR inteds to add release github action files which were removed while merging PR #151