### PR TITLE
Fixing Transaction Epoch

### DIFF
--- a/core/quorum_recv.go
+++ b/core/quorum_recv.go
@@ -1059,6 +1059,9 @@ func (c *Core) updateReceiverToken(
 			Status:          true,
 			Epoch:           int64(transactionEpoch),
 		}
+		if td.Epoch == 0 {
+			td.Epoch = time.Now().Unix()
+		}
 		c.w.AddTransactionHistory(td)
 	}
 
@@ -1235,6 +1238,9 @@ func (c *Core) updateFTToken(senderAddress string, receiverAddress string, token
 			Status:          true,
 			Epoch:           int64(transactionEpoch),
 		}
+		if td.Epoch == 0 {
+			td.Epoch = time.Now().Unix()
+		}
 		c.w.AddTransactionHistory(td)
 	}
 	//Adding quorums to DIDPeerTable of receiver
@@ -1370,7 +1376,7 @@ func (c *Core) updatePledgeToken(req *ensweb.Request) *ensweb.Result {
 	// is avoided
 	//
 	// However in case either sender or receiver happen to be a Quorum server, even though the above
-	// scenario is covered , but since the token block is also added on Quorum's end, we end up in a 
+	// scenario is covered , but since the token block is also added on Quorum's end, we end up in a
 	// situation where update of same block happens twice. Hence the following check ensures that we
 	// skip the addition of block here, if either sender or receiver happen to be on a Quorum node.
 	if !c.w.IsDIDExist(b.GetReceiverDID()) && !c.w.IsDIDExist(b.GetSenderDID()) {


### PR DESCRIPTION
In case sender and quorum nodes are older than v0.0.18, but the receiver node is v0.0.18 or above, then the seneder and quorums will not send any transaction epoch to receiver. 

To solve this issue, the reciver will add transaction epoch as current unix value in the transaction history table, in case it receives the epoch value as 0. 