### PR TITLE
minor fixes

### DIFF
--- a/core/transfer.go
+++ b/core/transfer.go
@@ -217,7 +217,7 @@ func (c *Core) initiateRBTTransfer(reqID string, req *model.RBTTransferRequest) 
 	// Get the receiver & do sanity check
 	var rpeerid string = ""
 	if !isSelfRBTTransfer {
-		rpeerid := c.w.GetPeerID(receiverdid)
+		rpeerid = c.w.GetPeerID(receiverdid)
 		if rpeerid == "" {
 			c.log.Error("Peer ID not found", "did", receiverdid)
 			resp.Message = "invalid address, Peer ID not found"

--- a/server/smart_contract.go
+++ b/server/smart_contract.go
@@ -407,9 +407,8 @@ func (s *Server) APIExecuteSmartContract(req *ensweb.Request) *ensweb.Result {
 		s.log.Error("Invalid smart contract token")
 		return s.BasicResponse(req, false, "Invalid smart contract token", nil)
 	}
-
-	is_alphanumeric = regexp.MustCompile(`^[a-zA-Z0-9]*$`).MatchString(executeReq.ExecutorAddress)
-	if !strings.HasPrefix(executeReq.ExecutorAddress, "bafybmi") || len(executeReq.ExecutorAddress) != 59 || !is_alphanumeric {
+	is_alphanumeric = regexp.MustCompile(`^[a-zA-Z0-9]*$`).MatchString(did)
+	if !strings.HasPrefix(did, "bafybmi") || len(did) != 59 || !is_alphanumeric {
 		s.log.Error("Invalid executer DID")
 		return s.BasicResponse(req, false, "Invalid executer DID", nil)
 	}


### PR DESCRIPTION
Minor fixes

```
_, did, ok := util.ParseAddress(executeReq.ExecutorAddress)
	
	is_alphanumeric = regexp.MustCompile(`^[a-zA-Z0-9]*$`).MatchString(did)
	if !strings.HasPrefix(did, "bafybmi") || len(did) != 59 || !is_alphanumeric {
		s.log.Error("Invalid executer DID")
		return s.BasicResponse(req, false, "Invalid executer DID", nil)
	}
```
Here we are discarding the peerID, even if `executeReq.ExecutorAddress` contains peerID. So instead of `executeReq.ExecutorAddress`, we need to use did to check the validity of the DID.