### PR TITLE
Ashita/quorum checkfor pledged token state

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,3 +368,28 @@ This following options are used for this command
   -didType int
         DID type (0-Basic Mode, 1-Standard Mode, 2-Wallet Mode, 3-Child Mode, 4-Light Mode) (default 0)
 ```
+
+To check details about the token states for which pledging has been done
+: To check for what token states the pledging has been done, and which tokens are pledged
+
+```
+./rubixgoplatform getpledgedtokendetails
+
+This following options are used for this command
+  -port string
+        Server/Host port (default "20000")
+```
+
+To check tokenstatehash status
+: To check if a particular tokenstatehash is exhausted, i.e if it has been transferred further
+
+```
+./rubixgoplatform tokenstatehash
+
+This following options are used for this command
+  -port string
+        Server/Host port (default "20000")
+        
+  -tokenstatehash string
+        TokenState Hash, for which the status needs to be checked
+```

--- a/client/token.go
+++ b/client/token.go
@@ -46,7 +46,7 @@ func (c *Client) GetPinnedInfo(TokenStateHash string) (*model.BasicResponse, err
 	m := make(map[string]string)
 	m["tokenstatehash"] = TokenStateHash
 	var br model.BasicResponse
-	err := c.sendJSONRequest("GET", setup.APICheckPinnedState, m, nil, &br, time.Minute*2)
+	err := c.sendJSONRequest("DELETE", setup.APICheckPinnedState, m, nil, &br, time.Minute*2)
 	if err != nil {
 		c.log.Error("Failed to get Pins", "err", err)
 		return nil, err

--- a/client/token.go
+++ b/client/token.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"time"
+
 	"github.com/rubixchain/rubixgoplatform/core/model"
 	"github.com/rubixchain/rubixgoplatform/setup"
 )
@@ -28,4 +30,26 @@ func (c *Client) GetAllTokens(didStr string, tokenType string) (*model.TokenResp
 		return nil, err
 	}
 	return &tr, nil
+}
+
+func (c *Client) GetPledgedTokenDetails() (*model.TokenStateResponse, error) {
+	var tr model.TokenStateResponse
+	err := c.sendJSONRequest("GET", setup.APIGetPledgedTokenDetails, nil, nil, &tr, time.Minute*2)
+	if err != nil {
+		c.log.Error("Failed to get pledged token details", "err", err)
+		return nil, err
+	}
+	return &tr, nil
+}
+
+func (c *Client) GetPinnedInfo(TokenStateHash string) (*model.BasicResponse, error) {
+	m := make(map[string]string)
+	m["tokenstatehash"] = TokenStateHash
+	var br model.BasicResponse
+	err := c.sendJSONRequest("GET", setup.APICheckPinnedState, m, nil, &br, time.Minute*2)
+	if err != nil {
+		c.log.Error("Failed to get Pins", "err", err)
+		return nil, err
+	}
+	return &br, nil
 }

--- a/command/command.go
+++ b/command/command.go
@@ -82,6 +82,8 @@ const (
 	AddExplorerCmd                 string = "addexplorer"
 	RemoveExplorerCmd              string = "removeexplorer"
 	GetAllExplorerCmd              string = "getallexplorer"
+	GetPledgedTokenDetailsCmd      string = "getpledgedtokendetails"
+	CheckPinnedState               string = "checkpinnedstate"
 )
 
 var commands = []string{VersionCmd,
@@ -249,6 +251,7 @@ type Command struct {
 	links              []string
 	mnemonicFile       string
 	ChildPath          int
+	TokenState         string
 }
 
 func showVersion() {
@@ -445,6 +448,7 @@ func Run(args []string) {
 	flag.BoolVar(&cmd.latest, "latest", false, "flag to set latest")
 	flag.StringVar(&cmd.quorumAddr, "quorumAddr", "", "Quorum Node Address to check the status of the Quorum")
 	flag.StringVar(&links, "links", "", "Explorer url")
+	flag.StringVar(&cmd.TokenState, "tokenstatehash", "", "Give Token State Hash to check state")
 
 	if len(os.Args) < 2 {
 		fmt.Println("Invalid Command")
@@ -602,6 +606,10 @@ func Run(args []string) {
 		cmd.removeExplorer()
 	case GetAllExplorerCmd:
 		cmd.getAllExplorer()
+	case GetPledgedTokenDetailsCmd:
+		cmd.GetPledgedTokenDetails()
+	case CheckPinnedState:
+		cmd.CheckPinnedState()
 	default:
 		cmd.log.Error("Invalid command")
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -33,7 +33,7 @@ const (
 )
 
 const (
-	version string = "0.0.17 copy branch"
+	version string = "0.0.17"
 )
 const (
 	VersionCmd                     string = "-v"

--- a/command/command.go
+++ b/command/command.go
@@ -33,7 +33,7 @@ const (
 )
 
 const (
-	version string = "0.0.17"
+	version string = "0.0.17 copy branch"
 )
 const (
 	VersionCmd                     string = "-v"

--- a/command/tokenstate.go
+++ b/command/tokenstate.go
@@ -1,0 +1,37 @@
+package command
+
+import "fmt"
+
+func (cmd *Command) GetPledgedTokenDetails() {
+	info, err := cmd.c.GetPledgedTokenDetails()
+	if err != nil {
+		cmd.log.Error("Invalid response from the node", "err", err)
+		return
+	}
+	fmt.Printf("Response : %v\n", info)
+	if !info.Status {
+		cmd.log.Error("Failed to get account info", "message", info.Message)
+	} else {
+		cmd.log.Info("Successfully got the pledged token states info")
+		fmt.Println("DID	", "Pledged Token	", "Token State")
+		for _, i := range info.PledgedTokenStateDetails {
+			fmt.Println(i.DID, "	", i.TokensPledged, "	", i.TokenStateHash)
+		}
+	}
+}
+
+//command will take token hash, check for ipfs pinning, if no, ignore, if yes, get token detail, unpledge.
+
+func (cmd *Command) CheckPinnedState() {
+	info, err := cmd.c.GetPinnedInfo(cmd.TokenState)
+	if err != nil {
+		cmd.log.Error("Invalid response from the node", "err", err)
+		return
+	}
+	fmt.Printf("Response : %v\n", info)
+	if !info.Status {
+		cmd.log.Error("Pin not available", "message", info.Message)
+	} else {
+		cmd.log.Info("Token State is Pinned")
+	}
+}

--- a/command/tokenstate.go
+++ b/command/tokenstate.go
@@ -30,7 +30,7 @@ func (cmd *Command) CheckPinnedState() {
 	}
 	fmt.Printf("Response : %v\n", info)
 	if !info.Status {
-		cmd.log.Error("Pin not available", "message", info.Message)
+		cmd.log.Debug("Pin not available", "message", info.Message)
 	} else {
 		cmd.log.Info("Token State is Pinned")
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -50,6 +50,7 @@ const (
 	APICheckQuorumStatusPath  string = "/api/check-quorum-status"
 	APIGetPeerDIDTypePath     string = "/api/get-peer-didType"
 	APIGetPeerInfoPath        string = "/api/get-peer-info"
+	APIUpdateTokenHashDetails string = "/api/update-tokenhash-details"
 )
 
 const (

--- a/core/model/tokens.go
+++ b/core/model/tokens.go
@@ -42,12 +42,23 @@ type DIDAccountInfo struct {
 	LockedRBT  float64 `json:"locked_rbt"`
 }
 
-type TokenDetial struct {
+type TokenDetail struct {
 	Token  string `json:"token"`
 	Status int    `json:"status"`
 }
 
 type TokenResponse struct {
 	BasicResponse
-	TokenDetials []TokenDetial `json:"token_detials"`
+	TokenDetails []TokenDetail `json:"token_detials"`
+}
+
+type PledgedTokenStateDetails struct {
+	DID            string `json:"did"`
+	TokensPledged  string `json:"token"`
+	TokenStateHash string `json:"token_state"`
+}
+
+type TokenStateResponse struct {
+	BasicResponse
+	PledgedTokenStateDetails []PledgedTokenStateDetails `json:"token_state_details"`
 }

--- a/core/quorum_recv.go
+++ b/core/quorum_recv.go
@@ -779,6 +779,18 @@ func (c *Core) updateReceiverToken(req *ensweb.Request) *ensweb.Result {
 		crep.Message = "Failed to update token status, failed to get block ID"
 		return c.l.RenderJSON(req, &crep, http.StatusOK)
 	}
+	//add to ipfs to get latest Token State Hash after receiving the token by receiver. The hashes will be returned to sender, and from there to
+	//quorums using pledgefinality function, to be added to TokenStateHash Table
+	var updatedtokenhashes []string
+	for _, ti := range sr.TokenInfo {
+		t := ti.Token
+		b := c.w.GetLatestTokenBlock(ti.Token, ti.TokenType)
+		blockId, _ := b.GetBlockID(t)
+		tokenIDTokenStateData := t + blockId
+		tokenIDTokenStateBuffer := bytes.NewBuffer([]byte(tokenIDTokenStateData))
+		tokenIDTokenStateHash, _ := c.ipfs.Add(tokenIDTokenStateBuffer, ipfsnode.Pin(false), ipfsnode.OnlyHash(true))
+		updatedtokenhashes = append(updatedtokenhashes, tokenIDTokenStateHash)
+	}
 	td := &wallet.TransactionDetails{
 		TransactionID:   b.GetTid(),
 		TransactionType: b.GetTransType(),
@@ -794,6 +806,7 @@ func (c *Core) updateReceiverToken(req *ensweb.Request) *ensweb.Result {
 	c.w.AddTransactionHistory(td)
 	crep.Status = true
 	crep.Message = "Token received successfully"
+	crep.Result = updatedtokenhashes
 	return c.l.RenderJSON(req, &crep, http.StatusOK)
 }
 
@@ -939,6 +952,15 @@ func (c *Core) updatePledgeToken(req *ensweb.Request) *ensweb.Result {
 		}
 	}
 
+	//Adding to the Token State Hash Table
+	if ur.TransferredTokenStateHashes != nil {
+		err = c.w.AddTokenStateHash(did, ur.TransferredTokenStateHashes, ur.PledgedTokens, ur.TransactionID)
+	}
+	if err != nil {
+		c.log.Error("Failed to add token state hash", "err", err)
+	}
+
+	//TODO : Unpledging tokens to be removed
 	for _, t := range ur.PledgedTokens {
 		c.up.AddUnPledge(t)
 	}

--- a/core/quorum_recv.go
+++ b/core/quorum_recv.go
@@ -806,12 +806,10 @@ func (c *Core) updateReceiverToken(req *ensweb.Request) *ensweb.Result {
 	c.w.AddTransactionHistory(td)
 	crep.Status = true
 	crep.Message = "Token received successfully"
-
 	//Adding quorums to DIDPeerTable of receiver
 	for _, qrm := range sr.QuorumInfo {
 		c.w.AddDIDPeerMap(qrm.DID, qrm.PeerID, *qrm.DIDType)
 	}
-
 	crep.Result = updatedtokenhashes
 	return c.l.RenderJSON(req, &crep, http.StatusOK)
 }
@@ -1029,8 +1027,8 @@ func (c *Core) mapDIDArbitration(req *ensweb.Request) *ensweb.Result {
 	}
 	err = c.srv.UpdateTokenDetials(nd)
 	if err != nil {
-		c.log.Error("Failed to update table detials", "err", err)
-		br.Message = "Failed to update token detials"
+		c.log.Error("Failed to update table details", "err", err)
+		br.Message = "Failed to update token details"
 		return c.l.RenderJSON(req, &br, http.StatusOK)
 	}
 	dm := &service.DIDMap{
@@ -1373,5 +1371,18 @@ func (c *Core) unlockTokens(req *ensweb.Request) *ensweb.Result {
 	crep.Message = "Tokens Unlocked Successfully."
 	c.log.Info("Tokens Unclocked")
 	return c.l.RenderJSON(req, &crep, http.StatusOK)
+
+}
+
+func (c *Core) updateTokenHashDetails(req *ensweb.Request) *ensweb.Result {
+	c.log.Debug("Updating tokenStateHashDetails in DB")
+	tokenIDTokenStateHash := c.l.GetQuerry(req, "tokenIDTokenStateHash")
+	c.log.Debug("tokenIDTokenStateHash from query", tokenIDTokenStateHash)
+
+	err := c.w.RemoveTokenStateHash(tokenIDTokenStateHash)
+	if err == nil {
+		fmt.Println("removed hash successfully")
+	}
+	return c.l.RenderJSON(req, nil, http.StatusOK)
 
 }

--- a/core/quorum_validation.go
+++ b/core/quorum_validation.go
@@ -22,6 +22,7 @@ type TokenStateCheckResult struct {
 	Error                 error
 	Message               string
 	tokenIDTokenStateData string
+	tokenIDTokenStateHash string
 }
 
 func (c *Core) validateSigner(b *block.Block) (bool, error) {
@@ -329,6 +330,7 @@ func (c *Core) checkTokenState(tokenId, did string, index int, resultArray []Tok
 
 	//add to ipfs get only the hash of the token+tokenstate
 	tokenIDTokenStateHash, err := c.ipfs.Add(tokenIDTokenStateBuffer, ipfsnode.Pin(false), ipfsnode.OnlyHash(true))
+	result.tokenIDTokenStateHash = tokenIDTokenStateHash
 	if err != nil {
 		c.log.Error("Error adding data to ipfs", err)
 		result.Error = err

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -605,7 +605,7 @@ func (w *Wallet) AddTokenStateHash(did string, tokenstatehashes []string, pledge
 	concatenatedpledgedtokens := ""
 
 	for _, i := range pledgedtokens {
-		concatenatedpledgedtokens = concatenatedpledgedtokens + i + " "
+		concatenatedpledgedtokens = concatenatedpledgedtokens + i + ","
 	}
 
 	for _, tokenstatehash := range tokenstatehashes {
@@ -665,7 +665,7 @@ func (w *Wallet) RemoveTokenStateHash(tokenstatehash string) error {
 		return nil
 	}
 
-	pledgedTokensList := strings.Split(td.PledgedTokens, " ")
+	pledgedTokensList := strings.Split(td.PledgedTokens, ",")
 
 	for _, pledgedToken := range pledgedTokensList {
 		if strings.TrimSpace(pledgedToken) == "" {

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -667,9 +667,12 @@ func (w *Wallet) RemoveTokenStateHash(tokenstatehash string) error {
 
 	pledgedTokensList := strings.Split(td.PledgedTokens, " ")
 
-	for _, v := range pledgedTokensList {
+	for _, pledgedToken := range pledgedTokensList {
+		if strings.TrimSpace(pledgedToken) == "" {
+			continue
+		}
 		var tokend Token
-		err = w.s.Read(TokenStorage, &tokend, "did=? AND token_id=?", td.DID, v)
+		err = w.s.Read(TokenStorage, &tokend, "did=? AND token_id=?", td.DID, pledgedToken)
 		if err != nil {
 			w.log.Error("Failed to read token details from DB", "err", err)
 			return err
@@ -687,6 +690,5 @@ func (w *Wallet) RemoveTokenStateHash(tokenstatehash string) error {
 		w.log.Error("Failed to delete token state from DB", "err", err)
 		return err
 	}
-	fmt.Println("Delete TokenStateDetails : ", td1)
 	return nil
 }

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -602,11 +602,7 @@ func (w *Wallet) AddTokenStateHash(did string, tokenstatehashes []string, pledge
 	if tokenstatehashes == nil {
 		return nil
 	}
-	concatenatedpledgedtokens := ""
-
-	for _, i := range pledgedtokens {
-		concatenatedpledgedtokens = concatenatedpledgedtokens + i + ","
-	}
+	concatenatedpledgedtokens := strings.Join(pledgedtokens, ",")
 
 	for _, tokenstatehash := range tokenstatehashes {
 		td.DID = did

--- a/core/wallet/token_chain.go
+++ b/core/wallet/token_chain.go
@@ -34,6 +34,13 @@ const (
 
 const TCBlockCountLimit int = 100
 
+type TokenStateDetails struct {
+	DID            string `gorm:"column:did" json:"did"`
+	TokenStateHash string `gorm:"column:token_state_hash;primaryKey" json:"token_state_hash"`
+	PledgedTokens  string `gorm:"column:pledged_token" json:"pledged_token"`
+	TransactionID  string `gorm:"column:transaction_id" json:"transaction_id"`
+}
+
 func tcsType(tokenType int) string {
 	tt := "wt"
 	switch tokenType {

--- a/core/wallet/wallet.go
+++ b/core/wallet/wallet.go
@@ -27,6 +27,7 @@ const (
 	SmartContractTokenChainStorage string = "smartcontractokenchainstorage"
 	SmartContractStorage           string = "smartcontract"
 	CallBackUrlStorage             string = "callbackurl"
+	TokenStateHash                 string = "TokenStateHashTable"
 )
 
 type WalletConfig struct {
@@ -146,6 +147,12 @@ func InitWallet(s storage.Storage, dir string, log logger.Logger) (*Wallet, erro
 	err = w.s.Init(CallBackUrlStorage, &CallBackUrl{}, true)
 	if err != nil {
 		w.log.Error("Failed to initialize Smart Contract Callback Url storage", "err", err)
+		return nil, err
+	}
+
+	err = w.s.Init(TokenStateHash, &TokenStateDetails{}, true)
+	if err != nil {
+		w.log.Error("Failed to initialize TokenStateHash", "err", err)
 		return nil, err
 	}
 

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -86,6 +86,38 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/check-pinned-state": {
+            "delete": {
+                "description": "This API is used to check if the token state for which the token is pledged is exhausted or not.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account"
+                ],
+                "summary": "Check for exhausted token state hash",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Token State Hash",
+                        "name": "tokenstatehash",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/commit-data-token": {
             "post": {
                 "description": "This API will create data token",
@@ -590,6 +622,26 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/get-pledgedtoken-details": {
+            "get": {
+                "description": "This API allows the user to get details about the tokens the quorums have pledged i.e. which token is pledged for which token state",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account"
+                ],
+                "summary": "Get details about the pledged tokens",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.TokenStateResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/get-smart-contract-token-chain-data": {
             "post": {
                 "description": "This API will return smart contract token chain data",
@@ -877,6 +929,38 @@ const docTemplate = `{
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/model.NFTStatus"
+                    }
+                }
+            }
+        },
+        "model.PledgedTokenStateDetails": {
+            "type": "object",
+            "properties": {
+                "did": {
+                    "type": "string"
+                },
+                "token": {
+                    "type": "string"
+                },
+                "token_state": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.TokenStateResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "result": {},
+                "status": {
+                    "type": "boolean"
+                },
+                "token_state_details": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.PledgedTokenStateDetails"
                     }
                 }
             }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -78,6 +78,38 @@
                 }
             }
         },
