### PR TITLE
tests: adding generated test swarm key inside a Git ignored directory 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,10 +28,7 @@ linux/
 mac/
 windows/
 dist/
-
-testswarm_linux.key
-testswarm_windows.key
-testswarm_mac.key
+test_swarm_key/
 
 # used for testing purpose
 !node_registry.json

--- a/tests/fixtures/testswarm_linux.key
+++ b/tests/fixtures/testswarm_linux.key
@@ -1,3 +1,0 @@
-/key/swarm/psk/1.0.0/
-/base16/
-278b9a199c43fa84178920bd9f5cbcd69e933ddf02a8f69e47a3ea5a1705513f

--- a/tests/fixtures/testswarm_mac.key
+++ b/tests/fixtures/testswarm_mac.key
@@ -1,3 +1,0 @@
-/key/swarm/psk/1.0.0/
-/base16/
-e105d6caa191dc76ff553d36d094fafb2ad1c646000a52ebc89b488e17f61f92

--- a/tests/fixtures/testswarm_windows.key
+++ b/tests/fixtures/testswarm_windows.key
@@ -1,3 +1,0 @@
-/key/swarm/psk/1.0.0/
-/base16/
-e105d6caa191dc76ff553d36d094fafb2ad1c646000a52ebc89b488e17f61f92

--- a/tests/run.py
+++ b/tests/run.py
@@ -24,7 +24,11 @@ def generate_ipfs_swarm_key(build_name):
 
     output = "/key/swarm/psk/1.0.0/\n/base16/\n" + binascii.hexlify(key).decode()
 
-    filename = f"./fixtures/testswarm_{build_name}.key"
+    directory = "./test_swarm_key"
+    filename = f"{directory}/testswarm_{build_name}.key"
+
+    if not os.path.exists(directory):
+        os.makedirs(directory)
 
     with open(filename, "w") as file:
         file.write(output)
@@ -121,7 +125,8 @@ def copy_fixtures_to_build_dir(build_directory):
         raise FileNotFoundError(f"Copy operation for didimage.png.file failed. Destination file not found: {image_file_dest}")
     
     # Copy testswarm.key
-    swarmkey_src = os.path.join(fixtures_directory, f"testswarm_{build_directory}.key")
+    swarm_key_dir = os.path.join("tests", "test_swarm_key")
+    swarmkey_src = os.path.join(swarm_key_dir, f"testswarm_{build_directory}.key")
     swarmkey_dest = os.path.join(build_directory, f"testswarm.key")
     shutil.copyfile(swarmkey_src, swarmkey_dest)
 


### PR DESCRIPTION
Currently while running the tests, the test IPFS swarm key is generated inside `tests/fixtures` directory. This also means that existing swarm key present in this directory is changed whenever tests are run. This causes to appear in the local Git stagging area, and has to be manually reverted before pushing other changes to remote.

This PR aims to create a new directory `test_swarm_key`, which will be specific for test swarm key generated while running tests. This newly created directory is added in `.gitignore` as well to avoid the test swarm key from being added to the local Git staging area