### PR TITLE
Fixed multi-node NFT transfer and added NFT Subscription under NFT Deployment flow

### DIFF
--- a/core/model/nft.go
+++ b/core/model/nft.go
@@ -28,7 +28,7 @@ type NFTTokens struct {
 
 type NFTEvent struct {
 	NFT          string  `json:"nft"`
-	Did          string  `json:"did"`
+	ExecutorDid  string  `json:"executorDid"`
 	ReceiverDid  string  `json:"receiverDid"`
 	Type         int     `json:"type"`
 	NFTBlockHash string  `json:"nftBlockHash"`

--- a/core/nft.go
+++ b/core/nft.go
@@ -28,10 +28,8 @@ type NFTIpfsInfo struct {
 }
 
 type FetchNFTRequest struct {
-	NFT         string
-	NFTPath     string
-	ReceiverDID string
-	NFTValue    float64
+	NFT      string
+	NFTPath  string
 }
 
 func (c *Core) CreateNFTRequest(requestID string, createNFTRequest NFTReq) {
@@ -207,12 +205,20 @@ func (c *Core) deployNFT(reqID string, deployReq model.DeployNFTRequest) *model.
 	}
 
 	txnDetails, _, err := c.initiateConsensus(conensusRequest, consensusContract, didCryptoLib)
-
 	if err != nil {
 		c.log.Error("Consensus failed", "err", err)
 		resp.Message = "Consensus failed" + err.Error()
 		return resp
 	}
+
+	errNFTDeploy := c.SubscribeNFTSetup("", deployReq.NFT)
+	if errNFTDeploy != nil {
+		errMsg := fmt.Errorf("unable to subscribe to NFT %v while deployment, err: %v", deployReq.NFT, errNFTDeploy)
+		c.log.Error(errMsg.Error())
+		resp.Message = errMsg.Error()
+		return resp
+	}
+
 	et := time.Now()
 	dif := et.Sub(st)
 	//txnDetails.Amount = deployReq.RBTAmount
@@ -414,7 +420,7 @@ func (c *Core) executeNFT(reqID string, executeReq *model.ExecuteNFTRequest) *mo
 		local = true
 	}
 
-	err = c.w.UpdateNFTStatus(executeReq.NFT, executeReq.Owner, wallet.TokenIsTransferred, local, executeReq.Receiver, executeReq.NFTValue)
+	err = c.w.UpdateNFTStatus(executeReq.NFT, wallet.TokenIsTransferred, local, executeReq.Receiver, executeReq.NFTValue)
 	if err != nil {
 		c.log.Error("Failed to update NFT status after transferring", err)
 	}
@@ -441,15 +447,19 @@ func (c *Core) SubscribeNFTSetup(requestID string, topic string) error {
 
 func (c *Core) NFTCallBack(peerID string, topic string, data []byte) {
 	var newEvent model.NFTEvent
-	var fetchNFT FetchNFTRequest
 	requestID := reqID
 	err := json.Unmarshal(data, &newEvent)
 	if err != nil {
 		c.log.Error("Failed to get nft details", "err", err)
 		return
 	}
-	c.log.Info("Update on nft " + newEvent.NFT)
+	c.log.Info("Recieved Update on nft " + newEvent.NFT)
+
 	nft := newEvent.NFT
+	
+
+	// Fetch NFT files
+	var fetchNFT FetchNFTRequest
 	fetchNFT.NFT = nft
 
 	fetchNFTResponse := c.FetchNFT(requestID, &fetchNFT)
@@ -458,21 +468,64 @@ func (c *Core) NFTCallBack(peerID string, topic string, data []byte) {
 		return
 	}
 
-	publisherPeerID := peerID
-	did := newEvent.Did
-	tokenType := c.TokenType(NFTString)
-	address := publisherPeerID + "." + did
-	p, err := c.getPeer(address, "")
+	// Sync Token Chain
+
+	executorDid := newEvent.ExecutorDid
+	receiverDid := newEvent.ReceiverDid
+
+	nftTokenType := c.TokenType(NFTString)
+	publisherAddress := peerID + "." + executorDid
+	publisherPeer, err := c.getPeer(publisherAddress, "")
 	if err != nil {
-		c.log.Error("Failed to get peer", "err", err)
+		c.log.Error(fmt.Sprintf("failed to get peer: %v, err: %v", peerID, err))
 		return
 	}
 
-	err = c.syncTokenChainFrom(p, "", nft, tokenType)
+	err = c.syncTokenChainFrom(publisherPeer, "", nft, nftTokenType)
 	if err != nil {
 		c.log.Error("Failed to sync token chain block", "err", err)
 		return
 	}
+
+	// Update NFTTable
+
+	latestNFTTokenBlock := c.w.GetLatestTokenBlock(nft, nftTokenType)
+	if latestNFTTokenBlock == nil {
+		c.log.Error(fmt.Sprintf("failed to get the latest block for NFT: %v", nft))
+		return
+	}
+
+	currentOwner := latestNFTTokenBlock.GetOwner()
+
+	// Sanity check
+	if receiverDid != "" {
+		// Sanity check: In case of transfer NFT, it is always expected that receiver DID
+		// will always be same as the onwer (extracted from the latest NFT block)
+		if currentOwner != receiverDid {
+			c.log.Error("nft callback: reciever DID is not same as the owner of NFT extract from its latest token block")
+			return
+		}
+	} else {
+		if currentOwner != executorDid {
+			c.log.Error("nft callback: executor DID is not same as the owner of NFT extract from its latest token block")
+			return
+		}
+	}
+
+	var tokenStatus int
+	// Add check for receiverDid . In case of self-execution, it will be empty
+	if !c.w.IsDIDExist(receiverDid) {
+		tokenStatus = wallet.TokenIsTransferred
+	} else {
+		tokenStatus = wallet.TokenIsFree
+	}
+
+	err = c.w.CreateNFT(&wallet.NFT{TokenID: nft, DID: currentOwner, TokenStatus: tokenStatus, TokenValue: newEvent.NFTValue}, c.w.IsNFTExists(nft))
+	if err != nil {
+		c.log.Error("Failed to create NFT", "err", err)
+		return
+	}
+
 	c.log.Info("Token chain of " + nft + " syncing successful")
 }
 
@@ -504,20 +557,6 @@ func (c *Core) FetchNFT(requestID string, fetchNFTRequest *FetchNFTRequest) *mod
 		c.log.Error("failed to fetch NFT from IPFS", "err", err)
 	}
 
-	receiverPeerId := c.w.GetPeerID(fetchNFTRequest.ReceiverDID)
-	local := false
-	if receiverPeerId == c.peerID || receiverPeerId == "" {
-		local = true
-	}
-	did := fetchNFTRequest.ReceiverDID
-	if did == "" {
-		did = nft.DID
-	}
-	err = c.w.CreateNFT(&wallet.NFT{TokenID: fetchNFTRequest.NFT, DID: did, TokenStatus: 0, TokenValue: fetchNFTRequest.NFTValue}, local)
-	if err != nil {
-		c.log.Error("Failed to create NFT", "err", err)
-		return basicResponse
-	}
 	// Set the response values
 	basicResponse.Status = true
 	basicResponse.Message = "Successfully fetched NFT"

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -1357,7 +1357,7 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 
 		newEvent := model.NFTEvent{
 			NFT:          cr.NFT,
-			Did:          sc.GetDeployerDID(),
+			ExecutorDid:  sc.GetDeployerDID(),
 			NFTBlockHash: newnftIDTokenStateHash,
 			Type:         DeployType,
 		}
@@ -1417,7 +1417,7 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 
 		newEvent := model.NFTEvent{
 			NFT:          cr.NFT,
-			Did:          sc.GetExecutorDID(),
+			ExecutorDid:  sc.GetExecutorDID(),
 			ReceiverDid:  sc.GetReceiverDID(),
 			Type:         ExecuteType,
 			NFTBlockHash: newBlockId,

--- a/core/wallet/nft.go
+++ b/core/wallet/nft.go
@@ -11,6 +11,7 @@ type NFT struct {
 
 // CreateNFT write NFT into db
 func (w *Wallet) CreateNFT(nt *NFT, local bool) error {
+	// TODO: Update should only occur in UpdateNFT status function
 	var err error
 	if local {
 		err = w.s.Update(NFTTokenStorage, nt, "token_id=?", nt.TokenID)
@@ -91,7 +92,20 @@ func (w *Wallet) GetNFTToken(nftID string) (*NFT, error) {
 	return tokens, nil
 }
 
-func (w *Wallet) UpdateNFTStatus(nft string, did string, tokenStatus int, local bool, receiverDid string, saleAmount float64) error {
+func (w *Wallet) IsNFTExists(nftID string) bool {
+	w.dtl.Lock()
+	defer w.dtl.Unlock()
+	var tokens *NFT
+
+	err := w.s.Read(NFTTokenStorage, &tokens, "token_id=?", nftID)
+	if err != nil {
+		return false
+	} else {
+		return true
+	}
+}
+
+func (w *Wallet) UpdateNFTStatus(nft string, tokenStatus int, local bool, receiverDid string, saleAmount float64) error {
 	// Empty receiver DID indicates self execution of NFT and hence
 	// any change in NFTToken table must be skipped
 	if receiverDid != "" {


### PR DESCRIPTION
Closes #271 

This PR fixes the multi-node NFT transfer scenario where the `NFTTable` on the receiver's end was not updated with correct `DID` and `NFTValue` values. The issue stemmed in the current `NFTCallback` function, where the receiver DID  and NFT Value was not passed correctly. 

The `FetchNFT` function is patched up where the SQL DB update logic was taken out, and the function only fetches the NFT files.

NFT Subscription has been added under the NFT Deployment flow, which will enable Deployer node to subscribe to the NFT contract without manual intervention