### PR TITLE
Support to HD key generation using BIP-44

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -332,6 +332,9 @@ type Command struct {
 	defaultSetup                 bool
 	apiKey                       string
 	nftValue                     float64
+	accountType uint
+	changeAddr                   uint
+	addrIndex                    uint
 }
 
 func showVersion() {
@@ -552,6 +555,9 @@ func Run(args []string) {
 	flag.BoolVar(&cmd.defaultSetup, "defaultSetup", false, "Add Faucet Quorums")
 	flag.StringVar(&cmd.apiKey, "apikey", "", "Give the API Key corresponding to the DID")
 	flag.Float64Var(&cmd.nftValue, "nftValue", 0.0, "Value of the NFT")
+	flag.UintVar(&cmd.accountType, "accountType", 0, "to organise addreses of different wallets")
+	flag.UintVar(&cmd.changeAddr, "changeAddr", 0, "to create new address(did) for each transaction to maintain privacy")
+	flag.UintVar(&cmd.addrIndex, "addrIndex", 0, "to create a new child address(did) by changing the index")
 
 	if len(os.Args) < 2 {
 		fmt.Println("Invalid Command")

--- a/command/did.go
+++ b/command/did.go
@@ -162,6 +162,10 @@ func (cmd *Command) CreateDID() {
 		MnemonicFile:   cmd.mnemonicFile,
 		ChildPath:      cmd.ChildPath,
 	}
+	cfg.HDPath[2] = uint32(cmd.accountType)
+	cfg.HDPath[3] = uint32(cmd.changeAddr)
+	cfg.HDPath[4] = uint32(cmd.addrIndex)
+
 	msg, status := cmd.c.CreateDID(&cfg)
 	if !status {
 		cmd.log.Error("Failed to create DID", "message", msg)

--- a/core/did.go
+++ b/core/did.go
@@ -17,6 +17,18 @@ import (
 	"github.com/rubixchain/rubixgoplatform/util"
 )
 
+const (
+	HDPurpose         uint32 = 44   // 44 for BIP-44
+	RBTcoinType     uint32 = 1001 // for RBT tokens in Rubix mainnet
+	TestRbtcoinType uint32 = 1002 // for test RBTs in Rubix testnet
+)
+
+const (
+	NonWalletAccount uint32 = iota
+	XellAcount
+	SafePassAccount
+)
+
 // Struct to match the API response
 type APIResponse struct {
 	Message string  `json:"message"`
@@ -234,6 +246,15 @@ func (c *Core) CreateDID(didCreate *did.DIDCreate) (string, error) {
 	if didCreate.RootDID {
 		dt.RootDID = 1
 	}
+
+	// HDPath defines the required path to create a new child address/did
+	didCreate.HDPath[0] = HDPurpose
+	if c.testNet {
+		didCreate.HDPath[1] = TestRbtcoinType
+	} else {
+		didCreate.HDPath[1] = RBTcoinType
+	}
+
 	err = c.w.CreateDID(&dt)
 	if err != nil {
 		c.log.Error("Failed to create did in the wallet", "err", err)

--- a/core/did.go
+++ b/core/did.go
@@ -18,7 +18,7 @@ import (
 )
 
 const (
-	HDPurpose         uint32 = 44   // 44 for BIP-44
+	HDPurpose       uint32 = 44   // 44 for BIP-44
 	RBTcoinType     uint32 = 1001 // for RBT tokens in Rubix mainnet
 	TestRbtcoinType uint32 = 1002 // for test RBTs in Rubix testnet
 )
@@ -230,6 +230,14 @@ func (c *Core) CreateDID(didCreate *did.DIDCreate) (string, error) {
 		c.log.Error("root did is already exist")
 		return "", fmt.Errorf("root did is already exist")
 	}
+	// HDPath defines the required path to create a new child address/did
+	didCreate.HDPath[0] = HDPurpose
+	if c.testNet {
+		didCreate.HDPath[1] = TestRbtcoinType
+	} else {
+		didCreate.HDPath[1] = RBTcoinType
+	}
+
 	did, err := c.d.CreateDID(didCreate)
 	if err != nil {
 		return "", err
@@ -245,14 +253,6 @@ func (c *Core) CreateDID(didCreate *did.DIDCreate) (string, error) {
 	}
 	if didCreate.RootDID {
 		dt.RootDID = 1
-	}
-
-	// HDPath defines the required path to create a new child address/did
-	didCreate.HDPath[0] = HDPurpose
-	if c.testNet {
-		didCreate.HDPath[1] = TestRbtcoinType
-	} else {
-		didCreate.HDPath[1] = RBTcoinType
 	}
 
 	err = c.w.CreateDID(&dt)

--- a/core/did.go
+++ b/core/did.go
@@ -15,12 +15,13 @@ import (
 	"github.com/rubixchain/rubixgoplatform/did"
 	"github.com/rubixchain/rubixgoplatform/setup"
 	"github.com/rubixchain/rubixgoplatform/util"
+	"github.com/tyler-smith/go-bip32"
 )
 
 const (
-	HDPurpose       uint32 = 44   // 44 for BIP-44
-	RBTcoinType     uint32 = 1001 // for RBT tokens in Rubix mainnet
-	TestRbtcoinType uint32 = 1002 // for test RBTs in Rubix testnet
+	HDPurpose       uint32 = bip32.FirstHardenedChild + 44   // 44 for BIP-44
+	RBTcoinType     uint32 = bip32.FirstHardenedChild + 1001 // for RBT tokens in Rubix mainnet
+	TestRbtcoinType uint32 = bip32.FirstHardenedChild + 1002 // for test RBTs in Rubix testnet
 )
 
 const (
@@ -237,6 +238,7 @@ func (c *Core) CreateDID(didCreate *did.DIDCreate) (string, error) {
 	} else {
 		didCreate.HDPath[1] = RBTcoinType
 	}
+	didCreate.HDPath[2] = bip32.FirstHardenedChild + didCreate.HDPath[2]
 
 	did, err := c.d.CreateDID(didCreate)
 	if err != nil {

--- a/crypto/bip39_test.go
+++ b/crypto/bip39_test.go
@@ -7,14 +7,14 @@ import (
 	secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
 )
 
-func BIPtest(t *testing.T, mnemonic string, pwd string) {
+func BIPtest(t *testing.T, mnemonic string, pwd string, childPath int) {
 
 	masterKey, err := BIPGenerateMasterKeyFromMnemonic(mnemonic)
 	if err != nil {
 		t.Fatal("failed to generate key pair", "err", err)
 	}
 
-	priv, pub, err := BIPGenerateChild(string(masterKey), 0, pwd)
+	priv, pub, err := BIPGenerateChild(string(masterKey), childPath, pwd)
 	if err != nil {
 		t.Fatal("failed to generate child", "err", err)
 	}
@@ -44,6 +44,6 @@ func BIPtest(t *testing.T, mnemonic string, pwd string) {
 	}
 }
 func TestBIPKeyGeneration(t *testing.T) {
-	BIPtest(t, "cup symbol flee find decline market tube border artist clever make plastic unfold chaos float artwork sustain suspect risk process fox decrease west seven", "test1")
-	BIPtest(t, "cub symbol flee find decline market tube border artist clever make plastic unfold chaos float artwork sustain suspect risk process fox decrease west seven", "test2")
+	BIPtest(t, "cup symbol flee find decline market tube border artist clever make plastic unfold chaos float artwork sustain suspect risk process fox decrease west seven", "test1", 0)
+	BIPtest(t, "cub symbol flee find decline market tube border artist clever make plastic unfold chaos float artwork sustain suspect risk process fox decrease west seven", "test2", 1)
 }

--- a/crypto/bip44.go
+++ b/crypto/bip44.go
@@ -69,13 +69,16 @@ func NewHDWallet(mnemonic string) (*HDWallet, error) {
 }
 
 // DeriveKey derives a key for a given BIP-44 path (m/purpose'/coin_type'/account'/change/index)
-func (w *HDWallet) DerivePrivateKey(coinType, accountType, change, index uint32) (*bip32.Key, error) {
-	path := []uint32{
-		bip32.FirstHardenedChild + Purpose,     // e.g., 44'
-		bip32.FirstHardenedChild + coinType,    // e.g., 1001
-		bip32.FirstHardenedChild + accountType, // e.g., 0'
-		change,                                 // 0 (external) or 1 (change)
-		index,                                  // 0, 1, 2, ...
+func (w *HDWallet) DerivePrivateKey(path []uint32) (*bip32.Key, error) {
+	// path := []uint32{
+	// 	bip32.FirstHardenedChild + Purpose,     // e.g., 44'
+	// 	bip32.FirstHardenedChild + coinType,    // e.g., 1001
+	// 	bip32.FirstHardenedChild + accountType, // e.g., 0'
+	// 	change,                                 // 0 (external) or 1 (change)
+	// 	index,                                  // 0, 1, 2, ...
+	// }
+	if len(path) != 5 {
+		return nil, fmt.Errorf("failed to derive key, invalid HD path length: %v", len(path), "should be precisely 5")
 	}
 
 	currentKey := w.MasterKey
@@ -117,3 +120,29 @@ func DeriveKeyPair(privateKey *bip32.Key, pwd string) ([]byte, []byte, error) {
 
 	return pemEncPriv, pemEncPub, nil
 }
+
+// func GenerateHDChildKeys(coinType, accountType, change, index uint32, mnemonic, pwd string) ([]byte, []byte, error) {
+
+// 	hdWallet, err := NewHDWallet(mnemonic)
+// 	if err != nil {
+// 		return nil, nil, err
+// 	}
+
+// 	path := []uint32{
+// 		bip32.FirstHardenedChild + Purpose,     // e.g., 44'
+// 		bip32.FirstHardenedChild + coinType,    // e.g., 1001
+// 		bip32.FirstHardenedChild + accountType, // e.g., 0'
+// 		change,                                 // 0 (external) or 1 (change)
+// 		index,                                  // 0, 1, 2, ...
+// 	}
+// 	privateKey, err := hdWallet.DerivePrivateKey(path)
+// 	if err != nil {
+// 		return nil, nil, err
+// 	}
+
+// 	privKey, pubKey, err := DeriveKeyPair(privateKey, pwd)
+// 	if err != nil {
+// 		return nil, nil, err
+// 	}
+// 	return privKey, pubKey, nil
+// }

--- a/crypto/bip44.go
+++ b/crypto/bip44.go
@@ -35,15 +35,8 @@ const (
 // NewHDWallet creates a new HD wallet from a mnemonic or generates a new one
 func NewHDWallet(mnemonic string) (*HDWallet, error) {
 	if mnemonic == "" {
-		// Generate a new 12-word mnemonic (128-bit entropy)
-		entropy, err := bip39.NewEntropy(128)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate entropy: %v", err)
-		}
-		mnemonic, err = bip39.NewMnemonic(entropy)
-		if err != nil {
-			return nil, fmt.Errorf("failed to generate mnemonic: %v", err)
-		}
+		// Generate a new 24-word mnemonic (256-bit entropy)
+		mnemonic = BIPGenerateMnemonic()
 	}
 
 	// Validate mnemonic
@@ -72,7 +65,7 @@ func NewHDWallet(mnemonic string) (*HDWallet, error) {
 func (w *HDWallet) DerivePrivateKey(path []uint32) (*bip32.Key, error) {
 	// path := []uint32{
 	// 	bip32.FirstHardenedChild + Purpose,     // e.g., 44'
-	// 	bip32.FirstHardenedChild + coinType,    // e.g., 1001
+	// 	bip32.FirstHardenedChild + coinType,    // e.g., 1001'
 	// 	bip32.FirstHardenedChild + accountType, // e.g., 0'
 	// 	change,                                 // 0 (external) or 1 (change)
 	// 	index,                                  // 0, 1, 2, ...
@@ -85,11 +78,6 @@ func (w *HDWallet) DerivePrivateKey(path []uint32) (*bip32.Key, error) {
 	for _, i := range path {
 		var err error
 		currentKey, err = currentKey.NewChildKey(i)
-		// if i >= bip32.FirstHardenedChild {
-		// 	currentKey, err = currentKey.NewChildKey(i)
-		// } else { // useful for non-hardened keys, to derive the child public key without needing the private key
-		// 	currentKey, err = currentKey.PublicKey().NewChildKey(i)
-		// }
 		if err != nil {
 			return nil, fmt.Errorf("failed to derive key at index %d: %v", i, err)
 		}

--- a/crypto/bip44.go
+++ b/crypto/bip44.go
@@ -78,7 +78,7 @@ func (w *HDWallet) DerivePrivateKey(path []uint32) (*bip32.Key, error) {
 	// 	index,                                  // 0, 1, 2, ...
 	// }
 	if len(path) != 5 {
-		return nil, fmt.Errorf("failed to derive key, invalid HD path length: %v", len(path), "should be precisely 5")
+		return nil, fmt.Errorf("failed to derive key, invalid HD path length: %v, should be precisely 5", len(path))
 	}
 
 	currentKey := w.MasterKey

--- a/crypto/bip44.go
+++ b/crypto/bip44.go
@@ -1,0 +1,119 @@
+package crypto
+
+import (
+	"encoding/pem"
+	"fmt"
+
+	// "github.com/ethereum/go-ethereum/common"
+	// "github.com/ethereum/go-ethereum/core/types"
+	// "github.com/ethereum/go-ethereum/crypto"
+	secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/tyler-smith/go-bip32"
+	"github.com/tyler-smith/go-bip39"
+)
+
+// HDWallet manages a hierarchical deterministic wallet
+type HDWallet struct {
+	Mnemonic  string
+	Seed      []byte
+	MasterKey *bip32.Key
+	Accounts  map[uint32][]string // account index -> list of addresses
+}
+
+const (
+	Purpose         uint32 = 44   // 44 for BIP-44
+	RBTcoinType     uint32 = 1001 // for RBT tokens in Rubix mainnet
+	TestRbtcoinType uint32 = 1002 // for test RBTs in Rubix testnet
+)
+
+const (
+	NonWalletAccount uint32 = iota
+	XellAcount
+	SafePassAccount
+)
+
+// NewHDWallet creates a new HD wallet from a mnemonic or generates a new one
+func NewHDWallet(mnemonic string) (*HDWallet, error) {
+	if mnemonic == "" {
+		// Generate a new 12-word mnemonic (128-bit entropy)
+		entropy, err := bip39.NewEntropy(128)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate entropy: %v", err)
+		}
+		mnemonic, err = bip39.NewMnemonic(entropy)
+		if err != nil {
+			return nil, fmt.Errorf("failed to generate mnemonic: %v", err)
+		}
+	}
+
+	// Validate mnemonic
+	if !bip39.IsMnemonicValid(mnemonic) {
+		return nil, fmt.Errorf("invalid mnemonic")
+	}
+
+	// Derive seed
+	seed := bip39.NewSeed(mnemonic, "") // Empty passphrase
+
+	// Derive master key
+	masterKey, err := bip32.NewMasterKey(seed)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create master key: %v", err)
+	}
+
+	return &HDWallet{
+		Mnemonic:  mnemonic,
+		Seed:      seed,
+		MasterKey: masterKey,
+		Accounts:  make(map[uint32][]string),
+	}, nil
+}
+
+// DeriveKey derives a key for a given BIP-44 path (m/purpose'/coin_type'/account'/change/index)
+func (w *HDWallet) DerivePrivateKey(coinType, accountType, change, index uint32) (*bip32.Key, error) {
+	path := []uint32{
+		bip32.FirstHardenedChild + Purpose,     // e.g., 44'
+		bip32.FirstHardenedChild + coinType,    // e.g., 1001
+		bip32.FirstHardenedChild + accountType, // e.g., 0'
+		change,                                 // 0 (external) or 1 (change)
+		index,                                  // 0, 1, 2, ...
+	}
+
+	currentKey := w.MasterKey
+	for _, i := range path {
+		var err error
+		currentKey, err = currentKey.NewChildKey(i)
+		// if i >= bip32.FirstHardenedChild {
+		// 	currentKey, err = currentKey.NewChildKey(i)
+		// } else { // useful for non-hardened keys, to derive the child public key without needing the private key
+		// 	currentKey, err = currentKey.PublicKey().NewChildKey(i)
+		// }
+		if err != nil {
+			return nil, fmt.Errorf("failed to derive key at index %d: %v", i, err)
+		}
+	}
+	return currentKey, nil
+}
+
+func DeriveKeyPair(privateKey *bip32.Key, pwd string) ([]byte, []byte, error) {
+	privKey := secp256k1.PrivKeyFromBytes(privateKey.Key)
+	privkeybyte := privKey.Serialize()
+
+	pubkeybyte := privKey.PubKey().SerializeUncompressed()
+	var pemEncPriv []byte
+	if pwd != "" {
+		encBlock, err := Seal(pwd, privkeybyte)
+		if err != nil {
+			return nil, nil, err
+		}
+		_, err = UnSeal(pwd, encBlock)
+		if err != nil {
+			return nil, nil, err
+		}
+		pemEncPriv = pem.EncodeToMemory(&pem.Block{Type: "ENCRYPTED PRIVATE KEY", Bytes: encBlock})
+	} else {
+		pemEncPriv = pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: privkeybyte})
+	}
+	pemEncPub := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: pubkeybyte})
+
+	return pemEncPriv, pemEncPub, nil
+}

--- a/crypto/bip44_test.go
+++ b/crypto/bip44_test.go
@@ -1,0 +1,57 @@
+package crypto
+
+import (
+	"crypto/rand"
+	"testing"
+
+	secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+)
+
+func TestHDKeyGeneration(t *testing.T) {
+	GenerateHDKeysTest(t, "cup symbol flee find decline market tube border artist clever make plastic unfold chaos float artwork sustain suspect risk process fox decrease west seven", "test1", TestRbtcoinType, NonWalletAccount, 0, 0)
+	GenerateHDKeysTest(t, "cup symbol flee find decline market tube border artist clever make plastic unfold chaos float artwork sustain suspect risk process fox decrease west seven", "test1", TestRbtcoinType, NonWalletAccount, 0, 1)
+}
+
+func GenerateHDKeysTest(t *testing.T, mnemonic string, pwd string, coinType, accountType, change, index uint32) {
+	hdWallet, err := NewHDWallet(mnemonic)
+	if err != nil {
+		t.Fatal("failed to generate HD key pair", "err", err)
+	}
+
+	privateKey, err := hdWallet.DerivePrivateKey(coinType, accountType, change, index)
+	if err != nil {
+		t.Fatal("failed to derive HD priv key", "err", err)
+	}
+
+	privKey, pubKey, err := DeriveKeyPair(privateKey, pwd)
+	if err != nil {
+		t.Fatal("failed to derive HD key pair", "err", err)
+	}
+
+	privkey, pubkey, err := DecodeBIPKeyPair(pwd, privKey, pubKey)
+	if err != nil {
+		t.Fatal("failed to decode key pair", "err", err)
+	}
+
+	data, err := GetRandBytes(rand.Reader, 20)
+	if err != nil {
+		t.Fatal("failed to generate random number", "err", err)
+	}
+
+	privkeyback := secp256k1.PrivKeyFromBytes(privkey)
+	privKeySer := privkeyback.ToECDSA()
+	pubkeyback, err := secp256k1.ParsePubKey(pubkey)
+	if err != nil {
+		t.Fatal("failed to parse pub key", "err", err)
+	}
+	pubKeySer := pubkeyback.ToECDSA()
+
+	sig, err := BIPSign(privKeySer, data)
+	if err != nil {
+		t.Fatal("failed to do signature", "err", err)
+	}
+
+	if !BIPVerify(pubKeySer, data, sig) {
+		t.Fatal("failed to do verify signature", "err", err)
+	}
+}

--- a/crypto/bip44_test.go
+++ b/crypto/bip44_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	secp256k1 "github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/tyler-smith/go-bip32"
 )
 
 func TestHDKeyGeneration(t *testing.T) {
@@ -18,7 +19,14 @@ func GenerateHDKeysTest(t *testing.T, mnemonic string, pwd string, coinType, acc
 		t.Fatal("failed to generate HD key pair", "err", err)
 	}
 
-	privateKey, err := hdWallet.DerivePrivateKey(coinType, accountType, change, index)
+	path := []uint32{
+		bip32.FirstHardenedChild + Purpose,     // e.g., 44'
+		bip32.FirstHardenedChild + coinType,    // e.g., 1001
+		bip32.FirstHardenedChild + accountType, // e.g., 0'
+		change,                                 // 0 (external) or 1 (change)
+		index,                                  // 0, 1, 2, ...
+	}
+	privateKey, err := hdWallet.DerivePrivateKey(path)
 	if err != nil {
 		t.Fatal("failed to derive HD priv key", "err", err)
 	}

--- a/did/did.go
+++ b/did/did.go
@@ -105,18 +105,7 @@ func (d *DID) CreateDID(didCreate *DIDCreate) (string, error) {
 			mnemonic = string(_mnemonic)
 		}
 
-		// masterKey, err := crypto.BIPGenerateMasterKeyFromMnemonic(mnemonic)
-		// if err != nil {
-		// 	d.log.Error("failed to create keypair", "err", err)
-		// }
-
-		// //generating private and public key pair
-		// pvtKey, pubKey, err := crypto.BIPGenerateChild(string(masterKey), didCreate.ChildPath, didCreate.PrivPWD)
-		// if err != nil {
-		// 	d.log.Error("failed to create child", "err", err)
-		// }
-
-		//bip-44
+		//integrating bip-44 to support HD wallets
 		hdWallet, err := crypto.NewHDWallet(mnemonic)
 		if err != nil {
 			d.log.Error("failed to create keypair from mnemonic", "err", err)

--- a/did/did.go
+++ b/did/did.go
@@ -105,15 +105,33 @@ func (d *DID) CreateDID(didCreate *DIDCreate) (string, error) {
 			mnemonic = string(_mnemonic)
 		}
 
-		masterKey, err := crypto.BIPGenerateMasterKeyFromMnemonic(mnemonic)
+		// masterKey, err := crypto.BIPGenerateMasterKeyFromMnemonic(mnemonic)
+		// if err != nil {
+		// 	d.log.Error("failed to create keypair", "err", err)
+		// }
+
+		// //generating private and public key pair
+		// pvtKey, pubKey, err := crypto.BIPGenerateChild(string(masterKey), didCreate.ChildPath, didCreate.PrivPWD)
+		// if err != nil {
+		// 	d.log.Error("failed to create child", "err", err)
+		// }
+
+		//bip-44
+		hdWallet, err := crypto.NewHDWallet(mnemonic)
 		if err != nil {
-			d.log.Error("failed to create keypair", "err", err)
+			d.log.Error("failed to create keypair from mnemonic", "err", err)
+			return "", err
+		}
+		privateKey, err := hdWallet.DerivePrivateKey(didCreate.HDPath[:])
+		if err != nil {
+			d.log.Error("failed to create hd keypair", "err", err)
+			return "", err
 		}
 
-		//generating private and public key pair
-		pvtKey, pubKey, err := crypto.BIPGenerateChild(string(masterKey), didCreate.ChildPath, didCreate.PrivPWD)
+		pvtKey, pubKey, err := crypto.DeriveKeyPair(privateKey, didCreate.PrivPWD)
 		if err != nil {
-			d.log.Error("failed to create child", "err", err)
+			d.log.Error("failed to derive keypair", "err", err)
+			return "", err
 		}
 
 		err = util.FileWrite(dirName+"/private/"+MnemonicFileName, []byte(mnemonic))

--- a/did/model.go
+++ b/did/model.go
@@ -31,24 +31,25 @@ const (
 )
 
 type DIDCreate struct {
-	Type              int    `json:"type"`
-	Dir               string `json:"dir"`
-	Config            string `json:"config"`
-	RootDID           bool   `json:"root_did"`
-	MasterDID         string `json:"master_did"`
-	Secret            string `json:"secret"`
-	PrivPWD           string `json:"priv_pwd"`
-	QuorumPWD         string `json:"quorum_pwd"`
-	ImgFile           string `json:"img_file"`
-	DIDImgFileName    string `json:"did_img_file"`
-	PubImgFile        string `json:"pub_img_file"`
-	PrivImgFile       string `json:"priv_img_file"`
-	PubKeyFile        string `json:"pub_key_file"`
-	PrivKeyFile       string `json:"priv_key_file"`
-	QuorumPubKeyFile  string `json:"quorum_pub_key_file"`
-	QuorumPrivKeyFile string `json:"quorum_priv_key_file"`
-	MnemonicFile      string `json:"mnemonic_file"`
-	ChildPath         int    `json:"childPath"`
+	Type              int       `json:"type"`
+	Dir               string    `json:"dir"`
+	Config            string    `json:"config"`
+	RootDID           bool      `json:"root_did"`
+	MasterDID         string    `json:"master_did"`
+	Secret            string    `json:"secret"`
+	PrivPWD           string    `json:"priv_pwd"`
+	QuorumPWD         string    `json:"quorum_pwd"`
+	ImgFile           string    `json:"img_file"`
+	DIDImgFileName    string    `json:"did_img_file"`
+	PubImgFile        string    `json:"pub_img_file"`
+	PrivImgFile       string    `json:"priv_img_file"`
+	PubKeyFile        string    `json:"pub_key_file"`
+	PrivKeyFile       string    `json:"priv_key_file"`
+	QuorumPubKeyFile  string    `json:"quorum_pub_key_file"`
+	QuorumPrivKeyFile string    `json:"quorum_priv_key_file"`
+	MnemonicFile      string    `json:"mnemonic_file"`
+	ChildPath         int       `json:"childPath"`
+	HDPath            [5]uint32 `json:"hd_path"`
 }
 
 type DIDSignature struct {

--- a/server/did.go
+++ b/server/did.go
@@ -62,8 +62,6 @@ func (s *Server) APICreateDID(req *ensweb.Request) *ensweb.Result {
 		return s.BasicResponse(req, false, "failed to parse did configuration", nil)
 	}
 
-	s.log.Debug("***** hd paths passed via api call : ", didCreate.HDPath)
-
 	if didCreate.Type < 0 || didCreate.Type > 4 {
 		s.log.Error("DID Type should be between 0 and 4")
 		return s.BasicResponse(req, false, "DID Type should be between 0 and 4", nil)

--- a/server/did.go
+++ b/server/did.go
@@ -62,6 +62,8 @@ func (s *Server) APICreateDID(req *ensweb.Request) *ensweb.Result {
 		return s.BasicResponse(req, false, "failed to parse did configuration", nil)
 	}
 
+	s.log.Debug("***** hd paths passed via api call : ", didCreate.HDPath)
+
 	if didCreate.Type < 0 || didCreate.Type > 4 {
 		s.log.Error("DID Type should be between 0 and 4")
 		return s.BasicResponse(req, false, "DID Type should be between 0 and 4", nil)


### PR DESCRIPTION
Hierarchical deterministic wallets (HD wallets) provide a convenient way to manage multiple addresses and private keys from a single master seed. HD wallets use a tree structure where parent keys can produce children keys infinitely, allowing for organized transactions by type or entity. They offer the advantage of creating public keys without accessing corresponding private keys, enhancing security.

Rubix already supports BIP-32 and BIP-39. It is time to introduce BIP-44 in Rubix so that RBTs can be easily handled in any HD wallet.

BIP 44 - builds upon BIP 32 by providing a specific organizational structure for multi-account wallets, allowing users to manage different cryptocurrency accounts within the same wallet while maintaining a hierarchical deterministic structure. It introduces the concept of ‘account levels’ and ‘purpose levels’ to create a hierarchical structure for keys. Each account has its own subtree, allowing for better organization and separation of funds.

The derivation path used in BIP44 follows this structure: `m / purpose' / coin_type' / account' / change / address_index`
Each element in the path has a specific meaning:

**m**: This is the master node and represents the root of your HD wallet.
 
**purpose**: Always set to 44' for BIP44 compliant wallets.
 
**coin_type**: Specifies the type of cryptocurrency. Each cryptocurrency has a specific number assigned, such as 0' for Bitcoin and 60' for Ethereum. For Rubix, it is 1001 for Mainnet DIDs and 1002 for Testnet DIDs.
 
**account**: A BIP44 wallet can have multiple accounts, and this number represents each unique account.
 
**change**: This is either 0 for external (receiving) addresses or 1 for internal (change) addresses.
 
**address_index**: Represents the individual addresses generated under each account.
Using the BIP44 protocol, users can manage multiple coins, accounts, and addresses under a single master seed, created using the BIP39 protocol.

This brings us some extra flags for DID creation. For example, 
`./rubixgoplatform createdid -didType 4 -mnemonicKeyFile /mnemonic/file/path/ -accountType 1 -changeAddr 0 -addrIndex 2 -port 20000`