+        "/api/check-pinned-state": {
+            "delete": {
+                "description": "This API is used to check if the token state for which the token is pledged is exhausted or not.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account"
+                ],
+                "summary": "Check for exhausted token state hash",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Token State Hash",
+                        "name": "tokenstatehash",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/commit-data-token": {
             "post": {
                 "description": "This API will create data token",
@@ -582,6 +614,26 @@
                 }
             }
         },
+        "/api/get-pledgedtoken-details": {
+            "get": {
+                "description": "This API allows the user to get details about the tokens the quorums have pledged i.e. which token is pledged for which token state",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account"
+                ],
+                "summary": "Get details about the pledged tokens",
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.TokenStateResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/get-smart-contract-token-chain-data": {
             "post": {
                 "description": "This API will return smart contract token chain data",
@@ -869,6 +921,38 @@
                     "type": "array",
                     "items": {
                         "$ref": "#/definitions/model.NFTStatus"
+                    }
+                }
+            }
+        },
+        "model.PledgedTokenStateDetails": {
+            "type": "object",
+            "properties": {
+                "did": {
+                    "type": "string"
+                },
+                "token": {
+                    "type": "string"
+                },
+                "token_state": {
+                    "type": "string"
+                }
+            }
+        },
+        "model.TokenStateResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                },
+                "result": {},
+                "status": {
+                    "type": "boolean"
+                },
+                "token_state_details": {
+                    "type": "array",
+                    "items": {
+                        "$ref": "#/definitions/model.PledgedTokenStateDetails"
                     }
                 }
             }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -44,6 +44,27 @@ definitions:
           $ref: '#/definitions/model.NFTStatus'
         type: array
     type: object
