### PR TITLE
exit if mnemonic file not found

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -435,7 +435,7 @@ func Run(args []string) {
 	flag.StringVar(&cmd.didImgFile, "didImgFile", did.DIDImgFileName, "DID image")
 	flag.StringVar(&cmd.privImgFile, "privImgFile", did.PvtShareFileName, "DID public share image")
 	flag.StringVar(&cmd.pubImgFile, "pubImgFile", did.PubShareFileName, "DID public share image")
-	flag.StringVar(&cmd.mnemonicFile, "mnemonicKeyFile", did.MnemonicFileName, "Mnemonic key file")
+	flag.StringVar(&cmd.mnemonicFile, "mnemonicKeyFile", "", "Mnemonic key file")
 	flag.StringVar(&cmd.privKeyFile, "privKeyFile", did.PvtKeyFileName, "Private key file")
 	flag.StringVar(&cmd.pubKeyFile, "pubKeyFile", did.PubKeyFileName, "Public key file")
 	flag.StringVar(&cmd.quorumList, "quorumList", "quorumlist.json", "Quorum list")

--- a/did/did.go
+++ b/did/did.go
@@ -82,7 +82,13 @@ func (d *DID) CreateDID(didCreate *DIDCreate) (string, error) {
 
 		_, err := os.Stat(didCreate.MnemonicFile)
 		if os.IsNotExist(err) {
-			d.log.Debug("mnemonic file does not exist , creating new")
+			if didCreate.MnemonicFile == "" {
+				d.log.Debug("No mnemonic provided , creating new keypair")
+			} else {
+				d.log.Error("Mnemonic file does not exist ", didCreate.MnemonicFile)
+				os.RemoveAll(dirName)
+				return "", err
+			}
 		} else {
 			_mnemonic, err = os.ReadFile(didCreate.MnemonicFile)
 			if err != nil {


### PR DESCRIPTION
Closes #223 .

If `mnemonicKeyFile` file not found , error and exit without creating new key pair. Creates new if flag not provided.