### PR TITLE
Add nft value and nft data to /api/deploy-nft

### DIFF
--- a/block/block.go
+++ b/block/block.go
@@ -747,8 +747,8 @@ func (b *Block) GetChildTokens() []string {
 	return util.GetStringSliceFromMap(b.bm, TCChildTokensKey)
 }
 
-func (b *Block) GetEpoch() int64 {
-	return int64(util.GetIntFromMap(b.bm, TCEpochKey))
+func (b *Block) GetEpoch() int {
+	return util.GetIntFromMap(b.bm, TCEpochKey)
 }
 
 // Fetch initiator signature details from the given block

--- a/block/genesis.go
+++ b/block/genesis.go
@@ -47,6 +47,7 @@ type GenesisTokenInfo struct {
 	CommitedTokens     []TransTokens `json:"commitedTokens"`
 	SmartContractValue float64       `json:"smartContractValue"`
 	NFTValue           float64       `json:"nftValue"`
+	NFTData            string        `json:"nftData"`
 }
 
 type GenesisBlock struct {

--- a/block/genesis.go
+++ b/block/genesis.go
@@ -46,6 +46,7 @@ type GenesisTokenInfo struct {
 	GrandParentID      []string      `json:"grandParentID"`
 	CommitedTokens     []TransTokens `json:"commitedTokens"`
 	SmartContractValue float64       `json:"smartContractValue"`
+	NFTValue           float64       `json:"nftValue"`
 }
 
 type GenesisBlock struct {

--- a/command/command.go
+++ b/command/command.go
@@ -328,6 +328,7 @@ type Command struct {
 	creatorDID                   string
 	defaultSetup                 bool
 	apiKey                       string
+	nftValue                     float64
 }
 
 func showVersion() {
@@ -547,6 +548,7 @@ func Run(args []string) {
 	flag.StringVar(&cmd.creatorDID, "creatorDID", "", "DID of creator of FT")
 	flag.BoolVar(&cmd.defaultSetup, "defaultSetup", false, "Add Faucet Quorums")
 	flag.StringVar(&cmd.apiKey, "apikey", "", "Give the API Key corresponding to the DID")
+	flag.Float64Var(&cmd.nftValue, "nftValue", 0.0, "Value of the NFT")
 
 	if len(os.Args) < 2 {
 		fmt.Println("Invalid Command")

--- a/command/nft.go
+++ b/command/nft.go
@@ -79,6 +79,8 @@ func (cmd *Command) deployNFT() {
 		NFT:        cmd.nft,
 		DID:        cmd.deployerAddr,
 		QuorumType: cmd.transType,
+		NFTValue:   cmd.nftValue,
+		NFTData:    cmd.nftData,
 	}
 	response, err := cmd.c.DeployNFT(&deployRequest)
 	if err != nil {

--- a/core/diagnostic.go
+++ b/core/diagnostic.go
@@ -218,7 +218,7 @@ func (c *Core) GetSmartContractTokenChainData(getReq *model.SmartContractTokenCh
 			BlockNo:           blockNo,
 			BlockId:           blockId,
 			SmartContractData: scData,
-			Epoch:             uint64(epoch),
+			Epoch:             epoch,
 		}
 		sctDataArray = append(sctDataArray, sctData)
 		reply.SCTDataReply = sctDataArray
@@ -264,85 +264,73 @@ func (c *Core) GetSmartContractTokenChainData(getReq *model.SmartContractTokenCh
 
 func (c *Core) GetNFTTokenChainData(getReq *model.SmartContractTokenChainDataReq) *model.NFTDataReply {
 	reply := &model.NFTDataReply{
-		BasicResponse: model.BasicResponse{
-			Status: false,
-		},
+		BasicResponse: model.BasicResponse{Status: false},
 	}
+
+	// Check if token exists
 	_, err := c.w.GetNFTToken(getReq.Token)
 	if err != nil {
-		reply.Message = "Failed to get nft data, token does not exist"
+		reply.Message = "Failed to get NFT data, token does not exist"
 		return reply
 	}
-	nftDataArray := make([]model.NFTData, 0)
-	c.log.Debug("latest flag ", getReq.Latest)
+
+	var nftDataArray []model.NFTData
+
 	if getReq.Latest {
 		latestBlock := c.w.GetLatestTokenBlock(getReq.Token, c.TokenType(NFTString))
 		if latestBlock == nil {
-			reply.Message = "Failed to get nft data, block is empty"
+			reply.Message = "Failed to get NFT data, block is empty"
 			return reply
 		}
-		blockNo, err := latestBlock.GetBlockNumber(getReq.Token)
-		if err != nil {
-			reply.Message = "Failed to get latest block number"
+
+		blockNo, err1 := latestBlock.GetBlockNumber(getReq.Token)
+		blockId, err2 := latestBlock.GetBlockID(getReq.Token)
+		if err1 != nil || err2 != nil {
+			reply.Message = "Failed to get latest block details"
 			return reply
 		}
-		blockId, err := latestBlock.GetBlockID(getReq.Token)
-		if err != nil {
-			reply.Message = "Failed to get latest block ID"
-			return reply
-		}
-		nftData := latestBlock.GetNFTData()
-		nftOwner := latestBlock.GetOwner()
-		nftValue := latestBlock.GetTokenValue()
-		nftDataStruct := model.NFTData{
+
+		nftDataArray = append(nftDataArray, model.NFTData{
 			BlockNo:  blockNo,
 			BlockId:  blockId,
-			NFTData:  nftData,
-			NFTOwner: nftOwner,
-			NFTValue: nftValue,
-		}
-		nftDataArray = append(nftDataArray, nftDataStruct)
-		reply.NFTDataReply = nftDataArray
-		reply.Status = true
-		reply.Message = "Fetched latest block details of nft"
-		return reply
-	}
-
-	blks, _, err := c.w.GetAllTokenBlocks(getReq.Token, c.TokenType(NFTString), "")
-	if err != nil {
-		reply.Message = "Failed to get nft token blocks"
-		return reply
-	}
-
-	for _, blk := range blks {
-		block := block.InitBlock(blk, nil)
-		if block == nil {
-			reply.Message = "Failed to initialize nft block"
-			return reply
-		}
-		blockNo, err := block.GetBlockNumber(getReq.Token)
+			NFTData:  latestBlock.GetNFTData(),
+			NFTOwner: latestBlock.GetOwner(),
+			NFTValue: latestBlock.GetTokenValue(),
+			Epoch:    latestBlock.GetEpoch(),
+		})
+	} else {
+		blks, _, err := c.w.GetAllTokenBlocks(getReq.Token, c.TokenType(NFTString), "")
 		if err != nil {
-			reply.Message = "Failed to get latest block number"
+			reply.Message = "Failed to get NFT token blocks"
 			return reply
-		}
-		blockId, err := block.GetBlockID(getReq.Token)
-		if err != nil {
-			reply.Message = "Failed to get latest block ID"
-			return reply
-		}
-		nftData := block.GetNFTData()
-		nftOwner := block.GetOwner()
-		nftValue := block.GetTokenValue()
-		nftDataStruct := model.NFTData{
-			BlockNo:  blockNo,
-			BlockId:  blockId,
-			NFTData:  nftData,
-			NFTOwner: nftOwner,
-			NFTValue: nftValue,
 		}
 
-		nftDataArray = append(nftDataArray, nftDataStruct)
+		for _, blk := range blks {
+			block := block.InitBlock(blk, nil)
+			if block == nil {
+				reply.Message = "Failed to initialize NFT block"
+				return reply
+			}
+
+			blockNo, err1 := block.GetBlockNumber(getReq.Token)
+			blockId, err2 := block.GetBlockID(getReq.Token)
+			if err1 != nil || err2 != nil {
+				reply.Message = "Failed to get block details"
+				return reply
+			}
+
+			nftDataArray = append(nftDataArray, model.NFTData{
+				BlockNo:  blockNo,
+				BlockId:  blockId,
+				NFTData:  block.GetNFTData(),
+				NFTOwner: block.GetOwner(),
+				NFTValue: block.GetTokenValue(),
+				Epoch:    block.GetEpoch(), // Fixed the missing Epoch value
+			})
+		}
 	}
+
+	// Set final response
 	reply.NFTDataReply = nftDataArray
 	reply.Status = true
 	reply.Message = "Fetched NFT data"

--- a/core/model/diagnostic.go
+++ b/core/model/diagnostic.go
@@ -35,7 +35,7 @@ type SCTDataReply struct {
 	BlockNo           uint64
 	BlockId           string
 	SmartContractData string
-	Epoch             uint64            
+	Epoch             int
 }
 
 type NFTData struct {
@@ -44,6 +44,7 @@ type NFTData struct {
 	NFTData  string
 	NFTOwner string
 	NFTValue float64
+	Epoch    int
 }
 
 type RegisterCallBackUrlReq struct {

--- a/core/model/nft.go
+++ b/core/model/nft.go
@@ -36,9 +36,11 @@ type NFTEvent struct {
 }
 
 type DeployNFTRequest struct {
-	NFT        string `json:"nft"`
-	DID        string `json:"did"`
-	QuorumType int    `json:"quorum_type"`
+	NFT        string  `json:"nft"`
+	DID        string  `json:"did"`
+	QuorumType int     `json:"quorum_type"`
+	NFTValue   float64 `json:"nft_value"`
+	NFTData    string  `json:"nft_data"`
 }
 
 type ExecuteNFTRequest struct {

--- a/core/nft.go
+++ b/core/nft.go
@@ -160,7 +160,7 @@ func (c *Core) deployNFT(reqID string, deployReq model.DeployNFTRequest) *model.
 	nftInfo := contract.TokenInfo{
 		Token:      deployReq.NFT,
 		TokenType:  c.TokenType(NFTString),
-		TokenValue: 0,
+		TokenValue: deployReq.NFTValue,
 		OwnerDID:   did,
 	}
 	nftInfoArray = append(nftInfoArray, nftInfo)
@@ -168,12 +168,13 @@ func (c *Core) deployNFT(reqID string, deployReq model.DeployNFTRequest) *model.
 	consensusContractDetails := &contract.ContractType{
 		Type:       contract.NFTDeployType,
 		PledgeMode: contract.PeriodicPledgeMode,
-		TotalRBTs:  1,
+		TotalRBTs:  float64(deployReq.NFTValue),
 		TransInfo: &contract.TransInfo{
 			DeployerDID: did,
 			NFT:         deployReq.NFT,
-			NFTData:     "",
+			NFTData:     deployReq.NFTData,
 			TransTokens: nftInfoArray,
+			NFTValue:    deployReq.NFTValue,
 		},
 		ReqID: reqID,
 	}

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -2219,7 +2219,7 @@ func (c *Core) pledgeQuorumToken(cr *ConensusRequest, sc *contract.Contract, tid
 		nftGenesisBlock := &block.GenesisBlock{
 			Type: block.TokenGeneratedType,
 			Info: []block.GenesisTokenInfo{
-				{Token: cr.NFT, NFTValue: nftValue},
+				{Token: cr.NFT, NFTValue: nftValue, NFTData: sc.GetNFTData()},
 			},
 		}
 		tcb = block.TokenChainBlock{

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1514,6 +1514,12 @@ const docTemplate = `{
                 "nft": {
                     "type": "string"
                 },
+                "nft_data": {
+                    "type": "string"
+                },
+                "nft_value": {
+                    "type": "number"
+                },
                 "quorum_type": {
                     "type": "integer"
                 }

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1505,6 +1505,12 @@
                 "nft": {
                     "type": "string"
                 },
+                "nft_data": {
+                    "type": "string"
+                },
+                "nft_value": {
+                    "type": "number"
+                },
                 "quorum_type": {
                     "type": "integer"
                 }

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -128,6 +128,10 @@ definitions:
         type: string
       nft:
         type: string
+      nft_data:
+        type: string
+      nft_value:
+        type: number
       quorum_type:
         type: integer
     type: object

--- a/server/nft.go
+++ b/server/nft.go
@@ -104,9 +104,11 @@ func (s *Server) APICreateNFT(req *ensweb.Request) *ensweb.Result {
 }
 
 type DeployNFTSwaggoInput struct {
-	NFT        string `json:"nft"`
-	DID        string `json:"did"`
-	QuorumType int    `json:"quorum_type"`
+	NFT        string  `json:"nft"`
+	DID        string  `json:"did"`
+	QuorumType int     `json:"quorum_type"`
+	NFTValue   float64 `json:"nft_value"`
+	NFTData    string  `json:"nft_data"`
 }
 
 // NFT godoc


### PR DESCRIPTION
## Changes Introduced  
1. **Enhanced `/api/deploy-nft` Endpoint**  
   - Added `nftValue` and `nftData` fields to the API request/response. 

2. **Updated `/api/get-nft-token-chain-data` Endpoint**  
   - Included `epoch` in the response.

3. **Removed Committed Tokens List from NFT Genesis Block**  
   - The committed tokens list, which was previously added to the genesis block of an NFT, has been **removed**.  
   - **Reason:** Unlike smart contracts, NFTs do not require token commitments at deployment. Keeping this list was unnecessary and inconsistent with the NFT deployment process.
  
4. **Add the NFTData to the genesis block while deploying NFT**