### PR TITLE
Remove -privPWD from bip seed creation

### DIFF
--- a/crypto/bip39.go
+++ b/crypto/bip39.go
@@ -90,9 +90,9 @@ func DecodeBIPKeyPair(pwd string, privKey []byte, pubKey []byte) ([]byte, []byte
 
 // Generate BIPMasterKey from Mnemonic and user provided password
 // Useful in key recovery / device migration through mnemonics
-func BIPGenerateMasterKeyFromMnemonic(mnemonic string, pwd string) ([]byte, error) {
+func BIPGenerateMasterKeyFromMnemonic(mnemonic string) ([]byte, error) {
 	var masterkeySeralise string
-	seed := bip39.NewSeed(mnemonic, pwd)
+	seed := bip39.NewSeed(mnemonic, "")
 	masterKey, _ := bip32.NewMasterKey(seed)
 	masterkeySeralise = masterKey.B58Serialize()
 	return []byte(masterkeySeralise), nil
@@ -112,7 +112,7 @@ func BIPGenerateMasterKey(cfg *CryptoConfig) ([]byte, error) {
 	var err error
 	if cfg.Alg == 0 {
 		mnemonic := BIPGenerateMnemonic()
-		pemEncPriv, err = BIPGenerateMasterKeyFromMnemonic(mnemonic, cfg.Pwd)
+		pemEncPriv, err = BIPGenerateMasterKeyFromMnemonic(mnemonic)
 		if err != nil {
 			return nil, err
 		}

--- a/crypto/bip39_test.go
+++ b/crypto/bip39_test.go
@@ -9,7 +9,7 @@ import (
 
 func BIPtest(t *testing.T, mnemonic string, pwd string) {
 
-	masterKey, err := BIPGenerateMasterKeyFromMnemonic(mnemonic, pwd)
+	masterKey, err := BIPGenerateMasterKeyFromMnemonic(mnemonic)
 	if err != nil {
 		t.Fatal("failed to generate key pair", "err", err)
 	}
@@ -44,6 +44,6 @@ func BIPtest(t *testing.T, mnemonic string, pwd string) {
 	}
 }
 func TestBIPKeyGeneration(t *testing.T) {
-	BIPtest(t, "cup symbol flee find decline market tube border artist clever make plastic unfold chaos float artwork sustain suspect risk process fox decrease west seven", "test")
-	BIPtest(t, "cub symbol flee find decline market tube border artist clever make plastic unfold chaos float artwork sustain suspect risk process fox decrease west seven", "test")
+	BIPtest(t, "cup symbol flee find decline market tube border artist clever make plastic unfold chaos float artwork sustain suspect risk process fox decrease west seven", "test1")
+	BIPtest(t, "cub symbol flee find decline market tube border artist clever make plastic unfold chaos float artwork sustain suspect risk process fox decrease west seven", "test2")
 }

--- a/did/did.go
+++ b/did/did.go
@@ -97,7 +97,7 @@ func (d *DID) CreateDID(didCreate *DIDCreate) (string, error) {
 			mnemonic = string(_mnemonic)
 		}
 
-		masterKey, err := crypto.BIPGenerateMasterKeyFromMnemonic(mnemonic, didCreate.PrivPWD)
+		masterKey, err := crypto.BIPGenerateMasterKeyFromMnemonic(mnemonic)
 		if err != nil {
 			d.log.Error("failed to create keypair", "err", err)
 		}


### PR DESCRIPTION
Closes #214 

Remove password input for bip master key generation. Password will continue to be used for encoding private key. 

To test:
Run the bip39_test.go file test cases with different passwords and log, it will produce same key pair . Also you can test by running create DID command and passing different passwords , same DID will be generated at both instance