### PR TITLE
fix for FT Transfer between DIDs on the same node

### DIFF
--- a/core/ft.go
+++ b/core/ft.go
@@ -412,6 +412,7 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 	FTsForTxn := AllFTs[:req.FTCount]
 	//TODO: Pinning of tokens
 	
+	rpeerid = c.w.GetPeerID(req.Receiver)
 	if rpeerid == "" {
 		// Check if DID is present in the DIDTable as the
 		// receiver might be part of the current node

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -883,7 +883,7 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 				}
 			}
 		}
-		err = c.w.FTTokensTransffered(sc.GetSenderDID(), ti, nb)
+		err = c.w.FTTokensTransffered(sc.GetSenderDID(), ti, nb, rp.IsLocal())
 		if err != nil {
 			c.log.Error("Failed to transfer tokens", "err", err)
 			return nil, nil, err

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -520,14 +520,14 @@ func (w *Wallet) TokensTransferred(did string, ti []contract.TokenInfo, b *block
 	// }
 	return nil
 }
-func (w *Wallet) FTTokensTransffered(did string, ti []contract.TokenInfo, b *block.Block) error {
+func (w *Wallet) FTTokensTransffered(did string, ti []contract.TokenInfo, b *block.Block, areReceiverAndSenderPeerSame bool) error {
 	w.l.Lock()
 	defer w.l.Unlock()
 
-	// Check if the Sender DID is local or not
+	// Check if the Reciever DID is local or not
 	// If so, then skip the following as its has been
 	// done by the previous Receive process
-	if !w.IsDIDExist(did) {
+	if !areReceiverAndSenderPeerSame {
 		err := w.CreateTokenBlock(b)
 		if err != nil {
 			return err


### PR DESCRIPTION
This PR aims to fix a scenario where FT is transferred between two DIDs present on the same node. Following are the changes made:

- In `FTTokensTransffered` function, a check has been added which skip the entire function for the scenario where Sender DID and Receiver DID are present on same node. This avoids duplicated addition of token blocks in the same node.

- Before initiating consensus, we check if the RecieverDID is part of the same node as SenderDID. If so, then we assign the peer for ReceiverDID as `c.peerID`.