### PR TITLE
Resolving errors in Fetch smart contract 

### DIFF
--- a/client/smart_contract.go
+++ b/client/smart_contract.go
@@ -63,7 +63,6 @@ func (c *Client) FetchSmartContract(fetchSmartContractRequest *FetchSmartContrac
 	}
 
 	var basicResponse model.BasicResponse
-	// err := c.sendMutiFormRequest("POST", setup.APIFetchSmartContract, nil, fields, nil, &basicResponse)
 	err := c.sendJSONRequest("GET", setup.APIFetchSmartContract, fields, nil, &basicResponse)
 	if err != nil {
 		return nil, err
@@ -71,17 +70,6 @@ func (c *Client) FetchSmartContract(fetchSmartContractRequest *FetchSmartContrac
 	return &basicResponse, nil
 
 }
-
-// func (c *Client) GetAccountInfo(didStr string) (*model.GetAccountInfo, error) {
-// 	m := make(map[string]string)
-// 	m["did"] = didStr
-// 	var info model.GetAccountInfo
-// 	err := c.sendJSONRequest("GET", setup.APIGetAccountInfo, m, nil, &info)
-// 	if err != nil {
-// 		return nil, err
-// 	}
-// 	return &info, nil
-// }
 
 func (c *Client) PublishNewEvent(smartContractToken string, did string, publishType int, block string) (*model.BasicResponse, error) {
 	var response model.BasicResponse

--- a/client/smart_contract.go
+++ b/client/smart_contract.go
@@ -63,13 +63,25 @@ func (c *Client) FetchSmartContract(fetchSmartContractRequest *FetchSmartContrac
 	}
 
 	var basicResponse model.BasicResponse
-	err := c.sendMutiFormRequest("POST", setup.APIFetchSmartContract, nil, fields, nil, &basicResponse)
+	// err := c.sendMutiFormRequest("POST", setup.APIFetchSmartContract, nil, fields, nil, &basicResponse)
+	err := c.sendJSONRequest("GET", setup.APIFetchSmartContract, fields, nil, &basicResponse)
 	if err != nil {
 		return nil, err
 	}
 	return &basicResponse, nil
 
 }
+
+// func (c *Client) GetAccountInfo(didStr string) (*model.GetAccountInfo, error) {
+// 	m := make(map[string]string)
+// 	m["did"] = didStr
+// 	var info model.GetAccountInfo
+// 	err := c.sendJSONRequest("GET", setup.APIGetAccountInfo, m, nil, &info)
+// 	if err != nil {
+// 		return nil, err
+// 	}
+// 	return &info, nil
+// }
 
 func (c *Client) PublishNewEvent(smartContractToken string, did string, publishType int, block string) (*model.BasicResponse, error) {
 	var response model.BasicResponse

--- a/core/core.go
+++ b/core/core.go
@@ -7,6 +7,7 @@ import (
 	"io/ioutil"
 	"net"
 	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
@@ -418,29 +419,22 @@ func (c *Core) CreateSCTempFolder() (string, error) {
 }
 
 func (c *Core) RenameSCFolder(tempFolderPath string, smartContractName string) (string, error) {
-
-	scFolderName := c.cfg.DirPath + "SmartContract/" + smartContractName
-	err := os.Rename(tempFolderPath, scFolderName)
-	if err != nil {
-		c.log.Error("Unable to rename ", tempFolderPath, " to ", scFolderName, "error ", err)
-		scFolderName = ""
+	scFolderName := filepath.Join(c.cfg.DirPath, "SmartContract", smartContractName)
+	info, _ := os.Stat(scFolderName)
+	
+	// Check if the Smart Contract Folder exists
+	if info != nil {
+		return "", nil
+	} else {
+		// Directory not found, proceed to rename it
+		err := os.Rename(tempFolderPath, scFolderName)
+		if err != nil {
+			c.log.Error("Unable to rename ", tempFolderPath, " to ", scFolderName, "error ", err)
+			return "", err
+		} else {
+			return scFolderName, nil
+		}
 	}
-	return scFolderName, err
-}
-func (c *Core) Foldercheck(smartContractName string) interface{} {
-    folderName := c.cfg.DirPath + "SmartContract/" + smartContractName
-    info, err := os.Stat(folderName)
-    if err != nil {
-        c.log.Error("Unable to get the file info, error is: ", err)
-        return false
-    }
-
-    // Return the folder name if it's a directory, otherwise return false
-    if info.IsDir() {
-        return folderName
-    }
-
-    return false
 }
 
 func (c *Core) HandleQuorum(conn net.Conn) {

--- a/core/core.go
+++ b/core/core.go
@@ -421,20 +421,18 @@ func (c *Core) CreateSCTempFolder() (string, error) {
 func (c *Core) RenameSCFolder(tempFolderPath string, smartContractName string) (string, error) {
 	scFolderName := filepath.Join(c.cfg.DirPath, "SmartContract", smartContractName)
 	info, _ := os.Stat(scFolderName)
-	
+
 	// Check if the Smart Contract Folder exists
-	if info != nil {
-		return "", nil
-	} else {
+	if info == nil {
 		// Directory not found, proceed to rename it
 		err := os.Rename(tempFolderPath, scFolderName)
 		if err != nil {
 			c.log.Error("Unable to rename ", tempFolderPath, " to ", scFolderName, "error ", err)
 			return "", err
-		} else {
-			return scFolderName, nil
 		}
 	}
+
+	return scFolderName, nil
 }
 
 func (c *Core) HandleQuorum(conn net.Conn) {

--- a/core/core.go
+++ b/core/core.go
@@ -427,6 +427,21 @@ func (c *Core) RenameSCFolder(tempFolderPath string, smartContractName string) (
 	}
 	return scFolderName, err
 }
+func (c *Core) Foldercheck(smartContractName string) interface{} {
+    folderName := c.cfg.DirPath + "SmartContract/" + smartContractName
+    info, err := os.Stat(folderName)
+    if err != nil {
+        c.log.Error("Unable to get the file info, error is: ", err)
+        return false
+    }
+
+    // Return the folder name if it's a directory, otherwise return false
+    if info.IsDir() {
+        return folderName
+    }
+
+    return false
+}
 
 func (c *Core) HandleQuorum(conn net.Conn) {
 

--- a/core/smart_contract.go
+++ b/core/smart_contract.go
@@ -298,7 +298,7 @@ func (c *Core) FetchSmartContract(requestID string, fetchSmartContractRequest *F
 	// Set the response values
 	basicResponse.Status = true
 	basicResponse.Message = "Successfully fetched smart contract"
-	basicResponse.Result = &smartContractToken
+	basicResponse.Result = smartContractToken
 
 	return basicResponse
 }

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -330,7 +330,7 @@ const docTemplate = `{
             }
         },
         "/api/fetch-smart-contract": {
-            "post": {
+            "get": {
                 "description": "This API will Fetch smart contract",
                 "consumes": [
                     "application/json"
@@ -345,13 +345,9 @@ const docTemplate = `{
                 "operationId": "fetch-smart-contract",
                 "parameters": [
                     {
-                        "description": "Fetch smart contract",
-                        "name": "input",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/server.FetchSmartContractSwaggoInput"
-                        }
+                        "type": "string",
+                        "name": "smartContractToken",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1199,14 +1195,6 @@ const docTemplate = `{
                 "smartContractData": {
                     "type": "string"
                 },
-                "smartContractToken": {
-                    "type": "string"
-                }
-            }
-        },
-        "server.FetchSmartContractSwaggoInput": {
-            "type": "object",
-            "properties": {
                 "smartContractToken": {
                     "type": "string"
                 }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -322,7 +322,7 @@
             }
         },
         "/api/fetch-smart-contract": {
-            "post": {
+            "get": {
                 "description": "This API will Fetch smart contract",
                 "consumes": [
                     "application/json"
@@ -337,13 +337,9 @@
                 "operationId": "fetch-smart-contract",
                 "parameters": [
                     {
-                        "description": "Fetch smart contract",
-                        "name": "input",
-                        "in": "body",
-                        "required": true,
-                        "schema": {
-                            "$ref": "#/definitions/server.FetchSmartContractSwaggoInput"
-                        }
+                        "type": "string",
+                        "name": "smartContractToken",
+                        "in": "query"
                     }
                 ],
                 "responses": {
@@ -1191,14 +1187,6 @@
                 "smartContractData": {
                     "type": "string"
                 },
-                "smartContractToken": {
-                    "type": "string"
-                }
-            }
-        },
-        "server.FetchSmartContractSwaggoInput": {
-            "type": "object",
-            "properties": {
                 "smartContractToken": {
                     "type": "string"
                 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -121,11 +121,6 @@ definitions:
       smartContractToken:
         type: string
     type: object
-  server.FetchSmartContractSwaggoInput:
-    properties:
-      smartContractToken:
-        type: string
-    type: object
   server.GetSmartContractTokenChainDataSwaggoInput:
     properties:
       latest:
@@ -411,18 +406,15 @@ paths:
       tags:
       - Smart Contract
   /api/fetch-smart-contract:
-    post:
+    get:
       consumes:
       - application/json
       description: This API will Fetch smart contract
       operationId: fetch-smart-contract
       parameters:
-      - description: Fetch smart contract
-        in: body
-        name: input
-        required: true
-        schema:
-          $ref: '#/definitions/server.FetchSmartContractSwaggoInput'
+      - in: query
+        name: smartContractToken
+        type: string
       produces:
       - application/json
       responses:

--- a/server/server.go
+++ b/server/server.go
@@ -145,7 +145,7 @@ func (s *Server) RegisterRoutes() {
 	s.AddRoute(setup.APIAddNFTSale, "GET", s.AuthHandle(s.APIAddNFTSale, true, s.AuthError, false))
 	s.AddRoute(setup.APIDeploySmartContract, "POST", s.AuthHandle(s.APIDeploySmartContract, true, s.AuthError, false))
 	s.AddRoute(setup.APIGenerateSmartContract, "POST", s.AuthHandle(s.APIGenerateSmartContract, true, s.AuthError, false))
-	s.AddRoute(setup.APIFetchSmartContract, "POST", s.AuthHandle(s.APIFetchSmartContract, true, s.AuthError, false))
+	s.AddRoute(setup.APIFetchSmartContract, "GET", s.AuthHandle(s.APIFetchSmartContract, true, s.AuthError, false))
 	s.AddRoute(setup.APIPublishContract, "POST", s.AuthHandle(s.APIPublishContract, true, s.AuthError, false))
 	s.AddRoute(setup.APISubscribecontract, "POST", s.AuthHandle(s.APISubscribecontract, true, s.AuthError, false))
 	s.AddRoute(setup.APIDumpSmartContractTokenChainBlock, "POST", s.AuthHandle(s.APIDumpSmartContractTokenChainBlock, true, s.AuthError, false))

--- a/server/smart_contract.go
+++ b/server/smart_contract.go
@@ -283,7 +283,6 @@ func moveFile(src, dst string) error {
 // @Success      200  {object}  model.BasicResponse
 // @Router       /api/fetch-smart-contract [get]
 func (s *Server) APIFetchSmartContract(req *ensweb.Request) *ensweb.Result {
-	// fmt.Println("APIFetchSmartContract function called")
 	var fetchSC core.FetchSmartContractRequest
 	var err error
 	fetchSC.SmartContractTokenPath, err = s.c.CreateSCTempFolder()
@@ -292,28 +291,12 @@ func (s *Server) APIFetchSmartContract(req *ensweb.Request) *ensweb.Result {
 		s.log.Error("Fetch smart contract failed, failed to create smartcontract folder", "err", err)
 		return s.BasicResponse(req, false, "Fetch smart contract failed, failed to create smartcontract folder", nil)
 	}
-
-	// _, scToken, err := s.ParseMultiPartForm(req, "smartContractToken")
-	// if err != nil {
-	// 	fmt.Println("error in parseMultipPartForm", err)
-	// }
-	// fmt.Println("scToken in APIFetchSmartContract is:", scToken)
-
-	// sctkn := s.GetQuerry(req, "smartContractToken")
-	// fmt.Println("scToken in APIFetchSmartContract is:", sctkn)
-	// fetchSC.SmartContractToken = scToken["smartContractToken"][0]
 	fetchSC.SmartContractToken = s.GetQuerry(req, "smartContractToken")
-	// if err != nil {
-	// 	s.log.Error("Fetch smart contract failed, failed to fetch smartcontract token value", "err", err)
-	// 	return s.BasicResponse(req, false, "Fetch smart contract failed, failed to fetch smartcontract token value", nil)
-	// }
-
 	is_alphanumeric := regexp.MustCompile(`^[a-zA-Z0-9]*$`).MatchString(fetchSC.SmartContractToken)
 	if len(fetchSC.SmartContractToken) != 46 || !strings.HasPrefix(fetchSC.SmartContractToken, "Qm") || !is_alphanumeric {
 		s.log.Error("Invalid smart contract token")
 		return s.BasicResponse(req, false, "Invalid smart contract token", nil)
 	}
-
 	if s.c.Foldercheck(fetchSC.SmartContractToken) == false {
 		fetchSC.SmartContractTokenPath, err = s.c.RenameSCFolder(fetchSC.SmartContractTokenPath, fetchSC.SmartContractToken)
 		if err != nil {


### PR DESCRIPTION
In this PR, I changed the smart contract API from a POST request to a GET request due to errors related to the Content-Type, which was set to multipart/form-data. These errors occurred when passing the required data through Swagger while calling the API.
This PR also resolves the smart contract folder renaming error that occurred when fetching the smart contract from the command line as well as from the API, in cases where the node already contains the smart contract folder.