### PR TITLE
Handling password for lite mode 

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,10 +201,9 @@ This following options are used for this command
         Server/Host port (default "20000")
   -quorumPWD string
         Quroum key password (default "mypassword")
-        use, in case did is created in NLSS modes - didType : 0 to 3
+        Not required for lite mode (didType : 4) did
   -privPWD string
         Private key password (default "mypassword")
-        use, in case did is created in lite mode - didType : 4
   -fp forcepassword
         Enter the  Quroum key password in terminal
 ```

--- a/README.md
+++ b/README.md
@@ -201,6 +201,10 @@ This following options are used for this command
         Server/Host port (default "20000")
   -quorumPWD string
         Quroum key password (default "mypassword")
+        use, in case did is created in NLSS modes - didType : 0 to 3
+  -privPWD string
+        Private key password (default "mypassword")
+        use, in case did is created in lite mode - didType : 4
   -fp forcepassword
         Enter the  Quroum key password in terminal
 ```


### PR DESCRIPTION
This PR is resolving the error for lite mode quorums with `-fp` flag. Previosly, `setupquorum` command was throwing the following error for lite mode quorums with `-fp` flag:

`[ERROR] Main: Failed to setup quorum: msg="Failed to setup quorum, failed to setup quorum"`

This is because, the **NLSS DIDs** maintain two key pairs, one pair is used for quorum role, and the other for non-quorum roles (initiator). But **lite mode DIDs** maintain only one key pair, and use the same for each role. But the `setupquorum` command is trying to fetch the second key pair with the password provided with the flag `-quorumPWD`. 

This PR is resolving this issue by handling the passwords correctly for lite mode quorums. Since, lite mode quorums maintain only one key pair, thus `setupquorum` command only needs `-privPWD` , to access the private key of the lite mode quorum.

The updated `setupquorum` command:
```
For lite mode DIDs:
./rubixgoplatform setupquorum -did <> -port <> -privPWD <>

For other mode (NLSS) DIDs:
./rubixgoplatform setupquorum -did <> -port <> -privPWD <> -quorumPWD <>

NOTE: Providing -quorumPWD <> for lite mode did won't throw any error, although it is not required
```
This PR is also tested with the following test cases for `-fp` flag with `didType 4` and `didType 0` :

- `createdid` command with `-fp` flag 
- `generatetestrbt` command with `-privPWD` 
- `setupquorum` command with  `-privPWD` and -`quorumPWD` flags
- `transferrbt` command with `-privPWD` 
- `registerdid` command with `-privPWD`  
