### PR TITLE
Double Spend Fix

### DIFF
--- a/core/token_chain_validation.go
+++ b/core/token_chain_validation.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	"github.com/rubixchain/rubixgoplatform/block"
+	"github.com/rubixchain/rubixgoplatform/core/ipfsport"
 	"github.com/rubixchain/rubixgoplatform/core/model"
 	"github.com/rubixchain/rubixgoplatform/core/wallet"
 	"github.com/rubixchain/rubixgoplatform/did"
@@ -141,7 +142,7 @@ func (c *Core) ValidateTokenChain(userDID string, tokenInfo *wallet.Token, token
 				}
 			case block.TokenGeneratedType:
 				//validate genesis block
-				response, err = c.ValidateGenesisBlock(b, *tokenInfo, tokenType, userDID)
+				response, err = c.ValidateGenesisBlock(nil, b, *tokenInfo, tokenType, userDID, true)
 				if err != nil {
 					c.log.Error("msg", response.Message, "err", err)
 					return response, err
@@ -323,7 +324,8 @@ func (c *Core) ValidatePledgedUnpledgedBlock(b *block.Block, tokenId string, cal
 }
 
 // genesis block validation : validate block of type: TokenGeneratedType = "05"
-func (c *Core) ValidateGenesisBlock(b *block.Block, tokenInfo wallet.Token, tokenType int, userDID string) (*model.BasicResponse, error) {
+// isSyncParent - if this is true, the parent token chain sync will happen recursively
+func (c *Core) ValidateGenesisBlock(p *ipfsport.Peer, b *block.Block, tokenInfo wallet.Token, tokenType int, userDID string, isSyncParent bool) (*model.BasicResponse, error) {
 	response := &model.BasicResponse{}
 
 	//Validate block hash of genesis block
@@ -343,7 +345,14 @@ func (c *Core) ValidateGenesisBlock(b *block.Block, tokenInfo wallet.Token, toke
 
 	//if part token, validate parent token chain
 	if tokenType == token.TestPartTokenType {
-		response, err = c.ValidateParentTokenLatestBlock(tokenInfo.ParentTokenID, userDID)
+		if p != nil {
+			err := c.syncTokenChainFrom(p, "", tokenInfo.ParentTokenID, tokenType)
+			if err != nil {
+				c.log.Error("Failed to sync token chain block", "err", err)
+				// return false, fmt.Errorf("failed to sync tokenchain Token: %v, issueType: %v", ti[i].Token, TokenChainNotSynced)
+			}
+		}
+		response, err = c.ValidateParentTokenLatestBlock(p, tokenInfo.ParentTokenID, userDID, isSyncParent)
 		if err != nil {
 			c.log.Error("msg", response.Message, "err", err)
 			return response, err
@@ -357,7 +366,7 @@ func (c *Core) ValidateGenesisBlock(b *block.Block, tokenInfo wallet.Token, toke
 }
 
 // Validate Parent token latest block if token is part token
-func (c *Core) ValidateParentTokenLatestBlock(parentTokenId string, userDID string) (*model.BasicResponse, error) {
+func (c *Core) ValidateParentTokenLatestBlock(p *ipfsport.Peer, parentTokenId string, userDID string, isSyncParent bool) (*model.BasicResponse, error) {
 	c.log.Debug("validating parent token chain latest block", parentTokenId)
 	response := &model.BasicResponse{
 		Status: false,
@@ -410,6 +419,12 @@ func (c *Core) ValidateParentTokenLatestBlock(parentTokenId string, userDID stri
 
 	//Get latest block in the token chain
 	parentTokenLatestBlock := c.w.GetLatestTokenBlock(parentTokenId, parentTokenType)
+	if parentTokenLatestBlock == nil {
+		c.log.Error("could not sync parent token", parentTokenId)
+		response.Status = false
+		response.Message = "parent token chain not found"
+		return response, err
+	}
 	response, err = c.ValidateRBTBurntBlock(parentTokenLatestBlock, *parentTokenInfo, "", userDID)
 	if err != nil {
 		c.log.Error("msg", response.Message, "err", err)
@@ -417,7 +432,7 @@ func (c *Core) ValidateParentTokenLatestBlock(parentTokenId string, userDID stri
 	}
 
 	//if parent token is also a part token, then validate it's parent token latest block
-	if parentTokenType == c.TokenType(PartString) {
+	if parentTokenType == c.TokenType(PartString) && isSyncParent {
 		if parentTokenInfo.ParentTokenID == "" {
 			genesisBlock := c.w.GetGenesisTokenBlock(parentTokenId, parentTokenType)
 			grandParentToken, _, err := genesisBlock.GetParentDetials(parentTokenId)
@@ -427,7 +442,7 @@ func (c *Core) ValidateParentTokenLatestBlock(parentTokenId string, userDID stri
 			c.log.Debug("grand parent token:", grandParentToken)
 			parentTokenInfo.ParentTokenID = grandParentToken
 		}
-		response, err = c.ValidateParentTokenLatestBlock(parentTokenInfo.ParentTokenID, userDID)
+		response, err = c.ValidateParentTokenLatestBlock(p, parentTokenInfo.ParentTokenID, userDID, isSyncParent)
 		if err != nil {
 			c.log.Error("msg", response.Message, "err", err)
 			return response, err
@@ -650,7 +665,7 @@ func (c *Core) CurrentOwnerPinCheck(b *block.Block, tokenId string, userDID stri
 	results := make([]MultiPinCheckRes, 1)
 	var wg sync.WaitGroup
 	wg.Add(1)
-	go c.pinCheck(tokenId, 0, currentOwnerPeerID, "", results, &wg)
+	go c.pinCheck(tokenId, 0, currentOwnerPeerID, "", results, &wg, nil)
 	wg.Wait()
 	for i := range results {
 		if results[i].Error != nil {

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -461,6 +461,11 @@ func (w *Wallet) TokensReceived(did string, ti []contract.TokenInfo, b *block.Bl
 		// Check if token already exists
 		var t Token
 		err := w.s.Read(TokenStorage, &t, "token_id=?", tokenInfo.Token)
+		if err == nil || t.TokenID != "" {
+			if t.TokenStatus == 0 {
+				return nil, fmt.Errorf("Token %v already with the receiver with token status %v", t.TokenID, t.TokenStatus)
+			}
+		}
 		if err != nil || t.TokenID == "" {
 			// Token doesn't exist, proceed to handle it
 			dir := util.GetRandString()
@@ -518,7 +523,7 @@ func (w *Wallet) TokensReceived(did string, ti []contract.TokenInfo, b *block.Bl
 		}
 		senderAddress := senderPeerId + "." + b.GetSenderDID()
 		receiverAddress := receiverPeerId + "." + b.GetReceiverDID()
-		//Pinnig the whole tokens and pat tokens
+		//Pinnig the whole tokens and part tokens
 		ok, err := w.Pin(tokenInfo.Token, role, did, b.GetTid(), senderAddress, receiverAddress, tokenInfo.TokenValue)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This PR is to prevent double spend of tokens by validating the pins on token, verifying the token chain block, and checking the pins on the tokenstatehash by the quorums and receiver.