### PR TITLE
fix: distributed pledging exit when quorum count is <7 

### DIFF
--- a/core/quorum.go
+++ b/core/quorum.go
@@ -82,25 +82,25 @@ func (qm *QuorumManager) GetQuorum(t int, lastChar string) []string {
 			return nil
 		}
 		var quorumAddrList []string
-		quorumCount := 0
+		quorumAddrCount := 0
 		for _, q := range quorumList {
 			addr := string(q.PeerID + "." + q.DID)
 			quorumAddrList = append(quorumAddrList, addr)
-			quorumCount = quorumCount + 1
-			if quorumCount == 7 {
+			quorumAddrCount = quorumAddrCount + 1
+			if quorumAddrCount == 7 {
 				break
 			}
 		}
 		return quorumAddrList
 	case QuorumTypeTwo:
 		var quorumAddrList []string
-		quorumCount := 0
+		quorumAddrCount := 0
 		for _, q := range qm.ql {
 			peerID := qm.GetPeerID(q)
 			addr := string(peerID + "." + q)
 			quorumAddrList = append(quorumAddrList, addr)
-			quorumCount = quorumCount + 1
-			if quorumCount == 7 {
+			quorumAddrCount = quorumAddrCount + 1
+			if quorumAddrCount == 7 {
 				break
 			}
 		}

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -364,8 +364,8 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 		delete(c.pd, cr.ReqID)
 		c.qlock.Unlock()
 	}()
-	c.quorumCount = 0
-	c.noBalanceQuorumCount = 0
+	c.quorumCount = QuorumRequired - len(cr.QuorumList)
+	c.noBalanceQuorumCount = QuorumRequired - len(cr.QuorumList)
 	for _, a := range cr.QuorumList {
 		//This part of code is trying to connect to the quorums in quorum list, where various functions are called to pledge the tokens
 		//and checking of transaction by the quorum i.e. consensus for the transaction. Once the quorum is connected, it pledges and


### PR DESCRIPTION
A fix for #173  when `noBalanceQuorumCount` check is done with quorum count 5 or 6. 

### Explanation
`noBalanceQuorumCount` is initialised to zero and incremented each time a quorum doesn't have enough tokens to pledge. Rubix PBFT consensus requires 5 nodes to pledge and hence as soon as `noBalanceQuorumCount ` reaches greater than 2 , sender exit.   The problem is when there are only 5 or 6 quorum nodes where in such situtaions , we should exit as soon as we realise we will not have 5 nodes that can pledge.  Currently the sender wait 300 seconds before exiting with a different error code.

### Fix
Initialise  `noBalanceQuorumCount` to `QuorumRequired - len(cr.QuorumList)`  

| cr.QuorumList        | noBalanceQuorumCount          
| ------------- |:-------------:| 
| 7      | 0 |
| 6     | 1   | 
| 5 | 2 | 


PS : Also renaming `quorumCount` in quorum.go to `quorumAddrCount` to avoid naming confusion.