### PR TITLE
Adding epoch information in the get-smart-contract-token-chain-data API response

### DIFF
--- a/core/diagnostic.go
+++ b/core/diagnostic.go
@@ -209,6 +209,7 @@ func (c *Core) GetSmartContractTokenChainData(getReq *model.SmartContractTokenCh
 			reply.Message = "Failed to get smart contract token latest block number"
 			return reply
 		}
+		epoch := latestBlock.GetEpoch()
 		scData := latestBlock.GetSmartContractData()
 		if scData == "" && blockNo == 0 {
 			reply.Message = "Gensys Block, No Smart contract Data"
@@ -217,6 +218,7 @@ func (c *Core) GetSmartContractTokenChainData(getReq *model.SmartContractTokenCh
 			BlockNo:           blockNo,
 			BlockId:           blockId,
 			SmartContractData: scData,
+			Epoch:             int(epoch),
 		}
 		sctDataArray = append(sctDataArray, sctData)
 		reply.SCTDataReply = sctDataArray

--- a/core/diagnostic.go
+++ b/core/diagnostic.go
@@ -218,7 +218,7 @@ func (c *Core) GetSmartContractTokenChainData(getReq *model.SmartContractTokenCh
 			BlockNo:           blockNo,
 			BlockId:           blockId,
 			SmartContractData: scData,
-			Epoch:             int(epoch),
+			Epoch:             uint64(epoch),
 		}
 		sctDataArray = append(sctDataArray, sctData)
 		reply.SCTDataReply = sctDataArray

--- a/core/model/diagnostic.go
+++ b/core/model/diagnostic.go
@@ -35,6 +35,7 @@ type SCTDataReply struct {
 	BlockNo           uint64
 	BlockId           string
 	SmartContractData string
+	Epoch             int            
 }
 
 type NFTData struct {

--- a/core/model/diagnostic.go
+++ b/core/model/diagnostic.go
@@ -35,7 +35,7 @@ type SCTDataReply struct {
 	BlockNo           uint64
 	BlockId           string
 	SmartContractData string
-	Epoch             int            
+	Epoch             uint64            
 }
 
 type NFTData struct {


### PR DESCRIPTION
Closes #279

This PR enhances the `/api/get-smart-contract-token-chain-data` API by including the epoch timestamp in its response. 

```
{
  "status": true,
  "message": "Fetched latest block smart contract data",
  "result": null,
  "SCTDataReply": [
    {
      "BlockNo": 1,
      "BlockId": "1-ff4c752fe1d265a8ed53b74baa1ae2c0074b4bfa108eb2d1d4f4c514973ba940",
      "SmartContractData": "{\"Type\":0,\"PrivPWD\":\"mypassword\",\"img_file\":\"/home/rubix/Sai-Rubix/rubixgoplatform/linux/image.png\"}",
      "Epoch": 1735808514
    }
  ]
}
```


