### PR TITLE
Return DID for existing public key

### DIFF
--- a/core/did.go
+++ b/core/did.go
@@ -250,6 +250,9 @@ func (c *Core) CreateDIDFromPubKey(didCreate *did.DIDCreate, pubKey string) (str
 	if err != nil {
 		return "", err
 	}
+	if c.w.IsDIDExist(did) {
+		return did, nil
+	}
 	if didCreate.Dir == "" {
 		didCreate.Dir = did
 	}

--- a/core/model/did.go
+++ b/core/model/did.go
@@ -41,5 +41,4 @@ type DIDFromPubKeyRequest struct {
 // DIDFromPubKeyResponse to receive request to create did for provided pub key
 type DIDFromPubKeyResponse struct {
 	DID    string `json:"did"`
-	PubKey string `json:"public_key"`
 }

--- a/server/did.go
+++ b/server/did.go
@@ -291,8 +291,7 @@ func (s *Server) APICreateDIDFromPubKey(req *ensweb.Request) *ensweb.Result {
 
 	// respond with the requested did along with the corr. public key
 	didResp := model.DIDFromPubKeyResponse{
-		DID:    did,
-		PubKey: didReq.PubKey,
+		DID: did,
 	}
 	return s.RenderJSON(req, didResp, http.StatusOK)
 }


### PR DESCRIPTION
When a DID for a particular public key already exists in the ode's database, the `/api/request-did-for-pubkey` API was throwing error: "UNIQUE constraint failed: DIDTable.did". This PR is returning the existing DID for the requested public key instead of throwing an error.