### PR TITLE
User can define the address

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -336,7 +336,7 @@ func (cmd *Command) getURL(url string) string {
 }
 
 func (cmd *Command) runApp() {
-	core.InitConfig(cmd.runDir+cmd.cfgFile, cmd.encKey, uint16(cmd.node))
+	core.InitConfig(cmd.runDir+cmd.cfgFile, cmd.encKey, uint16(cmd.node), cmd.addr)
 	err := apiconfig.LoadAPIConfig(cmd.runDir+cmd.cfgFile, cmd.encKey, &cmd.cfg)
 
 	if err != nil {

--- a/core/core.go
+++ b/core/core.go
@@ -121,12 +121,12 @@ type Core struct {
 	noBalanceQuorumCount int
 }
 
-func InitConfig(configFile string, encKey string, node uint16) error {
+func InitConfig(configFile string, encKey string, node uint16, addr string) error {
 	if _, err := os.Stat(configFile); errors.Is(err, os.ErrNotExist) {
 		nodePort := NodePort + node
 		portOffset := MaxPeerConn * node
 		cfg := config.Config{
-			NodeAddress: "localhost",
+			NodeAddress: addr,
 			NodePort:    fmt.Sprintf("%d", nodePort),
 			DirPath:     "./",
 			CfgData: config.ConfigData{


### PR DESCRIPTION
`NodeAddress` field was hard-coded to "localhost". Now users can define the address using `-addr` flag.