### PR TITLE
fixed the self transfer command by changing the TransferRBT `client` package call to SelfTransferRBT call

### DIFF
--- a/command/transfer.go
+++ b/command/transfer.go
@@ -97,7 +97,7 @@ func (cmd *Command) SelfTransferRBT() {
 		Type:     cmd.transType,
 	}
 
-	br, err := cmd.c.TransferRBT(&rt)
+	br, err := cmd.c.SelfTransferRBT(&rt)
 	if err != nil {
 		cmd.log.Error("Failed to self RBT transfer", "err", err)
 		return


### PR DESCRIPTION
This PR intends to fix the SelfTransferRBT command by replacing `TransferRBT` call to `SelfTransferRBT` call.