### PR TITLE
read peerid from db and added tests

### DIFF
--- a/core/transfer.go
+++ b/core/transfer.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rubixchain/rubixgoplatform/contract"
 	"github.com/rubixchain/rubixgoplatform/core/model"
 	"github.com/rubixchain/rubixgoplatform/core/wallet"
-	"github.com/rubixchain/rubixgoplatform/util"
 	"github.com/rubixchain/rubixgoplatform/wrapper/uuid"
 )
 
@@ -33,21 +32,12 @@ func (c *Core) initiateRBTTransfer(reqID string, req *model.RBTTransferRequest) 
 		resp.Message = "Sender and receiver cannot be same"
 		return resp
 	}
-
-	if !strings.Contains(req.Sender, ".") || !strings.Contains(req.Receiver, ".") {
-		resp.Message = "Sender and receiver address should be of the format PeerID.DID"
-		return resp
-	}
-
-	_, did, ok := util.ParseAddress(req.Sender)
-	if !ok {
-		resp.Message = "Invalid sender DID"
-		return resp
-	}
-
-	rpeerid, rdid, ok := util.ParseAddress(req.Receiver)
-	if !ok {
-		resp.Message = "Invalid receiver DID"
+	did := req.Sender
+	rdid := req.Receiver
+	rpeerid := c.w.GetPeerID(rdid)
+	if rpeerid == "" {
+		c.log.Error("Peer ID not found", "did", rdid)
+		resp.Message = "invalid address, Peer ID not found"
 		return resp
 	}
 

--- a/tests/node/actions.py
+++ b/tests/node/actions.py
@@ -32,7 +32,7 @@ def quorum_config(node_config: dict, node_did_alias_map: dict, skip_adding_quoru
             did = get_did_by_alias(config, node_did_alias_map[node])
             quorum_info = {
                 "type": 2,
-                "address": config["peerId"] + "." + did
+                "address": did
             }
             
             quorum_list.append(quorum_info)

--- a/tests/scenarios/bip39_nlss_test.py
+++ b/tests/scenarios/bip39_nlss_test.py
@@ -46,7 +46,6 @@ def nlss_to_bip39(node_config):
     node_bip39, node_nlss = node_config["node11"], node_config["node12"]
     server_port_nlss, grpc_port_nlss = node_nlss["server"], node_nlss["grpcPort"]
     did_bip39, did_nlss = get_did_by_alias(node_bip39, "bip39_1"), get_did_by_alias(node_nlss, "nlss_1")
-    address_bip39, address_nlss = node_bip39["peerId"]+"."+did_bip39, node_nlss["peerId"]+"."+did_nlss
     
     print("------ Test Case (PASS): Transferring whole, part and mix RBT from NLSS DID to BIP39 DID ------\n")
 
@@ -74,15 +73,15 @@ def nlss_to_bip39(node_config):
 
     print("\n2. Transferring 1 RBT from NLSS DID to BIP39 DID....")
     add_peer_details(node_bip39["peerId"], did_bip39, 4, server_port_nlss, grpc_port_nlss) #adding peer details of bip39 node to nlss
-    expect_success(rbt_transfer)(address_nlss, address_bip39, 1, server_port_nlss, grpc_port_nlss)
+    expect_success(rbt_transfer)(did_nlss, did_bip39, 1, server_port_nlss, grpc_port_nlss)
     print("Transferred 1 RBT from NLSS DID to BIP39 DID")
 
     print("\n3. Transferring 1.5 RBT from NLSS DID to BIP39 DID....")
-    expect_success(rbt_transfer)(address_nlss, address_bip39, 1.5, server_port_nlss, grpc_port_nlss)
+    expect_success(rbt_transfer)(did_nlss, did_bip39, 1.5, server_port_nlss, grpc_port_nlss)
     print("Transferred 1.5 RBT from NLSS DID to BIP39 DID")
 
     print("\n4. Transferring 0.5 RBT from NLSS DID to BIP39 DID....")
-    expect_success(rbt_transfer)(address_nlss, address_bip39, 0.5, server_port_nlss, grpc_port_nlss)
+    expect_success(rbt_transfer)(did_nlss, did_bip39, 0.5, server_port_nlss, grpc_port_nlss)
     print("Transferred 0.5 RBT from NLSS DID to BIP39 DID")
 
     print("\n------ Test Case (PASS): Transferring whole, part and mix RBT from NLSS DID to BIP39 DID completed ------\n")
@@ -91,7 +90,6 @@ def bip39_to_nlss(node_config):
     node_bip39, node_nlss = node_config["node11"], node_config["node12"]
     server_port_bip39, grpc_port_bip39 = node_bip39["server"], node_bip39["grpcPort"]
     did_bip39, did_nlss = get_did_by_alias(node_bip39, "bip39_1"), get_did_by_alias(node_nlss, "nlss_1")
-    address_bip39, address_nlss = node_bip39["peerId"]+"."+did_bip39, node_nlss["peerId"]+"."+did_nlss
 
     quorum_config = get_quorum_config()
     
@@ -102,14 +100,14 @@ def bip39_to_nlss(node_config):
 
     print("\n4. Transferring 0.5 RBT from BIP39 DID to NLSS DID....")
     add_peer_details(node_nlss["peerId"], did_nlss, 0, server_port_bip39, grpc_port_bip39) #adding peer details of nlss node to bip39
-    expect_success(rbt_transfer)(address_bip39, address_nlss, 0.5, server_port_bip39, grpc_port_bip39)
+    expect_success(rbt_transfer)(did_bip39, did_nlss, 0.5, server_port_bip39, grpc_port_bip39)
     print("Transferred 0.5 RBT from BIP39 DID to NLSS DID")
 
     print("\n3. Transferring 1.5 RBT from BIP39 DID to NLSS DID....")
-    expect_success(rbt_transfer)(address_bip39, address_nlss, 1.5, server_port_bip39, grpc_port_bip39)
+    expect_success(rbt_transfer)(did_bip39, did_nlss, 1.5, server_port_bip39, grpc_port_bip39)
     print("Transferred 1.5 RBT from BIP39 DID to NLSS DID")
 
     print("\n2. Transferring 1 RBT from BIP39 DID to NLSS DID....")
-    expect_success(rbt_transfer)(address_bip39, address_nlss, 1, server_port_bip39, grpc_port_bip39)
+    expect_success(rbt_transfer)(did_bip39, did_nlss, 1, server_port_bip39, grpc_port_bip39)
     print("Transferred 1 RBT from BIP39 DID to NLSS DID")
 

--- a/tests/scenarios/rbt_transfer.py
+++ b/tests/scenarios/rbt_transfer.py
@@ -50,12 +50,11 @@ def max_decimal_place_transfer(config):
     node_A_info, node_B_info = config["node9"], config["node10"]
     server_port_B, grpc_port_B = node_B_info["server"], node_B_info["grpcPort"]
     did_A, did_B = get_did_by_alias(node_A_info, "did_a"), get_did_by_alias(node_B_info, "did_b")
-    address_A, address_B = node_A_info["peerId"]+"."+did_A, node_B_info["peerId"]+"."+did_B
 
     print("------ Test Case (FAIL) : Transferring 0.00000009 RBT from B which is more than allowed decimal places ------")
 
     print("\nTransferring 0.00000009 RBT from B to A....")
-    expect_failure(rbt_transfer)(address_B, address_A, 0.00000009, server_port_B, grpc_port_B)
+    expect_failure(rbt_transfer)(did_B, did_A, 0.00000009, server_port_B, grpc_port_B)
 
     print("\n------ Test Case (FAIL) : Transferring 0.00000009 RBT from B which is more than allowed decimal places completed ------\n")
 
@@ -64,19 +63,18 @@ def insufficient_balance_transfer(config):
     server_port_A, grpc_port_A = node_A_info["server"], node_A_info["grpcPort"]
     server_port_B, grpc_port_B = node_B_info["server"], node_B_info["grpcPort"]
     did_A, did_B = get_did_by_alias(node_A_info, "did_a"), get_did_by_alias(node_B_info, "did_b")
-    address_A, address_B = node_A_info["peerId"]+"."+did_A, node_B_info["peerId"]+"."+did_B
 
     print("\n------ Test Case (FAIL) : Transferring 100 RBT from A which has zero balance ------")
 
     print("\nTransferring 100 RBT from A to B....")
-    expect_failure(rbt_transfer)(address_A, address_B, 100, server_port_A, grpc_port_A)
+    expect_failure(rbt_transfer)(did_A, did_B, 100, server_port_A, grpc_port_A)
 
     print("\n------ Test Case (FAIL) : Transferring 100 RBT from A which has zero balance completed ------\n")
 
     print("\n------ Test Case (FAIL) : Transferring 100 RBT from B which has insufficient balance ------")
 
     print("\nTransferring 100 RBT from B to A....")
-    expect_failure(rbt_transfer)(address_B, address_A, 0.25, server_port_B, grpc_port_B)
+    expect_failure(rbt_transfer)(did_B, did_A, 0.25, server_port_B, grpc_port_B)
 
     print("\n------ Test Case (FAIL) : Transferring 100 RBT from B which has insufficient balance completed ------\n")
 
@@ -85,7 +83,6 @@ def shuttle_transfer(config):
     server_port_A, grpc_port_A = node_A_info["server"], node_A_info["grpcPort"]
     server_port_B, grpc_port_B = node_B_info["server"], node_B_info["grpcPort"]
     did_A, did_B = get_did_by_alias(node_A_info, "did_a"), get_did_by_alias(node_B_info, "did_b")
-    address_A, address_B = node_A_info["peerId"]+"."+did_A, node_B_info["peerId"]+"."+did_B
 
     print("------ Test Case (PASS): Shuttle transfer started ------\n")
 
@@ -114,32 +111,32 @@ def shuttle_transfer(config):
 
     print("\n2. Transferring 0.5 RBT from A to B....")
     add_peer_details(node_B_info["peerId"], did_B, 4, server_port_A, grpc_port_A) #adding peer details of node B to node A
-    expect_success(rbt_transfer)(address_A, address_B, 0.5, server_port_A, grpc_port_A)
+    expect_success(rbt_transfer)(did_A, did_B, 0.5, server_port_A, grpc_port_A)
     print("Transferred 0.5 RBT from A to B")
 
     print("\n3. Transferring 1.499 RBT from A to B....")
-    expect_success(rbt_transfer)(address_A, address_B, 1.499, server_port_A, grpc_port_A)
+    expect_success(rbt_transfer)(did_A, did_B, 1.499, server_port_A, grpc_port_A)
     print("Transferred 1.499 RBT from A to B")
 
     print("\n4. Transferring 0.25 RBT from B to A....")
     add_peer_details(node_A_info["peerId"], did_A, 4, server_port_B, grpc_port_B) #adding peer details of node A to node B
-    expect_success(rbt_transfer)(address_B, address_A, 0.25, server_port_B, grpc_port_B)
+    expect_success(rbt_transfer)(did_B, did_A, 0.25, server_port_B, grpc_port_B)
     print("Transferred 0.25 RBT from B to A")
 
     print("\n5. Transferring 0.25 RBT from B to A....")
-    expect_success(rbt_transfer)(address_B, address_A, 0.25, server_port_B, grpc_port_B)
+    expect_success(rbt_transfer)(did_B, did_A, 0.25, server_port_B, grpc_port_B)
     print("Transferred 0.25 RBT from B to A")
 
     print("\n6. Transferring 0.25 RBT from B to A....")
-    expect_success(rbt_transfer)(address_B, address_A, 0.25, server_port_B, grpc_port_B)
+    expect_success(rbt_transfer)(did_B, did_A, 0.25, server_port_B, grpc_port_B)
     print("Transferred 0.25 RBT from B to A")
 
     print("\n7. Transferring 0.25 RBT from B to A....")
-    expect_success(rbt_transfer)(address_B, address_A, 0.25, server_port_B, grpc_port_B)
+    expect_success(rbt_transfer)(did_B, did_A, 0.25, server_port_B, grpc_port_B)
     print("Transferred 0.25 RBT from B to A")
 
     print("\n8. Transferring 1 RBT from A to B....")
-    expect_success(rbt_transfer)(address_A, address_B, 1, server_port_A, grpc_port_A)
+    expect_success(rbt_transfer)(did_A, did_B, 1, server_port_A, grpc_port_A)
     print("Transferred 1 RBT from A to B")    
 
     print("\n9. Generating 2 whole RBT for A")
@@ -147,11 +144,11 @@ def shuttle_transfer(config):
     print("Funded node A with 2 RBT")
     
     print("\n10. Transferring 2 RBT from A to B....")
-    expect_success(rbt_transfer)(address_A, address_B, 2, server_port_A, grpc_port_A)
+    expect_success(rbt_transfer)(did_A, did_B, 2, server_port_A, grpc_port_A)
     print("Transferred 2 RBT from A to B")    
 
     print("\n11. Transferring 0.001 RBT from A to B....")
-    expect_success(rbt_transfer)(address_A, address_B, 0.001, server_port_A, grpc_port_A)
+    expect_success(rbt_transfer)(did_A, did_B, 0.001, server_port_A, grpc_port_A)
     print("Transferred 0.001 RBT from A to B")
 
     print("\n------ Test Case (PASS): Shuttle transfer completed ------\n")


### PR DESCRIPTION
Change the structure of entering node information for transferrbt and quorum list from `peerid.did` to `did` 

The transferrbt command will be

```
./rubixgoplatform transferrbt -port 20000 -senderAddr bafybmiftqpvkq6sibrpjr3biallzbrmdwumlkwa37spo7iwdaxqpcpgdgm -receiverAddr bafybmiesr2x772guu7o4qfxywpdyqixlfcvpbocr4jgyij4ou2ff4l55aq -rbtAmount 1.0
```

A sample quorumlist.json file will look like 

```

[
    {
        "type": 2,
        "address": "bafybmigrbkrtuu5nfc7jroz67lniyblydb4fntb55wevzn3764dy2jc6sm"
    },
    {
        "type": 2,
        "address": "bafybmifl33o4br2vhjtrwu4giglqdbouxs6jthbs5wo6nmhg2t65a7u77q"
    },
    {
        "type": 2,
        "address": "bafybmidytlbajqv66ezn6bcbjujlawrotg3na3iuqikjf5v7cbbjawdro4"
    },
    {
        "type": 2,
        "address": "bafybmic335nflx7ip4oosmf3j6kri6h4ilhw6dgey76mxpihyjxdckke5y"
    },
    {
        "type": 2,
        "address": "bafybmigjr3yvsqeohq7245log6hubrt5y3bicmjlondz3zstn2wnrxpofm"
    }
]
```