+  model.PledgedTokenStateDetails:
+    properties:
+      did:
+        type: string
+      token:
+        type: string
+      token_state:
+        type: string
+    type: object
+  model.TokenStateResponse:
+    properties:
+      message:
+        type: string
+      result: {}
+      status:
+        type: boolean
+      token_state_details:
+        items:
+          $ref: '#/definitions/model.PledgedTokenStateDetails'
+        type: array
+    type: object
   model.TxnCountForDID:
     properties:
       message:
@@ -198,6 +219,28 @@ paths:
       summary: Add NFTs
       tags:
       - NFT
+  /api/check-pinned-state:
+    delete:
+      consumes:
+      - application/json
+      description: This API is used to check if the token state for which the token
+        is pledged is exhausted or not.
+      parameters:
+      - description: Token State Hash
+        in: query
+        name: tokenstatehash
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.BasicResponse'
+      summary: Check for exhausted token state hash
+      tags:
+      - Account
   /api/commit-data-token:
     post:
       consumes:
@@ -531,6 +574,20 @@ paths:
       summary: Get Data Token
       tags:
       - Data Tokens
+  /api/get-pledgedtoken-details:
+    get:
+      description: This API allows the user to get details about the tokens the quorums
+        have pledged i.e. which token is pledged for which token state
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.TokenStateResponse'
+      summary: Get details about the pledged tokens
+      tags:
+      - Account
   /api/get-smart-contract-token-chain-data:
     post:
       consumes:

