### PR TITLE
Quick fix : Mnemonic key error handling

### DIFF
--- a/did/did.go
+++ b/did/did.go
@@ -59,6 +59,7 @@ func InitDID(dir string, log logger.Logger, ipfs *ipfsnode.Shell) *DID {
 func (d *DID) CreateDID(didCreate *DIDCreate) (string, error) {
 	t1 := time.Now()
 	temp := uuid.New()
+	var _mnemonic []byte
 	dirName := d.dir + temp.String()
 	err := os.MkdirAll(dirName+"/public", os.ModeDir|os.ModePerm)
 	if err != nil {
@@ -79,10 +80,14 @@ func (d *DID) CreateDID(didCreate *DIDCreate) (string, error) {
 			return "", err
 		}
 
-		_mnemonic, err := os.ReadFile(didCreate.MnemonicFile)
-		if err != nil {
-			d.log.Debug("failed to read mnemonic file", "err", err)
+		_, err := os.Stat(didCreate.MnemonicFile)
+		if os.IsExist(err) {
+			_mnemonic, err = os.ReadFile(didCreate.MnemonicFile)
+			if err != nil {
+				d.log.Debug("failed to read mnemonic file", "err", err)
+			}
 		}
+
 		var mnemonic string
 		if _mnemonic == nil {
 			mnemonic = crypto.BIPGenerateMnemonic()
@@ -260,12 +265,6 @@ func (d *DID) CreateDID(didCreate *DIDCreate) (string, error) {
 			return "", err
 		}
 
-	} else if didCreate.Type != LiteDIDMode {
-		_, err := util.Filecopy(didCreate.PubKeyFile, dirName+"/public/"+PubKeyFileName)
-		if err != nil {
-			d.log.Error("failed to copy pub key", "err", err)
-			return "", err
-		}
 	}
 
 	if didCreate.Type == ChildDIDMode {

--- a/did/did.go
+++ b/did/did.go
@@ -265,6 +265,12 @@ func (d *DID) CreateDID(didCreate *DIDCreate) (string, error) {
 			return "", err
 		}
 
+	} else if didCreate.Type != LiteDIDMode {
+		_, err := util.Filecopy(didCreate.PubKeyFile, dirName+"/public/"+PubKeyFileName)
+		if err != nil {
+			d.log.Error("failed to copy pub key", "err", err)
+			return "", err
+		}
 	}
 
 	if didCreate.Type == ChildDIDMode {


### PR DESCRIPTION
### Small fix :  
Which we create type 4 DID , we check whether mnemonicFile is present (default -mnemonic.txt) unless specified using -mnemonicKeyFile flag.  We had a debug statement `Main.Core: failed to read mnemonic file: err="open mnemonic.txt: no such file or directory"` which could potentially confuse for users. 
This PR checks whether specified mnemonickeyfile exist or not and read it only in case it does. If there is no mnenmonickey , we create a random key and store in mnemonic.txt inside DID folder

### Testing : 
call createdid without specifying mnemonicKeyFile (or a filename that doesn't exist) 

Attaching screenshot of code execution before and after. 

<img width="657" alt="Screenshot 2024-06-06 at 6 12 02 PM" src="https://github.com/rubixchain/rubixgoplatform/assets/130964671/ace4393d-0d2a-492c-8582-2318e815dca8">

