### PR TITLE
fixed the swagger input and server handle for Self Transfer API

### DIFF
--- a/docs/docs.go
+++ b/docs/docs.go
@@ -751,12 +751,12 @@ const docTemplate = `{
                 "operationId": "initiate-self-transfer",
                 "parameters": [
                     {
-                        "description": "Intitate RBT transfer",
+                        "description": "Intitate Self RBT transfer",
                         "name": "input",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/server.RBTTransferRequestSwaggoInput"
+                            "$ref": "#/definitions/server.RBTSelfTransferRequestSwaggoInput"
                         }
                     }
                 ],
@@ -1158,6 +1158,17 @@ const docTemplate = `{
             "properties": {
                 "smartContractToken": {
                     "type": "string"
+                }
+            }
+        },
+        "server.RBTSelfTransferRequestSwaggoInput": {
+            "type": "object",
+            "properties": {
+                "sender": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -700,6 +700,41 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/initiate-pin-token": {
+            "post": {
+                "description": "This API will pin token in the Pinning node on behalf of the sender",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account"
+                ],
+                "summary": "Initiate Pin Token",
+                "operationId": "initiate-pin-token",
+                "parameters": [
+                    {
+                        "description": "Intitate Pin Token",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.RBTPinRequestSwaggoInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/initiate-rbt-transfer": {
             "post": {
                 "description": "This API will initiate RBT transfer to the specified dID",
@@ -757,6 +792,41 @@ const docTemplate = `{
                         "required": true,
                         "schema": {
                             "$ref": "#/definitions/server.RBTSelfTransferRequestSwaggoInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/recover-token": {
+            "post": {
+                "description": "This API will recover token and tokenchain from the Pinning node to the node which has pinned the token",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account"
+                ],
+                "summary": "Recover Token and Tokenchain from the pinning node",
+                "operationId": "recover-token",
+                "parameters": [
+                    {
+                        "description": "Recover-Token",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.RBTRecoverRequestSwaggoInput"
                         }
                     }
                 ],
@@ -1158,6 +1228,43 @@ const docTemplate = `{
             "properties": {
                 "smartContractToken": {
                     "type": "string"
+                }
+            }
+        },
+        "server.RBTPinRequestSwaggoInput": {
+            "type": "object",
+            "properties": {
+                "comment": {
+                    "type": "string"
+                },
+                "pinningNode": {
+                    "type": "string"
+                },
+                "sender": {
+                    "type": "string"
+                },
+                "tokenCOunt": {
+                    "type": "number"
+                },
+                "type": {
+                    "type": "integer"
+                }
+            }
+        },
+        "server.RBTRecoverRequestSwaggoInput": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                },
+                "pinningNode": {
+                    "type": "string"
+                },
+                "sender": {
+                    "type": "string"
+                },
+                "tokenCOunt": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -692,6 +692,41 @@
                 }
             }
         },
+        "/api/initiate-pin-token": {
+            "post": {
+                "description": "This API will pin token in the Pinning node on behalf of the sender",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account"
+                ],
+                "summary": "Initiate Pin Token",
+                "operationId": "initiate-pin-token",
+                "parameters": [
+                    {
+                        "description": "Intitate Pin Token",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.RBTPinRequestSwaggoInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/initiate-rbt-transfer": {
             "post": {
                 "description": "This API will initiate RBT transfer to the specified dID",
@@ -749,6 +784,41 @@
                         "required": true,
                         "schema": {
                             "$ref": "#/definitions/server.RBTSelfTransferRequestSwaggoInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/recover-token": {
+            "post": {
+                "description": "This API will recover token and tokenchain from the Pinning node to the node which has pinned the token",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Account"
+                ],
+                "summary": "Recover Token and Tokenchain from the pinning node",
+                "operationId": "recover-token",
+                "parameters": [
+                    {
+                        "description": "Recover-Token",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.RBTRecoverRequestSwaggoInput"
                         }
                     }
                 ],
@@ -1150,6 +1220,43 @@
             "properties": {
                 "smartContractToken": {
                     "type": "string"
+                }
+            }
+        },
+        "server.RBTPinRequestSwaggoInput": {
+            "type": "object",
+            "properties": {
+                "comment": {
+                    "type": "string"
+                },
+                "pinningNode": {
+                    "type": "string"
+                },
+                "sender": {
+                    "type": "string"
+                },
+                "tokenCOunt": {
+                    "type": "number"
+                },
+                "type": {
+                    "type": "integer"
+                }
+            }
+        },
+        "server.RBTRecoverRequestSwaggoInput": {
+            "type": "object",
+            "properties": {
+                "password": {
+                    "type": "string"
+                },
+                "pinningNode": {
+                    "type": "string"
+                },
+                "sender": {
+                    "type": "string"
+                },
+                "tokenCOunt": {
+                    "type": "number"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -743,12 +743,12 @@
                 "operationId": "initiate-self-transfer",
                 "parameters": [
                     {
-                        "description": "Intitate RBT transfer",
+                        "description": "Intitate Self RBT transfer",
                         "name": "input",
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/server.RBTTransferRequestSwaggoInput"
+                            "$ref": "#/definitions/server.RBTSelfTransferRequestSwaggoInput"
                         }
                     }
                 ],
@@ -1150,6 +1150,17 @@
             "properties": {
                 "smartContractToken": {
                     "type": "string"
+                }
+            }
+        },
+        "server.RBTSelfTransferRequestSwaggoInput": {
+            "type": "object",
+            "properties": {
+                "sender": {
+                    "type": "string"
+                },
+                "type": {
+                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -138,6 +138,30 @@ definitions:
       smartContractToken:
         type: string
     type: object
+  server.RBTPinRequestSwaggoInput:
+    properties:
+      comment:
+        type: string
+      pinningNode:
+        type: string
+      sender:
+        type: string
+      tokenCOunt:
+        type: number
+      type:
+        type: integer
+    type: object
+  server.RBTRecoverRequestSwaggoInput:
+    properties:
+      password:
+        type: string
+      pinningNode:
+        type: string
+      sender:
+        type: string
+      tokenCOunt:
+        type: number
+    type: object
   server.RBTSelfTransferRequestSwaggoInput:
     properties:
       sender:
@@ -633,6 +657,29 @@ paths:
       summary: Get ALL NFTs
       tags:
       - NFT
+  /api/initiate-pin-token:
+    post:
+      consumes:
+      - application/json
+      description: This API will pin token in the Pinning node on behalf of the sender
+      operationId: initiate-pin-token
+      parameters:
+      - description: Intitate Pin Token
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/server.RBTPinRequestSwaggoInput'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.BasicResponse'
+      summary: Initiate Pin Token
+      tags:
+      - Account
   /api/initiate-rbt-transfer:
     post:
       consumes:
@@ -677,6 +724,30 @@ paths:
           schema:
             $ref: '#/definitions/model.BasicResponse'
       summary: Initiate Self Transfer
+      tags:
+      - Account
+  /api/recover-token:
+    post:
+      consumes:
+      - application/json
+      description: This API will recover token and tokenchain from the Pinning node
+        to the node which has pinned the token
+      operationId: recover-token
+      parameters:
+      - description: Recover-Token
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/server.RBTRecoverRequestSwaggoInput'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.BasicResponse'
+      summary: Recover Token and Tokenchain from the pinning node
       tags:
       - Account
   /api/register-callback-url:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -138,6 +138,13 @@ definitions:
       smartContractToken:
         type: string
     type: object
+  server.RBTSelfTransferRequestSwaggoInput:
+    properties:
+      sender:
+        type: string
+      type:
+        type: integer
+    type: object
   server.RBTTransferRequestSwaggoInput:
     properties:
       comment:
@@ -656,12 +663,12 @@ paths:
       description: This API will initiate self RBT transfer for a specific DID
       operationId: initiate-self-transfer
       parameters:
-      - description: Intitate RBT transfer
+      - description: Intitate Self RBT transfer
         in: body
         name: input
         required: true
         schema:
-          $ref: '#/definitions/server.RBTTransferRequestSwaggoInput'
+          $ref: '#/definitions/server.RBTSelfTransferRequestSwaggoInput'
       produces:
       - application/json
       responses:

--- a/server/self_transfer.go
+++ b/server/self_transfer.go
@@ -5,13 +5,18 @@ import (
 	"github.com/rubixchain/rubixgoplatform/core/model"
 )
 
+type RBTSelfTransferRequestSwaggoInput struct {
+	Sender     string  `json:"sender"`
+	Type       int     `json:"type"`
+}
+
 // @Summary     Initiate Self Transfer
 // @Description This API will initiate self RBT transfer for a specific DID
 // @Tags        Account
 // @ID 			initiate-self-transfer
 // @Accept      json
 // @Produce     json
-// @Param 		input body RBTTransferRequestSwaggoInput true "Intitate RBT transfer"
+// @Param 		input body RBTSelfTransferRequestSwaggoInput true "Intitate Self RBT transfer"
 // @Success 200 {object} model.BasicResponse
 // @Router /api/initiate-self-transfer [post]
 func (s *Server) SelfTransferHandle(req *ensweb.Request) *ensweb.Result {
@@ -22,16 +27,14 @@ func (s *Server) SelfTransferHandle(req *ensweb.Request) *ensweb.Result {
 	}
 
 	senderDID := selfTransferReq.Sender
-	receiverDID := selfTransferReq.Receiver
-
-	if receiverDID != "" && senderDID != receiverDID {
-		return s.BasicResponse(req, false, "Sender and Receiver must be same in case of self transfer", nil)
-	}
+	
 
 	if !s.validateDIDAccess(req, senderDID) {
 		return s.BasicResponse(req, false, "DID does not have an access", nil)
 	}
 	
+	// Make receiver to be same as sender for Self Transfer
+	selfTransferReq.Receiver = selfTransferReq.Sender
 	s.c.AddWebReq(req)
 
 	go s.c.InitiateRBTTransfer(req.ID, &selfTransferReq)

--- a/server/tokens.go
+++ b/server/tokens.go
@@ -117,16 +117,15 @@ type RBTPinRequestSwaggoInput struct {
 }
 
 // ShowAccount godoc
-// @Summary     Initiate Pin RBT
-// @Description This API will pin rbt in the Pinning node on behalf of the sender
+// @Summary     Initiate Pin Token
+// @Description This API will pin token in the Pinning node on behalf of the sender
 // @Tags        Account
-// @ID 			initiate-pin-rbt
+// @ID 			initiate-pin-token
 // @Accept      json
 // @Produce     json
-// @Param 		input body RBTPinRequestSwaggoInput true "Intitate Pin RBT"
+// @Param 		input body RBTPinRequestSwaggoInput true "Intitate Pin Token"
 // @Success 200 {object} model.BasicResponse
 // @Router /api/initiate-pin-token [post]
-
 func (s *Server) APIInitiatePinRBT(req *ensweb.Request) *ensweb.Result {
 	var rbtReq model.RBTPinRequest
 	err := s.ParseJSON(req, &rbtReq)
@@ -153,16 +152,15 @@ type RBTRecoverRequestSwaggoInput struct {
 }
 
 // ShowAccount godoc
-// @Summary     Recover RBT Token and Tokenchain from the pinning node
+// @Summary     Recover Token and Tokenchain from the pinning node
 // @Description This API will recover token and tokenchain from the Pinning node to the node which has pinned the token
 // @Tags        Account
-// @ID 			recover-rbt
+// @ID 			recover-token
 // @Accept      json
 // @Produce     json
-// @Param 		input body RBTRecoverRequestSwaggoInput true "Recover-RBT"
+// @Param 		input body RBTRecoverRequestSwaggoInput true "Recover-Token"
 // @Success 200 {object} model.BasicResponse
 // @Router /api/recover-token [post]
-
 func (s *Server) APIRecoverRBT(req *ensweb.Request) *ensweb.Result {
 	var rbtReq model.RBTRecoverRequest
 	err := s.ParseJSON(req, &rbtReq)


### PR DESCRIPTION
This PR intends to fix the swagger input for Self Transfer API by defining a separate struct `RBTSelfTransferRequestSwaggoInput`, which keeps only the necessary params, such as `sender` and `type`.

In the Self Transfer `server` handle, we assign the receiver as sender, since we now don't explicitly provide receiver as input. This ensures that the correct control flow associated with Self Transfer is executed in the `core` package's `initiateRBTTransfer` func.

Swagger Docs for Token Pin and Recovery have been fixed