### PR TITLE
Resolving smart-contract folder renaming error 

### DIFF
--- a/core/smart_contract.go
+++ b/core/smart_contract.go
@@ -349,7 +349,7 @@ func (c *Core) ContractCallBack(peerID string, topic string, data []byte) {
 		var isPathExist bool
 		//info is set to FileInfo describing the oldScFolder
 		info, err := os.Stat(oldScFolder)
-		//If directory doesn't exist isPathExist is set to false
+		//If directory doesn't exist, isPathExist is set to false
 		if os.IsNotExist(err) {
 			isPathExist = false
 		} else {
@@ -368,10 +368,13 @@ func (c *Core) ContractCallBack(peerID string, topic string, data []byte) {
 		}
 		c.FetchSmartContract(requestID, &fetchSC)
 		c.log.Info("Smart contract " + fetchSC.SmartContractToken + " files fetching succesful")
+		c.log.Debug("SmartContractTokenPath", fetchSC.SmartContractTokenPath)
 	}
 	smartContractToken := newEvent.SmartContractToken
 	scFolderPath := c.cfg.DirPath + "SmartContract/" + smartContractToken
+	c.log.Debug("scfolderpath", scFolderPath)
 	if _, err := os.Stat(scFolderPath); os.IsNotExist(err) {
+		c.log.Debug("sc folder path does not exist")
 		fetchSC.SmartContractToken = smartContractToken
 		fetchSC.SmartContractTokenPath, err = c.CreateSCTempFolder()
 		if err != nil {

--- a/core/smart_contract.go
+++ b/core/smart_contract.go
@@ -368,13 +368,10 @@ func (c *Core) ContractCallBack(peerID string, topic string, data []byte) {
 		}
 		c.FetchSmartContract(requestID, &fetchSC)
 		c.log.Info("Smart contract " + fetchSC.SmartContractToken + " files fetching succesful")
-		c.log.Debug("SmartContractTokenPath", fetchSC.SmartContractTokenPath)
 	}
 	smartContractToken := newEvent.SmartContractToken
 	scFolderPath := c.cfg.DirPath + "SmartContract/" + smartContractToken
-	c.log.Debug("scfolderpath", scFolderPath)
 	if _, err := os.Stat(scFolderPath); os.IsNotExist(err) {
-		c.log.Debug("sc folder path does not exist")
 		fetchSC.SmartContractToken = smartContractToken
 		fetchSC.SmartContractTokenPath, err = c.CreateSCTempFolder()
 		if err != nil {

--- a/core/smart_contract.go
+++ b/core/smart_contract.go
@@ -344,6 +344,23 @@ func (c *Core) ContractCallBack(peerID string, topic string, data []byte) {
 			c.log.Error("Fetch smart contract failed, failed to create smartcontract folder", "err", err)
 			return
 		}
+		// oldScFolder is set to path of the smartcontract folder
+		oldScFolder := c.cfg.DirPath + "SmartContract/" + fetchSC.SmartContractToken
+		var isPathExist bool
+		//info is set to FileInfo describing the oldScFolder
+		info, err := os.Stat(oldScFolder)
+		//If directory doesn't exist isPathExist is set to false
+		if os.IsNotExist(err) {
+			isPathExist = false
+		} else {
+			isPathExist = info.IsDir()
+
+		}
+		//If isPathExist true, removing the existing folder which was generated while generating the smartcontract hash
+		if isPathExist {
+			c.log.Debug("removing the existing folder:", oldScFolder, "to add the new folder")
+			os.RemoveAll(oldScFolder)
+		}
 		fetchSC.SmartContractTokenPath, err = c.RenameSCFolder(fetchSC.SmartContractTokenPath, fetchSC.SmartContractToken)
 		if err != nil {
 			c.log.Error("Fetch smart contract failed, failed to create SC folder", "err", err)

--- a/core/wallet/smart_contract.go
+++ b/core/wallet/smart_contract.go
@@ -21,10 +21,16 @@ type CallBackUrl struct {
 }
 
 func (w *Wallet) CreateSmartContractToken(sc *SmartContract) error {
-	err := w.s.Write(SmartContractStorage, sc)
+	var sc_info SmartContract
+	//to check whether smart contract hash already exist in the DB, and write if it doesn't exist
+	err := w.s.Read(SmartContractStorage, &sc_info, "smart_contract_hash=?", sc.SmartContractHash)
 	if err != nil {
-		w.log.Error("Failed to write smart contract token", "err", err)
-		return err
+		err := w.s.Write(SmartContractStorage, sc)
+		if err != nil {
+			w.log.Error("Failed to write smart contract token", "err", err)
+			return err
+		}
+		return nil
 	}
 	return nil
 }


### PR DESCRIPTION
While deploying a smart-contract, the deployer creates a temporary folder and renames it with the smart-contract hash. But there already exists a folder with the name as smart-contract hash, which was created while generating smart-contract. Thus, throwing renaming error. To resolve it, this PR is removing the existing folder before renaming it.

This PR also resolves another error which occurs while trying to re-create the same smart-contract token. While deploying, a function `FetchSmartContract` is called, which calls the function `CreateSmartContractToken`, and `CreateSmartContractToken` tries to over-write the smart-contract information in the SQLite3 DB. To resolve it, we are checking if the data already exists in the DB before writing to the DB.

This PR is tested on Linux as well as Windows OS with voting-contract and bidding-contract.