--- a/grpcserver/token.go
+++ b/grpcserver/token.go
@@ -87,7 +87,7 @@ func (rn *RubixNative) GetAllTokens(ctx context.Context, in *protos.TokenReq) (*
 	resp := &protos.TokenResp{
 		TokenDetials: make([]*protos.TokenDetial, 0),
 	}
-	for _, td := range tr.TokenDetials {
+	for _, td := range tr.TokenDetails {
 		t := &protos.TokenDetial{
 			Token:      td.Token,
 			TokenState: int32(td.Status),

--- a/server/server.go
+++ b/server/server.go
@@ -161,6 +161,8 @@ func (s *Server) RegisterRoutes() {
 	s.AddRoute(setup.APIGetAllExplorer, "GET", s.AuthHandle(s.APIGetAllExplorer, false, s.AuthError, true))
 	s.AddRoute(setup.APIAddExplorer, "POST", s.AuthHandle(s.APIAddExplorer, false, s.AuthError, true))
 	s.AddRoute(setup.APIRemoveExplorer, "POST", s.AuthHandle(s.APIRemoveExplorer, false, s.AuthError, true))
+	s.AddRoute(setup.APIGetPledgedTokenDetails, "GET", s.AuthHandle(s.APIGetPledgedTokenDetails, false, s.AuthError, true))
+	s.AddRoute(setup.APICheckPinnedState, "GET", s.AuthHandle(s.APICheckPinnedState, false, s.AuthError, true))
 }
 
 func (s *Server) ExitFunc() error {

--- a/server/server.go
+++ b/server/server.go
@@ -162,7 +162,7 @@ func (s *Server) RegisterRoutes() {
 	s.AddRoute(setup.APIRemoveExplorer, "POST", s.AuthHandle(s.APIRemoveExplorer, false, s.AuthError, true))
 	s.AddRoute(setup.APIAddPeerDetails, "POST", s.AuthHandle(s.APIAddPeerDetails, false, s.AuthError, true))
 	s.AddRoute(setup.APIGetPledgedTokenDetails, "GET", s.AuthHandle(s.APIGetPledgedTokenDetails, false, s.AuthError, true))
-	s.AddRoute(setup.APICheckPinnedState, "GET", s.AuthHandle(s.APICheckPinnedState, false, s.AuthError, true))
+	s.AddRoute(setup.APICheckPinnedState, "DELETE", s.AuthHandle(s.APICheckPinnedState, false, s.AuthError, true))
 }
 
 func (s *Server) ExitFunc() error {

--- a/server/tokens.go
+++ b/server/tokens.go
@@ -1,6 +1,7 @@
 package server
 
 import (
+	"fmt"
 	"net/http"
 
 	"github.com/rubixchain/rubixgoplatform/core/model"
@@ -157,7 +158,7 @@ func (s *Server) APICheckPinnedState(req *ensweb.Request) *ensweb.Result {
 	var br model.BasicResponse
 	if len(provList) == 0 {
 		br.Status = false
-		br.Message = "No pins available on " + tokenstatehash
+		br.Message = fmt.Sprintf("No pins available on %s", tokenstatehash)
 		return s.RenderJSON(req, br, http.StatusOK)
 	} else {
 		br.Status = true

--- a/server/tokens.go
+++ b/server/tokens.go
@@ -130,3 +130,44 @@ func (s *Server) APISignatureResponse(req *ensweb.Request) *ensweb.Result {
 	dc.InChan <- resp
 	return s.didResponse(req, resp.ID)
 }
+
+func (s *Server) APIGetPledgedTokenDetails(req *ensweb.Request) *ensweb.Result {
+	pledgedTokenInfo, err := s.c.GetPledgedInfo()
+	if err != nil {
+		return s.BasicResponse(req, false, err.Error(), nil)
+	}
+	tokenstateresponse := model.TokenStateResponse{
+		BasicResponse: model.BasicResponse{
+			Status:  true,
+			Message: "Got pledged tokens with token states info successfully",
+		},
+		PledgedTokenStateDetails: make([]model.PledgedTokenStateDetails, 0),
+	}
+	tokenstateresponse.PledgedTokenStateDetails = append(tokenstateresponse.PledgedTokenStateDetails, pledgedTokenInfo...)
+	return s.RenderJSON(req, tokenstateresponse, http.StatusOK)
+}
+
+func (s *Server) APICheckPinnedState(req *ensweb.Request) *ensweb.Result {
+	tokenstatehash := s.GetQuerry(req, "tokenstatehash")
+
+	provList, err := s.c.GetDHTddrs(tokenstatehash)
+	if err != nil {
+		return s.BasicResponse(req, false, err.Error(), nil)
+	}
+	var br model.BasicResponse
+	if len(provList) == 0 {
+		br.Status = false
+		br.Message = "No pins available on " + tokenstatehash
+		return s.RenderJSON(req, br, http.StatusOK)
+	} else {
+		br.Status = true
+		br.Result = provList
+	}
+
+	err = s.c.UpdatePledgedTokenInfo(tokenstatehash)
+	if err != nil {
+		return s.BasicResponse(req, false, err.Error(), nil)
+	}
+	br.Message = "Got Pins on " + tokenstatehash + ". Updated the pledging detail in table and removed from pledged token state table."
+	return s.RenderJSON(req, br, http.StatusOK)
+}

--- a/server/tokens.go
+++ b/server/tokens.go
@@ -132,6 +132,13 @@ func (s *Server) APISignatureResponse(req *ensweb.Request) *ensweb.Result {
 	return s.didResponse(req, resp.ID)
 }
 
+// APIGetPledgedTokenDetails godoc
+// @Summary     Get details about the pledged tokens
+// @Description This API allows the user to get details about the tokens the quorums have pledged i.e. which token is pledged for which token state
+// @Tags        Account
+// @Produce     json
+// @Success     200 {object} model.TokenStateResponse
+// @Router      /api/get-pledgedtoken-details [get]
 func (s *Server) APIGetPledgedTokenDetails(req *ensweb.Request) *ensweb.Result {
 	pledgedTokenInfo, err := s.c.GetPledgedInfo()
 	if err != nil {
@@ -148,6 +155,15 @@ func (s *Server) APIGetPledgedTokenDetails(req *ensweb.Request) *ensweb.Result {
 	return s.RenderJSON(req, tokenstateresponse, http.StatusOK)
 }
 
+// APICheckPinnedState godoc
+// @Summary     Check for exhausted token state hash
+// @Description This API is used to check if the token state for which the token is pledged is exhausted or not.
+// @Tags        Account
+// @Accept      json
+// @Produce     json
+// @Param       tokenstatehash	query	string	true	"Token State Hash"
+// @Success 	200		{object}	model.BasicResponse
+// @Router /api/check-pinned-state [delete]
 func (s *Server) APICheckPinnedState(req *ensweb.Request) *ensweb.Result {
 	tokenstatehash := s.GetQuerry(req, "tokenstatehash")
 

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -67,6 +67,8 @@ const (
 	APIGetAllExplorer                   string = "/api/get-all-explorer"
 	APIAddExplorer                      string = "/api/add-explorer"
 	APIRemoveExplorer                   string = "/api/remove-explorer"
+	APIGetPledgedTokenDetails           string = "/api/get-pledgedtoken-details"
+	APICheckPinnedState                 string = "/api/check-pinned-state"
 )
 
 // jwt.RegisteredClaims

--- a/tests/run.py
+++ b/tests/run.py
@@ -3,6 +3,7 @@ import os
 import shutil
 import requests
 import argparse
+import binascii
 from node.commands import run_command
 from node.quorum import run_quorum_nodes
 
@@ -12,6 +13,21 @@ from scenarios import (
 )
 
 IPFS_KUBO_VERSION = "v0.21.0"
+
+
+def generate_ipfs_swarm_key(build_name):
+    try:
+        key = os.urandom(32)
+    except Exception as e:
+        print("While trying to read random source:", e)
+        return
+
+    output = "/key/swarm/psk/1.0.0/\n/base16/\n" + binascii.hexlify(key).decode()
+
+    filename = f"./fixtures/testswarm_{build_name}.key"
+
+    with open(filename, "w") as file:
+        file.write(output)
 
 def get_os_info():
     os_name = platform.system()


### PR DESCRIPTION
When a token is transferred, say with state t1, the quorums will check if t1 is pinned or not. If it is, means the token is being double spent. If it is not, it will pin t1 to prevent it from double spending, and after the transfer, the latest token state will become t2. So the quorums are pinning state t1, and pledging for state t2. 
Now when the token is transferred further, the new state will become t3,  and the sender will inform the old quorums, about the token state t2 being exhausted, so that the quorums can unpledge the tokens. And even if the sender doesn't send, the quorums can check the pinned state for t2 by themselves using the below APIs

To check details about all the pledged tokens and the tokenstates for which pledging is done
```
./rubixgoplatform getpledgedtokendetails -port 20001
2024-06-28T16:35:41.993+0530 [INFO]  Main: Successfully got the pledged token states info
DID	 Pledged Token	 Token State
bafybmic2jh5arz5lnwag3xfbsgtqduo3fe7ejitp3ddk7sse74a3uck5mi 
QmQqLWdiCjzqUS739NTbDFmBohc5MGoi6155JtuamSM82m  	 QmQvVDh19mTAd3YhRgbVSLPea7XU6yxJ285KWKAiD4cjBP
```
```
To check if a particular token state is exhausted ot not
./rubixgoplatform checkpinnedstate -tokenstatehash QmQvVDh19mTAd3YhRgbVSLPea7XU6yxJ285KWKAiD4cjBP -port 20001
2024-06-28T16:37:36.811+0530 [ERROR] Main: Pin not available: message="No pins available on QmQvVDh19mTAd3YhRgbVSLPea7XU6yxJ285KWKAiD4cjBP"
```

Test cases:
Same set of quorums for multiple shuttle transfers
Different sets of quorums for multiple shuttle transfers