### PR TITLE
Changes associated with NFT, Smart Contracts and other minor fixes 

### DIFF
--- a/command/bootstrap.go
+++ b/command/bootstrap.go
@@ -10,12 +10,12 @@ func (cmd *Command) addBootStrap() {
 		cmd.log.Error("Peers required for bootstrap. Use flag -peers to provide peers separated by a ','")
 		return
 	}
-	for _, peer := range cmd.peers {
-		if !strings.HasSuffix(peer, "/") {
-			cmd.log.Error(fmt.Sprintf("Invalid bootstrap peer : %s", peer))
-			return
-		}
-	}
+	// for _, peer := range cmd.peers {
+	// 	if !strings.HasSuffix(peer, "/") {
+	// 		cmd.log.Error(fmt.Sprintf("Invalid bootstrap peer : %s", peer))
+	// 		return
+	// 	}
+	// }
 	msg, status := cmd.c.AddBootStrap(cmd.peers)
 
 	if !status {

--- a/command/nft.go
+++ b/command/nft.go
@@ -125,7 +125,7 @@ func (cmd *Command) executeNFT() {
 
 	executeRequest := model.ExecuteNFTRequest{
 		NFT:        cmd.nft,
-		Owner:      cmd.executorAddr,
+		Executor:   cmd.executorAddr,
 		Receiver:   cmd.receiverAddr,
 		QuorumType: cmd.transType,
 		Comment:    cmd.transComment,

--- a/command/smartContract.go
+++ b/command/smartContract.go
@@ -94,7 +94,7 @@ func (cmd *Command) fetchSmartContract() {
 		return
 	}
 	if !basicResponse.Status {
-		cmd.log.Error("Failed to fetch smart contract token", "err", err)
+		cmd.log.Error("Failed to fetch smart contract token", "err", basicResponse.Message)
 		return
 	}
 	cmd.log.Info("Smart contract token fetched successfully")

--- a/core/core.go
+++ b/core/core.go
@@ -662,20 +662,29 @@ func (c *Core) FetchDID(did string) error {
 }
 
 func (c *Core) GetNFTFromIpfs(nftTokenHash string, nftFolderHash string) error {
-	_, err := os.Stat(c.cfg.DirPath + "NFT/" + nftTokenHash)
-	if err != nil {
-		err = os.MkdirAll(c.cfg.DirPath+"NFT/"+nftTokenHash, os.ModeDir|os.ModePerm)
+	dirPath := c.cfg.DirPath + "NFT/" + nftTokenHash
+	// Check if the directory exists
+	_, err := os.Stat(dirPath)
+	if os.IsNotExist(err) {
+		// If the directory does not exist, create it
+		err = os.MkdirAll(dirPath, os.ModeDir|os.ModePerm)
 		if err != nil {
 			c.log.Error("failed to create directory", "err", err)
 			return err
 		}
-		err = c.ipfs.Get(nftFolderHash, c.cfg.DirPath+"NFT/"+nftTokenHash)
-		if err != nil {
-			c.log.Error("failed to get NFT from IPFS", "err", err)
-			return err
-		}
+	} else if err != nil {
+		// Handle other errors while checking directory existence
+		c.log.Error("failed to check directory existence", "err", err)
+		return err
 	}
-	return err
+	// Fetch NFT data from IPFS and store in the directory
+	err = c.ipfs.Get(nftFolderHash, dirPath)
+	if err != nil {
+		c.log.Error("failed to get NFT from IPFS", "err", err)
+		return err
+	}
+	c.log.Info("NFT data fetched successfully from ipfs")
+	return nil
 }
 
 func (c *Core) GetPeerID() string {

--- a/core/diagnostic.go
+++ b/core/diagnostic.go
@@ -276,12 +276,14 @@ func (c *Core) GetSmartContractTokenChainData(getReq *model.SmartContractTokenCh
 		epoch := block.GetEpoch()
 
 		var executorSignature string
+		var executorSignData string
 		signObj := block.GetInitiatorSignature()
 		if signObj == nil {
 			reply.Message = "unable to fetch intiateor signature"
 			return reply
 		} else {
 			executorSignature = signObj.PrivateSign
+			executorSignData = signObj.Hash
 		}
 
 		executorDID := block.GetExecutorDID()
@@ -293,6 +295,7 @@ func (c *Core) GetSmartContractTokenChainData(getReq *model.SmartContractTokenCh
 			Epoch:              epoch,
 			InitiatorSignature: executorSignature,
 			ExecutorDID:        executorDID,
+			InitiatorSignData:  executorSignData,
 		}
 
 		sctDataArray = append(sctDataArray, sctData)

--- a/core/diagnostic.go
+++ b/core/diagnostic.go
@@ -332,12 +332,13 @@ func (c *Core) GetNFTTokenChainData(getReq *model.SmartContractTokenChainDataReq
 		}
 
 		nftDataArray = append(nftDataArray, model.NFTData{
-			BlockNo:  blockNo,
-			BlockId:  blockId,
-			NFTData:  latestBlock.GetNFTData(),
-			NFTOwner: latestBlock.GetOwner(),
-			NFTValue: latestBlock.GetTokenValue(),
-			Epoch:    latestBlock.GetEpoch(),
+			BlockNo:       blockNo,
+			BlockId:       blockId,
+			NFTData:       latestBlock.GetNFTData(),
+			NFTOwner:      latestBlock.GetOwner(),
+			NFTValue:      latestBlock.GetTokenValue(),
+			Epoch:         latestBlock.GetEpoch(),
+			TransactionID: latestBlock.GetTid(),
 		})
 	} else {
 		blks, _, err := c.w.GetAllTokenBlocks(getReq.Token, c.TokenType(NFTString), "")
@@ -361,12 +362,13 @@ func (c *Core) GetNFTTokenChainData(getReq *model.SmartContractTokenChainDataReq
 			}
 
 			nftDataArray = append(nftDataArray, model.NFTData{
-				BlockNo:  blockNo,
-				BlockId:  blockId,
-				NFTData:  block.GetNFTData(),
-				NFTOwner: block.GetOwner(),
-				NFTValue: block.GetTokenValue(),
-				Epoch:    block.GetEpoch(), // Fixed the missing Epoch value
+				BlockNo:       blockNo,
+				BlockId:       blockId,
+				NFTData:       block.GetNFTData(),
+				NFTOwner:      block.GetOwner(),
+				NFTValue:      block.GetTokenValue(),
+				Epoch:         block.GetEpoch(), // Fixed the missing Epoch value
+				TransactionID: block.GetTid(),
 			})
 		}
 	}

--- a/core/diagnostic.go
+++ b/core/diagnostic.go
@@ -218,24 +218,28 @@ func (c *Core) GetSmartContractTokenChainData(getReq *model.SmartContractTokenCh
 		epoch := latestBlock.GetEpoch()
 		scData := latestBlock.GetSmartContractData()
 
-		var executorSignature string
+		var initiatorSignature string
+		var initiatorSignData string
+
 		signObj := latestBlock.GetInitiatorSignature()
 		if signObj == nil {
 			reply.Message = "unable to fetch intiateor signature"
 			return reply
 		} else {
-			executorSignature = signObj.PrivateSign
+			initiatorSignature = signObj.PrivateSign
+			initiatorSignData = signObj.Hash
 		}
 
 		executorDID := latestBlock.GetExecutorDID()
 
 		sctData := model.SCTDataReply{
-			BlockNo:           blockNo,
-			BlockId:           blockId,
-			SmartContractData: scData,
-			Epoch:             epoch,
-			ExecutorSignature: executorSignature,
-			ExecutorDID:       executorDID,
+			BlockNo:            blockNo,
+			BlockId:            blockId,
+			SmartContractData:  scData,
+			Epoch:              epoch,
+			InitiatorSignature: initiatorSignature,
+			ExecutorDID:        executorDID,
+			InitiatorSignData:  initiatorSignData,
 		}
 
 		sctDataArray = append(sctDataArray, sctData)
@@ -283,12 +287,12 @@ func (c *Core) GetSmartContractTokenChainData(getReq *model.SmartContractTokenCh
 		executorDID := block.GetExecutorDID()
 
 		sctData := model.SCTDataReply{
-			BlockNo:           blockNo,
-			BlockId:           blockId,
-			SmartContractData: scData,
-			Epoch:             epoch,
-			ExecutorSignature: executorSignature,
-			ExecutorDID:       executorDID,
+			BlockNo:            blockNo,
+			BlockId:            blockId,
+			SmartContractData:  scData,
+			Epoch:              epoch,
+			InitiatorSignature: executorSignature,
+			ExecutorDID:        executorDID,
 		}
 
 		sctDataArray = append(sctDataArray, sctData)

--- a/core/explorer.go
+++ b/core/explorer.go
@@ -1,9 +1,9 @@
 package core
 
 import (
+	"bytes"
 	"fmt"
 	"io"
-	"math"
 	"net/http"
 	"strings"
 	"sync"
@@ -21,8 +21,8 @@ const (
 	ExplorerBasePath              string = "/api/v2/services/app/Rubix/"
 	ExplorerTokenCreateAPI        string = "/api/token/create"
 	ExplorerTokenCreatePartsAPI   string = "/api/token/part/create"
-	ExplorerTokenCreateNFTAPI     string = "/api/token/nft/create"
-	ExplorerTokenCreateSCAPI      string = "/api/token/sc/create"
+	ExplorerTokenCreateNFTAPI     string = "/api/v2/token/nft/create"
+	ExplorerTokenCreateSCAPI      string = "/api/v2/token/sc/create"
 	ExplorerCreateUserAPI         string = "/api/user/create"
 	ExplorerUpdateUserInfoAPI     string = "/api/user/update-user-info"
 	ExplorerUpdateTokenInfoAPI    string = "/api/token/update-token-info"
@@ -30,7 +30,7 @@ const (
 	ExplorerGenerateUserKeyAPI    string = "/api/user/generate-api-key"
 	ExplorerExpireUserKeyAPI      string = "/api/user/set-expire-api-key"
 	ExplorerRBTTransactionAPI     string = "/api/transactions/rbt"
-	ExplorerSCTransactionAPI      string = "/api/transactions/sc"
+	ExplorerSCTransactionAPI      string = "/api/v2/transactions/sc"
 	ExplorerFTTransactionAPI      string = "/api/transactions/ft"
 	ExplorerNFTTransactionAPI     string = "/api/transactions/nft"
 	ExplorerUpdatePledgeStatusAPI string = "/api/token/update-pledge-status"
@@ -77,11 +77,6 @@ type TokenDetails struct {
 type Token struct {
 	TokenHash  string  `json:"token_hash"`
 	TokenValue float64 `json:"token_value"`
-}
-
-type NFTToken struct {
-	TokenHash  string  `json:"tokenId"`
-	TokenValue float64 `json:"tokenValue"`
 }
 
 type UnpledgeToken struct {
@@ -134,11 +129,6 @@ type PledgeInfo struct {
 	PledgedTokenList []Token             `json:"pledged_token_list"`
 }
 
-type PledgeInfoNFT struct {
-	PledgeDetails    map[string][]string `json:"pledgeDetails"`
-	PledgedTokenList []NFTToken          `json:"tokenList"`
-}
-
 type ExplorerRBTTrans struct {
 	TokenHashes    []string   `json:"token_hash"`
 	TransactionID  string     `json:"transaction_id"`
@@ -157,7 +147,7 @@ type ExplorerSCDeploy struct {
 	SCTokenHash        string     `json:"sc_token_hash"`
 	SCTokenValue       float64    `json:"sc_token_value"`
 	Network            int        `json:"network"`
-	SCBlockNumber      int        `json:"block_number"`
+	SCBlockNumber      int        `json:"block_num"`
 	TransactionID      string     `json:"transaction_id"`
 	SCBlockHash        string     `json:"block_hash"`
 	DeployerDID        string     `json:"deployer_did"`
@@ -185,52 +175,54 @@ type ExplorerSCTrans struct {
 }
 
 type ExplorerNFTDeploy struct {
-	NFT            string        `json:"nft"`
-	NFTBlockHash   string        `json:"nft_block_hash"`
-	NFTBlockNumber int           `json:"nft_block_number"`
-	NFTValue       float64       `json:"nft_value"`
-	TransactionID  string        `json:"transaction_id"`
-	Network        int           `json:"network"`
-	OwnerDID       string        `json:"owner_did"`
-	DeployerDID    string        `json:"deployer_did"`
-	PledgeAmount   float64       `json:"pledge_amount"`
-	QuorumList     []string      `json:"quorum_list"`
-	PledgeInfo     PledgeInfoNFT `json:"pledge_info"`
-	Comments       string        `json:"comments"`
+	NFT            string     `json:"nft"`
+	NFTBlockHash   string     `json:"nft_block_hash"`
+	NFTBlockNumber int        `json:"nft_block_number"`
+	NFTValue       float64    `json:"nft_value"`
+	SCTokenHash    string     `json:"sc_token_hash"`
+	TransactionID  string     `json:"transaction_id"`
+	Network        int        `json:"network"`
+	OwnerDID       string     `json:"owner_did"`
+	DeployerDID    string     `json:"deployer_did"`
+	PledgeAmount   float64    `json:"pledge_amount"`
+	QuorumList     []string   `json:"quorum_list"`
+	PledgeInfo     PledgeInfo `json:"pledge_info"`
+	Comments       string     `json:"comments"`
 }
 
 type ExplorerNFTExecute struct {
-	NFT            string        `json:"nft"`
-	ExecutorDID    string        `json:"executor_did"`
-	ReceiverDID    string        `json:"receiver_did"`
-	Network        int           `json:"network"`
-	Comments       string        `json:"comments"`
-	NFTValue       float64       `json:"nft_value"`
-	NFTData        string        `json:"nft_data"`
-	NFTBlockHash   string        `json:"block_hash"`
-	NFTBlockNumber int           `json:"block_number"`
-	PledgeAmount   float64       `json:"pledge_amount"`
-	TransactionID  string        `json:"transaction_id"`
-	Amount         float64       `json:"amount"`
-	QuorumList     []string      `json:"quorumList"`
-	PledgeInfo     PledgeInfoNFT `json:"pledgeInfo"`
+	NFT            string     `json:"nft"`
+	ExecutorDID    string     `json:"executor_did"`
+	ReceiverDID    string     `json:"receiver_did"`
+	Network        int        `json:"network"`
+	Comments       string     `json:"comments"`
+	NFTValue       float64    `json:"nft_value"`
+	NFTData        string     `json:"nft_data"`
+	SCTokenHash    string     `json:"sc_token_hash"`
+	NFTBlockHash   string     `json:"block_hash"`
+	NFTBlockNumber int        `json:"block_number"`
+	PledgeAmount   float64    `json:"pledge_amount"`
+	TransactionID  string     `json:"transaction_id"`
+	Amount         float64    `json:"amount"`
+	QuorumList     []string   `json:"quorum_list"`
+	PledgeInfo     PledgeInfo `json:"pledge_info"`
 }
 
 type ExplorerFTTrans struct {
-	FTBlockHash     []AllToken    `json:"ftBlockHash"`
-	CreatorDID      []string      `json:"creatorDID"`
-	SenderDID       string        `json:"senderDID"`
-	ReceiverDID     string        `json:"receiverDID"`
-	FTName          string        `json:"ftName"`
-	FTSymbol        string        `json:"ftSymbol"`
-	FTTransferCount int           `json:"ftTransferCount"`
-	Network         int           `json:"network"`
-	Comments        string        `json:"comments"`
-	FTTokenList     []string      `json:"ftTokenList"`
-	TransactionID   string        `json:"transactionID"`
-	Amount          float64       `json:"amount"`
-	QuorumList      []string      `json:"quorumList"`
-	PledgeInfo      PledgeInfoNFT `json:"pledgeInfo"`
+	FTBlockHash     []AllToken `json:"ft_block_hash"`
+	CreatorDID      string     `json:"creator_did"`
+	SenderDID       string     `json:"sender_did"`
+	ReceiverDID     string     `json:"receiver_did"`
+	FTName          string     `json:"ft_name"`
+	FTSymbol        string     `json:"ft_symbol"`
+	FTTransferCount int        `json:"ft_transfer_count"`
+	Network         int        `json:"network"`
+	Comments        string     `json:"comments"`
+	FTTokenList     []string   `json:"ft_token_list"`
+	TransactionID   string     `json:"transaction_id"`
+	Amount          float64    `json:"amount"`
+	QuorumList      []string   `json:"quorum_list"`
+	PledgeInfo      PledgeInfo `json:"pledge_info"`
 }
 
 type ExplorerResponse struct {
@@ -289,12 +281,22 @@ func (c *Core) InitRubixExplorer() error {
 		}
 	}
 
-	err = c.s.Read(ExplorerURLTable, &ExplorerURL{}, "url=?", newURL)
+	var explorerURL ExplorerURL
+	err = c.s.Read(ExplorerURLTable, &explorerURL, "url=?", newURL)
 	if err != nil {
 		err = c.s.Write(ExplorerURLTable, &ExplorerURL{URL: newURL, Port: 443, Protocol: "https"})
+		if err != nil {
+			c.log.Error("URL could not be added to DB ", "url", newURL)
+			return err
+		}
 	}
-	if err != nil {
-		return err
+	if explorerURL.Protocol == "" {
+		explorerURL.Protocol = "https"
+		err = c.s.Update(ExplorerURLTable, &explorerURL, "url=?", newURL)
+		if err != nil {
+			c.log.Error("Protocol could not be updated for ", "url", newURL)
+			return err
+		}
 	}
 
 	cl, err := ensweb.NewClient(&config.Config{ServerAddress: newURL, ServerPort: "0", Production: "true"}, c.log)
@@ -317,40 +319,113 @@ func (ec *ExplorerClient) SendExplorerJSONRequest(method string, path string, in
 		return err
 	}
 
+	const maxRetries = 3
 	for _, url := range urls {
 		apiKeyForHeader := ""
 		if url == "https://rexplorer.azurewebsites.net" || url == "https://testnet-core-api.rubixexplorer.com" {
-			apiKeyForHeader = ec.getAPIKey(path, input)
-		} else {
-			apiKeyForHeader = ""
+			apiKeyForHeader = ec.getAPIKey(path, input, false)
 		}
-		req, err := ec.JSONRequestForExplorer(method, path, input, url, apiKeyForHeader)
-		if err != nil {
-			ec.log.Error("Request could not be sent to : "+url, "err", err)
-			continue
-		}
-		resp, err := ec.Do(req)
-		if err != nil {
-			ec.log.Error("Failed to get response from explorer : "+url, "err", err)
-			continue
-		}
-		defer resp.Body.Close()
-		if resp.StatusCode != http.StatusOK {
+
+		attempts := 0
+
+		for attempts < maxRetries {
+			req, err := ec.JSONRequestForExplorer(method, path, input, url, apiKeyForHeader)
+			if err != nil {
+				ec.log.Error("Request could not be sent to : "+url, "err", err)
+				break
+			}
+			resp, err := ec.Do(req)
+			if err != nil {
+				ec.log.Error("Failed to get response from explorer : "+url, "err", err)
+				break
+			}
+			// defer resp.Body.Close()
 			bodyBytes, _ := io.ReadAll(resp.Body)
-			str := fmt.Sprintf("Http Request failed with status %d for %s. Response: %s", resp.StatusCode, url, string(bodyBytes))
-			ec.log.Error(str)
-			continue
-		}
-		if output == nil {
-			continue
-		}
-		err = jsonutil.DecodeJSONFromReader(resp.Body, output)
-		if err != nil {
-			ec.log.Error("Invalid response from the node", "err", err)
-			continue
+			resp.Body.Close()
+			if resp.StatusCode != http.StatusOK {
+				bodyString := string(bodyBytes)
+				str := fmt.Sprintf("Http Request failed with status %d for %s. Response: %s", resp.StatusCode, url, bodyString)
+				if strings.Contains(bodyString, "DuplicateKey") {
+					return fmt.Errorf("user already exists, duplicate key error")
+				}
+				if strings.Contains(bodyString, "Invalid API Key") {
+					//Fetch the API Key from explorer.
+					//Add or Update the new API Key in the DB
+					//Run from req, err := ec.JSONRequestForExplorer(method, path, input, url, apiKeyForHeader) line again.
+					//Put a count of 3, after 3 trials, it should stop.
+					attempts++
+					ec.log.Info("Invalid API Key. Retrying request with new API Key...", "Attempt", attempts)
+					didReq := ec.getAPIKey(path, input, true)
+					if didReq != "" {
+						apiKeyForHeader, err = ec.GetAPIKeyFromExplorer(url, didReq)
+						if err != nil {
+							break
+						}
+						ec.AddDIDKey(didReq, apiKeyForHeader)
+						// time.Sleep(2 * time.Second)
+						// apiKeyForHeader = ec.getAPIKey(path, input, false) // Fetch new key after regeneration
+					}
+					continue
+				}
+				ec.log.Error(str)
+				break
+			}
+			if output == nil {
+				break
+			}
+			err = jsonutil.DecodeJSONFromReader(bytes.NewReader(bodyBytes), output)
+			if err != nil {
+				ec.log.Error("Invalid response from the node", "err", err)
+				break
+			}
+			return nil
 		}
 	}
 	return nil
+}
+
+func (ec *ExplorerClient) GetAPIKeyFromExplorer(url string, didReq string) (string, error) {
+	var er ExplorerUserCreateResponse
+	eu := ExplorerUser{DID: didReq}
+
+	// Create request to fetch API key
+	req, err := ec.JSONRequestForExplorer("POST", ExplorerGenerateUserKeyAPI, &eu, url, "")
+	if err != nil {
+		ec.log.Error(fmt.Sprintf("Failed to create request for DID %v: %v", didReq, err.Error()))
+		return "", err
+	}
+
+	// Send request
+	resp, err := ec.Do(req)
+	if err != nil {
+		ec.log.Error(fmt.Sprintf("Failed to send request for DID %v: %v", didReq, err.Error()))
+		return "", err
+	}
+
+	// Read response
+	bodyBytes, _ := io.ReadAll(resp.Body)
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		ec.log.Error(fmt.Sprintf("Failed to generate API Key for %v. Response: %s", didReq, string(bodyBytes)))
+		return "", fmt.Errorf("failed to generate API key, response: %s", string(bodyBytes))
+	}
+
+	// Decode JSON response
+	err = jsonutil.DecodeJSONFromReader(bytes.NewReader(bodyBytes), &er)
+	if err != nil {
+		ec.log.Error(fmt.Sprintf("Invalid response for DID %v: %v", didReq, err.Error()))
+		return "", err
+	}
+
+	// Check response message
+	if !strings.Contains(er.Message, "successfully") {
+		errMsg := fmt.Sprintf("Failed to generate API Key for %v. Error: %v", didReq, er.Message)
+		ec.log.Error(errMsg)
+		return "", fmt.Errorf(errMsg)
+	}
+
+	ec.log.Info(fmt.Sprintf("API key generated successfully for DID %v: %s", didReq, er.APIKey))
+	return er.APIKey, nil
 }
 
 func (c *Core) ExplorerUserCreate() []string {
@@ -400,7 +475,16 @@ func (c *Core) ExplorerUserCreate() []string {
 							DIDType: d.Type,
 						}
 						err := c.ec.ExplorerUserCreate(&ed)
-						if err != nil {
+						if err != nil && strings.Contains(err.Error(), "duplicate") {
+							eu.DID = d.DID
+							err = c.s.Write(ExplorerUserDetailsTable, eu)
+							if err != nil {
+								c.log.Error(fmt.Sprintf("Error adding user DID %v: in the DB with error %v", d.DID, err))
+								return
+							}
+							c.UpdateUserInfo([]string{ed.DID})
+							c.GenerateUserAPIKey([]string{ed.DID})
+						} else if err != nil {
 							c.log.Error(fmt.Sprintf("Error creating user for DID %v: %v", d.DID, err))
 							return
 						}
@@ -431,8 +515,8 @@ func (ec *ExplorerClient) ExplorerUserCreate(ed *ExplorerDID) error {
 	if err != nil {
 		return err
 	}
-	if er.Message != "User created successfully!" {
-		ec.log.Error("Failed to create user for %v with error message %v", ed.DID, er.Message)
+	if !strings.Contains(er.Message, "successfully") {
+		ec.log.Error(fmt.Sprintf("Failed to create user for %v with error message %v", ed.DID, er.Message))
 		return fmt.Errorf("failed to create user")
 	}
 	ec.AddDIDKey(ed.DID, er.APIKey)
@@ -629,7 +713,7 @@ func (c *Core) GenerateUserAPIKey(dids []string) {
 				c.log.Error(fmt.Sprintf("Failed to send request for DID %v: %v", did, err.Error()))
 				return
 			}
-			if er.Message != "API key regenerated successfully!" {
+			if !strings.Contains(er.Message, "successfully") {
 				c.log.Error(fmt.Sprintf("Failed to generate API Key for %v. The error msg is %v", did, er.Message))
 				return
 			}
@@ -723,7 +807,7 @@ func (ec *ExplorerClient) ExplorerSCDeploy(et *ExplorerSCDeploy) error {
 		ec.log.Error("Failed to update explorer", "msg", er.Message)
 		return fmt.Errorf("failed to update explorer")
 	}
-	ec.log.Info(fmt.Sprintf("Smart contract transaction details for TransactionID %v is stored successfully", et.TransactionID))
+	ec.log.Info(fmt.Sprintf("Smart contract deployment details for TransactionID %v is stored successfully with msg=%v", et.TransactionID, er.Message))
 	return nil
 }
 
@@ -737,7 +821,7 @@ func (ec *ExplorerClient) ExplorerSCTransaction(et *ExplorerSCTrans) error {
 		ec.log.Error("Failed to update explorer", "msg", er.Message)
 		return fmt.Errorf("failed to update explorer")
 	}
-	ec.log.Info(fmt.Sprintf("Smart contract transaction details for TransactionID %v is stored successfully", et.TransactionID))
+	ec.log.Info(fmt.Sprintf("Smart contract transaction details for TransactionID %v is stored successfully with msg=%v", et.TransactionID, er.Message))
 	return nil
 }
 
@@ -751,7 +835,7 @@ func (ec *ExplorerClient) ExplorerNFTDeploy(et *ExplorerNFTDeploy) error {
 		ec.log.Error("Failed to update explorer", "msg", er.Message)
 		return fmt.Errorf("failed to update explorer")
 	}
-	ec.log.Info(fmt.Sprintf("Smart contract transaction details for TransactionID %v is stored successfully", et.TransactionID))
+	ec.log.Info(fmt.Sprintf("NFT deployment details for TransactionID %v is stored successfully with message=%v", et.TransactionID, er.Message))
 	return nil
 }
 
@@ -765,7 +849,7 @@ func (ec *ExplorerClient) ExplorerNFTTransaction(et *ExplorerNFTExecute) error {
 		ec.log.Error("Failed to update explorer", "msg", er.Message)
 		return fmt.Errorf("failed to update explorer")
 	}
-	ec.log.Info(fmt.Sprintf("Smart contract transaction details for TransactionID %v is stored successfully", et.TransactionID))
+	ec.log.Info(fmt.Sprintf("NFT transaction details for TransactionID %v is stored successfully with message=%v", et.TransactionID, er.Message))
 	return nil
 }
 
@@ -779,7 +863,7 @@ func (ec *ExplorerClient) ExplorerFTTransaction(et *ExplorerFTTrans) error {
 		ec.log.Error("Failed to update explorer", "msg", er.Message)
 		return fmt.Errorf("failed to update explorer")
 	}
-	ec.log.Info(fmt.Sprintf("Smart contract transaction details for TransactionID %v is stored successfully", et.TransactionID))
+	ec.log.Info(fmt.Sprintf("FT transaction details for TransactionID %v is stored successfully with message = %v", et.TransactionID, er.Message))
 	return nil
 }
 
@@ -861,24 +945,30 @@ func (c *Core) AddDIDKey(did string, apiKey string) error {
 }
 
 func (ec *ExplorerClient) AddDIDKey(did string, apiKey string) error {
+	var mu sync.Mutex
 	eu := ExplorerUser{}
 	err := ec.es.Read(ExplorerUserDetailsTable, &eu, "did=?", did)
+	mu.Lock()
 	if err != nil {
 		eu.DID = did
 		eu.APIKey = apiKey
 		err = ec.es.Write(ExplorerUserDetailsTable, eu)
 		if err != nil {
-			return err
+			return fmt.Errorf("failed to insert new API key for DID %s: %w", did, err)
 		}
 	} else {
 		eu.APIKey = apiKey
-		ec.es.Update(ExplorerUserDetailsTable, &eu, "did=?", did)
+		err = ec.es.Update(ExplorerUserDetailsTable, &eu, "did=?", did)
+		if err != nil {
+			return fmt.Errorf("failed to update API key for DID %s: %w", did, err)
+		}
 	}
+	mu.Unlock()
 
 	return nil
 }
 
-func (ec *ExplorerClient) getAPIKey(path string, input interface{}) string {
+func (ec *ExplorerClient) getAPIKey(path string, input interface{}, getDID bool) string {
 	eu := ExplorerUser{}
 	if path != ExplorerCreateUserAPI {
 		var did string
@@ -887,8 +977,23 @@ func (ec *ExplorerClient) getAPIKey(path string, input interface{}) string {
 			did = v.SenderDID
 		case *ExplorerCreateToken:
 			did = v.UserDID
+		case *ExplorerCreateTokenParts:
+			did = v.UserDID
+		case *ExplorerFTTrans:
+			did = v.SenderDID
+		case *ExplorerSCTrans:
+			did = v.ExecutorDID
+		case *ExplorerSCDeploy:
+			did = v.DeployerDID
+		case *ExplorerNFTDeploy:
+			did = v.DeployerDID
+		case *ExplorerNFTExecute:
+			did = v.ExecutorDID
 		default:
-			return "unsupported input type"
+			return ""
+		}
+		if getDID {
+			return did
 		}
 		err := ec.es.Read(ExplorerUserDetailsTable, &eu, "did=?", did) //Include explorer URL? TODO
 		if err != nil {
@@ -950,14 +1055,4 @@ func (c *Core) UpdatePledgeStatus(tokenHashes []string, did string) {
 		c.log.Error("Failed to update explorer", "msg", er.Message)
 	}
 	c.log.Info(fmt.Sprintf("Pledge status updated successfully for did %v and token hashes %v", did, tokenHashes))
-}
-
-// Function to convert []Token to []NFTToken
-func ConvertToNFTTokens(tokenList []Token) []NFTToken {
-	nftTokens := make([]NFTToken, len(tokenList))
-	for i, token := range tokenList {
-		nftTokens[i].TokenHash = token.TokenHash
-		nftTokens[i].TokenValue = math.Round(token.TokenValue*1000) / 1000 //Rounding token value to 3 decimal places.
-	}
-	return nftTokens
 }

--- a/core/explorer.go
+++ b/core/explorer.go
@@ -77,6 +77,11 @@ type Token struct {
 	TokenValue float64 `json:"token_value"`
 }
 
+type NFTToken struct {
+	TokenHash  string  `json:"tokenId"`
+	TokenValue float64 `json:"tokenValue"`
+}
+
 type UnpledgeToken struct {
 	TokenHashes []string `json:"token_hashes"`
 }
@@ -127,6 +132,11 @@ type PledgeInfo struct {
 	PledgedTokenList []Token             `json:"pledged_token_list"`
 }
 
+type PledgeInfoNFT struct {
+	PledgeDetails    map[string][]string `json:"pledgeDetails"`
+	PledgedTokenList []NFTToken          `json:"tokenList"`
+}
+
 type ExplorerRBTTrans struct {
 	TokenHashes    []string   `json:"token_hash"`
 	TransactionID  string     `json:"transaction_id"`
@@ -157,49 +167,49 @@ type ExplorerSCTrans struct {
 }
 
 type ExplorerNFTDeploy struct {
-	NFTBlockHash  []AllToken `json:"nftBlockHash"`
-	NFTValue      float64    `json:"nftValue"`
-	TransactionID string     `json:"transactionID"`
-	Network       int        `json:"network"`
-	OwnerDID      string     `json:"ownerDID"`
-	DeployerDID   string     `json:"deployerDID"`
-	PledgeAmount  float64    `json:"pledgeAmount"`
-	QuorumList    []string   `json:"quorumList"`
-	PledgeInfo    PledgeInfo `json:"pledgeInfo"`
-	Comments      string     `json:"comments"`
+	NFTBlockHash  []AllToken    `json:"nftBlockHash"`
+	NFTValue      float64       `json:"nftValue"`
+	TransactionID string        `json:"transactionID"`
+	Network       int           `json:"network"`
+	OwnerDID      string        `json:"ownerDID"`
+	DeployerDID   string        `json:"deployerDID"`
+	PledgeAmount  float64       `json:"pledgeAmount"`
+	QuorumList    []string      `json:"quorumList"`
+	PledgeInfo    PledgeInfoNFT `json:"pledgeInfo"`
+	Comments      string        `json:"comments"`
 }
 
 type ExplorerNFTExecute struct {
-	NFTBlockHash  []AllToken `json:"nftBlockHash"`
-	NFT           string     `json:"nft"`
-	ExecutorDID   string     `json:"executorDID"`
-	ReceiverDID   string     `json:"receiverDID"`
-	Network       int        `json:"network"`
-	Comments      string     `json:"comments"`
-	NFTValue      float64    `json:"nftValue"`
-	NFTData       string     `json:"nftData"`
-	PledgeAmount  float64    `json:"pledgeAmount"`
-	TransactionID string     `json:"transactionID"`
-	Amount        float64    `json:"amount"`
-	QuorumList    []string   `json:"quorumList"`
-	PledgeInfo    PledgeInfo `json:"pledgeInfo"`
+	NFTBlockHash  []AllToken    `json:"nftBlockHash"`
+	NFT           string        `json:"nft"`
+	ExecutorDID   string        `json:"executorDID"`
+	ReceiverDID   string        `json:"receiverDID"`
+	Network       int           `json:"network"`
+	Comments      string        `json:"comments"`
+	NFTValue      float64       `json:"nftValue"`
+	NFTData       string        `json:"nftData"`
+	PledgeAmount  float64       `json:"pledgeAmount"`
+	TransactionID string        `json:"transactionID"`
+	Amount        float64       `json:"amount"`
+	QuorumList    []string      `json:"quorumList"`
+	PledgeInfo    PledgeInfoNFT `json:"pledgeInfo"`
 }
 
 type ExplorerFTTrans struct {
-	FTBlockHash     []AllToken `json:"ftBlockHash"`
-	CreatorDID      string     `json:"creator"`
-	SenderDID       string     `json:"senderDID"`
-	ReceiverDID     string     `json:"receiverDID"`
-	FTName          string     `json:"ftName"`
-	FTSymbol        string     `json:"ftSymbol"`
-	FTTransferCount int        `json:"ftTransferCount"`
-	Network         int        `json:"network"`
-	Comments        string     `json:"comments"`
-	FTTokenList     []string   `json:"ftTokenList"`
-	TransactionID   string     `json:"transactionID"`
-	Amount          float64    `json:"amount"`
-	QuorumList      []string   `json:"quorumList"`
-	PledgeInfo      PledgeInfo `json:"pledge_info"`
+	FTBlockHash     []AllToken    `json:"ftBlockHash"`
+	CreatorDID      []string      `json:"creatorDID"`
+	SenderDID       string        `json:"senderDID"`
+	ReceiverDID     string        `json:"receiverDID"`
+	FTName          string        `json:"ftName"`
+	FTSymbol        string        `json:"ftSymbol"`
+	FTTransferCount int           `json:"ftTransferCount"`
+	Network         int           `json:"network"`
+	Comments        string        `json:"comments"`
+	FTTokenList     []string      `json:"ftTokenList"`
+	TransactionID   string        `json:"transactionID"`
+	Amount          float64       `json:"amount"`
+	QuorumList      []string      `json:"quorumList"`
+	PledgeInfo      PledgeInfoNFT `json:"pledgeInfo"`
 }
 
 type ExplorerResponse struct {
@@ -698,7 +708,7 @@ func (ec *ExplorerClient) ExplorerSCTransaction(et *ExplorerSCTrans) error {
 
 func (ec *ExplorerClient) ExplorerNFTDeploy(et *ExplorerNFTDeploy) error {
 	var er ExplorerResponse
-	err := ec.SendExplorerJSONRequest("POST", ExplorerNFTTransactionAPI, et, &er)
+	err := ec.SendExplorerJSONRequest("POST", ExplorerTokenCreateNFTAPI, et, &er)
 	if err != nil {
 		return err
 	}
@@ -905,4 +915,14 @@ func (c *Core) UpdatePledgeStatus(tokenHashes []string, did string) {
 		c.log.Error("Failed to update explorer", "msg", er.Message)
 	}
 	c.log.Info(fmt.Sprintf("Pledge status updated successfully for did %v and token hashes %v", did, tokenHashes))
+}
+
+// Function to convert []Token to []NFTToken
+func ConvertToNFTTokens(tokenList []Token) []NFTToken {
+	nftTokens := make([]NFTToken, len(tokenList))
+	for i, token := range tokenList {
+		nftTokens[i].TokenHash = token.TokenHash
+		nftTokens[i].TokenValue = token.TokenValue
+	}
+	return nftTokens
 }

--- a/core/explorer.go
+++ b/core/explorer.go
@@ -3,6 +3,7 @@ package core
 import (
 	"fmt"
 	"io"
+	"math"
 	"net/http"
 	"strings"
 	"sync"
@@ -922,7 +923,7 @@ func ConvertToNFTTokens(tokenList []Token) []NFTToken {
 	nftTokens := make([]NFTToken, len(tokenList))
 	for i, token := range tokenList {
 		nftTokens[i].TokenHash = token.TokenHash
-		nftTokens[i].TokenValue = token.TokenValue
+		nftTokens[i].TokenValue = math.Round(token.TokenValue*1000) / 1000 //Rounding token value to 3 decimal places.
 	}
 	return nftTokens
 }

--- a/core/explorer.go
+++ b/core/explorer.go
@@ -168,32 +168,35 @@ type ExplorerSCTrans struct {
 }
 
 type ExplorerNFTDeploy struct {
-	NFTBlockHash  []AllToken    `json:"nftBlockHash"`
-	NFTValue      float64       `json:"nftValue"`
-	TransactionID string        `json:"transactionID"`
-	Network       int           `json:"network"`
-	OwnerDID      string        `json:"ownerDID"`
-	DeployerDID   string        `json:"deployerDID"`
-	PledgeAmount  float64       `json:"pledgeAmount"`
-	QuorumList    []string      `json:"quorumList"`
-	PledgeInfo    PledgeInfoNFT `json:"pledgeInfo"`
-	Comments      string        `json:"comments"`
+	NFT            string        `json:"nft"`
+	NFTBlockHash   string        `json:"nft_block_hash"`
+	NFTBlockNumber int           `json:"nft_block_number"`
+	NFTValue       float64       `json:"nft_value"`
+	TransactionID  string        `json:"transaction_id"`
+	Network        int           `json:"network"`
+	OwnerDID       string        `json:"owner"`
+	DeployerDID    string        `json:"deployer"`
+	PledgeAmount   float64       `json:"pledge_amount"`
+	QuorumList     []string      `json:"quorum_list"`
+	PledgeInfo     PledgeInfoNFT `json:"pledge_info"`
+	Comments       string        `json:"comments"`
 }
 
 type ExplorerNFTExecute struct {
-	NFTBlockHash  []AllToken    `json:"nftBlockHash"`
-	NFT           string        `json:"nft"`
-	ExecutorDID   string        `json:"executorDID"`
-	ReceiverDID   string        `json:"receiverDID"`
-	Network       int           `json:"network"`
-	Comments      string        `json:"comments"`
-	NFTValue      float64       `json:"nftValue"`
-	NFTData       string        `json:"nftData"`
-	PledgeAmount  float64       `json:"pledgeAmount"`
-	TransactionID string        `json:"transactionID"`
-	Amount        float64       `json:"amount"`
-	QuorumList    []string      `json:"quorumList"`
-	PledgeInfo    PledgeInfoNFT `json:"pledgeInfo"`
+	NFT            string        `json:"nft"`
+	ExecutorDID    string        `json:"executorDID"`
+	ReceiverDID    string        `json:"receiverDID"`
+	Network        int           `json:"network"`
+	Comments       string        `json:"comments"`
+	NFTValue       float64       `json:"nftValue"`
+	NFTData        string        `json:"nftData"`
+	NFTBlockHash   string        `json:"blockHash"`
+	NFTBlockNumber int           `json:"blockNumber"`
+	PledgeAmount   float64       `json:"pledgeAmount"`
+	TransactionID  string        `json:"transactionID"`
+	Amount         float64       `json:"amount"`
+	QuorumList     []string      `json:"quorumList"`
+	PledgeInfo     PledgeInfoNFT `json:"pledgeInfo"`
 }
 
 type ExplorerFTTrans struct {

--- a/core/explorer.go
+++ b/core/explorer.go
@@ -442,7 +442,7 @@ func (c *Core) UpdateUserInfo(dids []string) {
 				c.log.Error("Failed to send request for user DID, " + did + " Error : " + err.Error())
 				return
 			}
-			if er.Message != "User balance updated successfully!" {
+			if !strings.Contains(er.Message, "successfully") {
 				c.log.Error("Failed to update user info for ", "DID", did, "msg", er.Message)
 			} else {
 				c.log.Info(fmt.Sprintf("%v for did %v", er.Message, did))
@@ -614,7 +614,7 @@ func (c *Core) GenerateUserAPIKey(dids []string) {
 				return
 			}
 			c.ec.AddDIDKey(did, er.APIKey)
-			c.log.Info(er.Message + " for DID " + did)
+			c.log.Info("API key regenerated successfully" + " for DID " + did)
 
 		}(did)
 
@@ -658,7 +658,7 @@ func (ec *ExplorerClient) ExplorerTokenCreateParts(et *ExplorerCreateTokenParts)
 	if err != nil {
 		return err
 	}
-	if er.Message != "Parts Tokens Create successfully!" {
+	if !strings.Contains(er.Message, "successfully") {
 		ec.log.Error("Failed to update explorer", "msg", er.Message)
 		return fmt.Errorf("failed to update explorer")
 	}
@@ -685,7 +685,7 @@ func (ec *ExplorerClient) ExplorerRBTTransaction(et *ExplorerRBTTrans) error {
 	if err != nil {
 		return err
 	}
-	if er.Message != "RBT transaction created successfully!" {
+	if !strings.Contains(er.Message, "successfully") {
 		ec.log.Error("Failed to update explorer", "msg", er.Message)
 		return fmt.Errorf("failed to update explorer")
 	}
@@ -699,7 +699,7 @@ func (ec *ExplorerClient) ExplorerSCTransaction(et *ExplorerSCTrans) error {
 	if err != nil {
 		return err
 	}
-	if er.Message != "SC transaction created successfully!" {
+	if !strings.Contains(er.Message, "successfully") {
 		ec.log.Error("Failed to update explorer", "msg", er.Message)
 		return fmt.Errorf("failed to update explorer")
 	}
@@ -713,7 +713,7 @@ func (ec *ExplorerClient) ExplorerNFTDeploy(et *ExplorerNFTDeploy) error {
 	if err != nil {
 		return err
 	}
-	if er.Message != "NFT transaction created successfully!" {
+	if !strings.Contains(er.Message, "successfully") {
 		ec.log.Error("Failed to update explorer", "msg", er.Message)
 		return fmt.Errorf("failed to update explorer")
 	}
@@ -727,7 +727,7 @@ func (ec *ExplorerClient) ExplorerNFTTransaction(et *ExplorerNFTExecute) error {
 	if err != nil {
 		return err
 	}
-	if er.Message != "NFT transaction created successfully!" {
+	if !strings.Contains(er.Message, "successfully") {
 		ec.log.Error("Failed to update explorer", "msg", er.Message)
 		return fmt.Errorf("failed to update explorer")
 	}
@@ -741,7 +741,7 @@ func (ec *ExplorerClient) ExplorerFTTransaction(et *ExplorerFTTrans) error {
 	if err != nil {
 		return err
 	}
-	if er.Message != "FT transaction created successfully!" {
+	if !strings.Contains(er.Message, "successfully") {
 		ec.log.Error("Failed to update explorer", "msg", er.Message)
 		return fmt.Errorf("failed to update explorer")
 	}

--- a/core/explorer.go
+++ b/core/explorer.go
@@ -22,6 +22,7 @@ const (
 	ExplorerTokenCreateAPI        string = "/api/token/create"
 	ExplorerTokenCreatePartsAPI   string = "/api/token/part/create"
 	ExplorerTokenCreateNFTAPI     string = "/api/token/nft/create"
+	ExplorerTokenCreateSCAPI      string = "/api/token/sc/create"
 	ExplorerCreateUserAPI         string = "/api/user/create"
 	ExplorerUpdateUserInfoAPI     string = "/api/user/update-user-info"
 	ExplorerUpdateTokenInfoAPI    string = "/api/token/update-token-info"
@@ -151,20 +152,36 @@ type ExplorerRBTTrans struct {
 	TransTokenList []Token    `json:"token_list"`
 	Comments       string     `json:"comments"`
 }
-type ExplorerSCTrans struct {
+
+type ExplorerSCDeploy struct {
 	SCTokenHash        string     `json:"sc_token_hash"`
-	SCBlockHash        string     `json:"block_hash"`
+	SCTokenValue       float64    `json:"sc_token_value"`
+	Network            int        `json:"network"`
 	SCBlockNumber      int        `json:"block_number"`
 	TransactionID      string     `json:"transaction_id"`
-	Network            int        `json:"network"`
-	ExecutorDID        string     `json:"executor"`
-	DeployerDID        string     `json:"deployer"`
-	Creator            string     `json:"creator"`
+	SCBlockHash        string     `json:"block_hash"`
+	DeployerDID        string     `json:"deployer_did"`
+	Creator            string     `json:"creator_did"`
 	PledgeAmount       float64    `json:"pledge_amount"`
 	QuorumList         []string   `json:"quorum_list"`
 	PledgeInfo         PledgeInfo `json:"pledge_info"`
 	CommittedTokenList []Token    `json:"token_list"`
 	Comments           string     `json:"comments"`
+}
+
+type ExplorerSCTrans struct {
+	SCTokenHash   string     `json:"sc_token_hash"`
+	SCBlockHash   string     `json:"block_hash"`
+	SCBlockNumber int        `json:"block_number"`
+	TransactionID string     `json:"transaction_id"`
+	Network       int        `json:"network"`
+	ExecutorDID   string     `json:"executor_did"`
+	DeployerDID   string     `json:"deployer_did"`
+	Creator       string     `json:"creator_did"`
+	PledgeAmount  float64    `json:"pledge_amount"`
+	QuorumList    []string   `json:"quorum_list"`
+	PledgeInfo    PledgeInfo `json:"pledge_info"`
+	Comments      string     `json:"comments"`
 }
 
 type ExplorerNFTDeploy struct {
@@ -174,8 +191,8 @@ type ExplorerNFTDeploy struct {
 	NFTValue       float64       `json:"nft_value"`
 	TransactionID  string        `json:"transaction_id"`
 	Network        int           `json:"network"`
-	OwnerDID       string        `json:"owner"`
-	DeployerDID    string        `json:"deployer"`
+	OwnerDID       string        `json:"owner_did"`
+	DeployerDID    string        `json:"deployer_did"`
 	PledgeAmount   float64       `json:"pledge_amount"`
 	QuorumList     []string      `json:"quorum_list"`
 	PledgeInfo     PledgeInfoNFT `json:"pledge_info"`
@@ -184,16 +201,16 @@ type ExplorerNFTDeploy struct {
 
 type ExplorerNFTExecute struct {
 	NFT            string        `json:"nft"`
-	ExecutorDID    string        `json:"executorDID"`
-	ReceiverDID    string        `json:"receiverDID"`
+	ExecutorDID    string        `json:"executor_did"`
+	ReceiverDID    string        `json:"receiver_did"`
 	Network        int           `json:"network"`
 	Comments       string        `json:"comments"`
-	NFTValue       float64       `json:"nftValue"`
-	NFTData        string        `json:"nftData"`
-	NFTBlockHash   string        `json:"blockHash"`
-	NFTBlockNumber int           `json:"blockNumber"`
-	PledgeAmount   float64       `json:"pledgeAmount"`
-	TransactionID  string        `json:"transactionID"`
+	NFTValue       float64       `json:"nft_value"`
+	NFTData        string        `json:"nft_data"`
+	NFTBlockHash   string        `json:"block_hash"`
+	NFTBlockNumber int           `json:"block_number"`
+	PledgeAmount   float64       `json:"pledge_amount"`
+	TransactionID  string        `json:"transaction_id"`
 	Amount         float64       `json:"amount"`
 	QuorumList     []string      `json:"quorumList"`
 	PledgeInfo     PledgeInfoNFT `json:"pledgeInfo"`
@@ -693,6 +710,20 @@ func (ec *ExplorerClient) ExplorerRBTTransaction(et *ExplorerRBTTrans) error {
 		return fmt.Errorf("failed to update explorer")
 	}
 	ec.log.Info(fmt.Sprintf("Transaction details for TransactionID %v is stored successfully", et.TransactionID))
+	return nil
+}
+
+func (ec *ExplorerClient) ExplorerSCDeploy(et *ExplorerSCDeploy) error {
+	var er ExplorerResponse
+	err := ec.SendExplorerJSONRequest("POST", ExplorerTokenCreateSCAPI, et, &er)
+	if err != nil {
+		return err
+	}
+	if !strings.Contains(er.Message, "successfully") {
+		ec.log.Error("Failed to update explorer", "msg", er.Message)
+		return fmt.Errorf("failed to update explorer")
+	}
+	ec.log.Info(fmt.Sprintf("Smart contract transaction details for TransactionID %v is stored successfully", et.TransactionID))
 	return nil
 }
 

--- a/core/ft.go
+++ b/core/ft.go
@@ -553,7 +553,7 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 
 	eTrans := &ExplorerFTTrans{
 		FTBlockHash:     AllTokens,
-		CreatorDID:      []string{creatorDID},
+		CreatorDID:      creatorDID,
 		SenderDID:       did,
 		ReceiverDID:     rdid,
 		FTName:          req.FTName,
@@ -562,7 +562,7 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 		FTSymbol:        "N/A",
 		Comments:        req.Comment,
 		TransactionID:   td.TransactionID,
-		PledgeInfo:      PledgeInfoNFT{PledgeDetails: pds.PledgedTokens, PledgedTokenList: ConvertToNFTTokens(pds.TokenList)},
+		PledgeInfo:      PledgeInfo{PledgeDetails: pds.PledgedTokens, PledgedTokenList: pds.TokenList},
 		QuorumList:      extractQuorumDID(cr.QuorumList),
 		Amount:          FTsForTxn[0].TokenValue * float64(req.FTCount),
 		FTTokenList:     FTTokenIDs,

--- a/core/ft.go
+++ b/core/ft.go
@@ -553,7 +553,7 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 
 	eTrans := &ExplorerFTTrans{
 		FTBlockHash:     AllTokens,
-		CreatorDID:      creatorDID,
+		CreatorDID:      []string{creatorDID},
 		SenderDID:       did,
 		ReceiverDID:     rdid,
 		FTName:          req.FTName,
@@ -562,7 +562,7 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 		FTSymbol:        "TODO",
 		Comments:        req.Comment,
 		TransactionID:   td.TransactionID,
-		PledgeInfo:      PledgeInfo{PledgeDetails: pds.PledgedTokens, PledgedTokenList: pds.TokenList},
+		PledgeInfo:      PledgeInfoNFT{PledgeDetails: pds.PledgedTokens, PledgedTokenList: ConvertToNFTTokens(pds.TokenList)},
 		QuorumList:      extractQuorumDID(cr.QuorumList),
 		Amount:          FTsForTxn[0].TokenValue * float64(req.FTCount),
 		FTTokenList:     FTTokenIDs,

--- a/core/ft.go
+++ b/core/ft.go
@@ -559,7 +559,7 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 		FTName:          req.FTName,
 		FTTransferCount: req.FTCount,
 		Network:         req.QuorumType,
-		FTSymbol:        "TODO",
+		FTSymbol:        "N/A",
 		Comments:        req.Comment,
 		TransactionID:   td.TransactionID,
 		PledgeInfo:      PledgeInfoNFT{PledgeDetails: pds.PledgedTokens, PledgedTokenList: ConvertToNFTTokens(pds.TokenList)},

--- a/core/ipfsport/peer.go
+++ b/core/ipfsport/peer.go
@@ -53,9 +53,9 @@ func NewPeerManager(startPort uint16, lport uint16, maxNumPort uint16, ipfs *ipf
 		_, bsID := path.Split(bs)
 		err := p.ipfs.SwarmConnect(context.Background(), "/ipfs/"+bsID)
 		if err == nil {
-			p.log.Info("Bootstrap swarm connected")
+			p.log.Info(fmt.Sprintf("Bootstrap swarm %v connected", bsID))
 		} else {
-			p.log.Error("Bootstrap swarm failed to connect")
+			p.log.Error(fmt.Sprintf("Bootstrap swarm %v failed to connect, err: %v", bsID, err))
 		}
 	}
 	return p

--- a/core/model/diagnostic.go
+++ b/core/model/diagnostic.go
@@ -42,12 +42,13 @@ type SCTDataReply struct {
 }
 
 type NFTData struct {
-	BlockNo  uint64
-	BlockId  string
-	NFTData  string
-	NFTOwner string
-	NFTValue float64
-	Epoch    int
+	BlockNo       uint64
+	BlockId       string
+	NFTData       string
+	NFTOwner      string
+	NFTValue      float64
+	Epoch         int
+	TransactionID string
 }
 
 type RegisterCallBackUrlReq struct {

--- a/core/model/diagnostic.go
+++ b/core/model/diagnostic.go
@@ -32,12 +32,13 @@ type NFTDataReply struct {
 }
 
 type SCTDataReply struct {
-	BlockNo           uint64
-	BlockId           string
-	SmartContractData string
-	Epoch             int
-	ExecutorSignature string
-	ExecutorDID       string
+	BlockNo            uint64
+	BlockId            string
+	SmartContractData  string
+	Epoch              int
+	InitiatorSignature string
+	ExecutorDID        string
+	InitiatorSignData  string
 }
 
 type NFTData struct {

--- a/core/model/diagnostic.go
+++ b/core/model/diagnostic.go
@@ -36,6 +36,8 @@ type SCTDataReply struct {
 	BlockId           string
 	SmartContractData string
 	Epoch             int
+	ExecutorSignature string
+	ExecutorDID       string
 }
 
 type NFTData struct {

--- a/core/model/nft.go
+++ b/core/model/nft.go
@@ -45,7 +45,7 @@ type DeployNFTRequest struct {
 
 type ExecuteNFTRequest struct {
 	NFT        string  `json:"nft"`
-	Owner      string  `json:"owner"`
+	Executor   string  `json:"executor"`
 	Receiver   string  `json:"receiver"`
 	QuorumType int     `json:"quorum_type"`
 	Comment    string  `json:"comment"`

--- a/core/model/smart_contract.go
+++ b/core/model/smart_contract.go
@@ -5,6 +5,7 @@ type NewContractEvent struct {
 	Did                    string `json:"did"`
 	Type                   int    `json:"type"`
 	SmartContractBlockHash string `json:"smartContractBlockHash"`
+	SmartContractData      string `json:"smartContractData"`
 }
 
 type NewSubscription struct {

--- a/core/nft.go
+++ b/core/nft.go
@@ -252,7 +252,7 @@ func (c *Core) deployNFT(reqID string, deployReq model.DeployNFTRequest) *model.
 
 	c.log.Info("NFT Deployed successfully", "duration", dif)
 	resp.Status = true
-	msg := fmt.Sprintf("NFT Deployed successfully in %v", dif)
+	msg := fmt.Sprintf("NFT Deployed successfully in %v with trnxid %v", dif, txnDetails.TransactionID)
 	resp.Message = msg
 	return resp
 }

--- a/core/nft.go
+++ b/core/nft.go
@@ -243,8 +243,9 @@ func (c *Core) deployNFT(reqID string, deployReq model.DeployNFTRequest) *model.
 		OwnerDID:       nftInfo.OwnerDID,
 		PledgeAmount:   consensusContractDetails.TotalRBTs,
 		QuorumList:     extractQuorumDID(conensusRequest.QuorumList),
-		PledgeInfo:     PledgeInfoNFT{PledgeDetails: pds.PledgedTokens, PledgedTokenList: ConvertToNFTTokens(pds.TokenList)},
+		PledgeInfo:     PledgeInfo{PledgeDetails: pds.PledgedTokens, PledgedTokenList: pds.TokenList},
 		Comments:       txnDetails.Comment,
+		SCTokenHash:    "' '",
 	}
 	explorerErr := c.ec.ExplorerNFTDeploy(eTrans)
 	if explorerErr != nil {
@@ -433,7 +434,8 @@ func (c *Core) executeNFT(reqID string, executeReq *model.ExecuteNFTRequest) *mo
 		PledgeAmount:   consensusContractDetails.TotalRBTs,
 		TransactionID:  txnDetails.TransactionID,
 		QuorumList:     extractQuorumDID(conensusRequest.QuorumList),
-		PledgeInfo:     PledgeInfoNFT{PledgeDetails: pds.PledgedTokens, PledgedTokenList: ConvertToNFTTokens(pds.TokenList)},
+		PledgeInfo:     PledgeInfo{PledgeDetails: pds.PledgedTokens, PledgedTokenList: pds.TokenList},
+		SCTokenHash:    "' '",
 	}
 
 	receiverPeerId := c.w.GetPeerID(executeReq.Receiver)
@@ -449,7 +451,7 @@ func (c *Core) executeNFT(reqID string, executeReq *model.ExecuteNFTRequest) *mo
 
 	explorerErr := c.ec.ExplorerNFTTransaction(eTrans)
 	if explorerErr != nil {
-		c.log.Error("Failed to send FT transaction to explorer ", "err", explorerErr)
+		c.log.Error("Failed to send NFT transaction to explorer ", "err", explorerErr)
 	}
 
 	c.log.Info("NFT Executed successfully", "duration", dif)

--- a/core/nft.go
+++ b/core/nft.go
@@ -223,6 +223,18 @@ func (c *Core) deployNFT(reqID string, deployReq model.DeployNFTRequest) *model.
 		return resp
 	}
 
+	nftTokenDetails := wallet.NFT{
+		TokenID:     nft.TokenID,
+		DID:         nft.DID,
+		TokenStatus: nft.TokenStatus,
+		TokenValue:  floatPrecision(deployReq.NFTValue, MaxDecimalPlaces),
+	}
+
+	if err := c.w.CreateNFT(&nftTokenDetails, true); err != nil {
+		c.log.Error("Failed to write nft to storage in NFTTokenStorage", err)
+		return resp
+	}
+
 	et := time.Now()
 	dif := et.Sub(st)
 	//txnDetails.Amount = deployReq.RBTAmount

--- a/core/nft.go
+++ b/core/nft.go
@@ -422,7 +422,7 @@ func (c *Core) executeNFT(reqID string, executeReq *model.ExecuteNFTRequest) *mo
 	blockNoInt, _ := strconv.Atoi(blockNoPart)
 	//Rename : TODO
 	eTrans := &ExplorerNFTExecute{
-		NFT:            NFTString,
+		NFT:            executeReq.NFT,
 		ExecutorDID:    currentOwner,
 		ReceiverDID:    receiver,
 		Network:        executeReq.QuorumType,
@@ -436,6 +436,7 @@ func (c *Core) executeNFT(reqID string, executeReq *model.ExecuteNFTRequest) *mo
 		QuorumList:     extractQuorumDID(conensusRequest.QuorumList),
 		PledgeInfo:     PledgeInfo{PledgeDetails: pds.PledgedTokens, PledgedTokenList: pds.TokenList},
 		SCTokenHash:    "' '",
+		Amount:         executeReq.NFTValue,
 	}
 
 	receiverPeerId := c.w.GetPeerID(executeReq.Receiver)

--- a/core/nft.go
+++ b/core/nft.go
@@ -233,16 +233,18 @@ func (c *Core) deployNFT(reqID string, deployReq model.DeployNFTRequest) *model.
 	blockNoInt, _ := strconv.Atoi(blockNoPart)
 	//Rename : TODO
 	eTrans := &ExplorerNFTDeploy{
-		NFTBlockHash:  []AllToken{{TokenHash: deployReq.NFT, BlockHash: strings.Split(txnDetails.BlockID, "-")[1], BlockNumber: blockNoInt}},
-		TransactionID: txnDetails.TransactionID,
-		Network:       conensusRequest.Type,
-		NFTValue:      nftInfo.TokenValue,
-		DeployerDID:   did,
-		OwnerDID:      nftInfo.OwnerDID,
-		PledgeAmount:  consensusContractDetails.TotalRBTs,
-		QuorumList:    extractQuorumDID(conensusRequest.QuorumList),
-		PledgeInfo:    PledgeInfoNFT{PledgeDetails: pds.PledgedTokens, PledgedTokenList: ConvertToNFTTokens(pds.TokenList)},
-		Comments:      txnDetails.Comment,
+		NFT:            deployReq.NFT,
+		NFTBlockNumber: blockNoInt,
+		NFTBlockHash:   strings.Split(txnDetails.BlockID, "-")[1],
+		TransactionID:  txnDetails.TransactionID,
+		Network:        conensusRequest.Type,
+		NFTValue:       nftInfo.TokenValue,
+		DeployerDID:    did,
+		OwnerDID:       nftInfo.OwnerDID,
+		PledgeAmount:   consensusContractDetails.TotalRBTs,
+		QuorumList:     extractQuorumDID(conensusRequest.QuorumList),
+		PledgeInfo:     PledgeInfoNFT{PledgeDetails: pds.PledgedTokens, PledgedTokenList: ConvertToNFTTokens(pds.TokenList)},
+		Comments:       txnDetails.Comment,
 	}
 	explorerErr := c.ec.ExplorerNFTDeploy(eTrans)
 	if explorerErr != nil {
@@ -419,18 +421,19 @@ func (c *Core) executeNFT(reqID string, executeReq *model.ExecuteNFTRequest) *mo
 	blockNoInt, _ := strconv.Atoi(blockNoPart)
 	//Rename : TODO
 	eTrans := &ExplorerNFTExecute{
-		NFT:           NFTString,
-		ExecutorDID:   currentOwner,
-		ReceiverDID:   receiver,
-		Network:       executeReq.QuorumType,
-		Comments:      executeReq.Comment,
-		NFTValue:      executeReq.NFTValue,
-		NFTData:       executeReq.NFTData,
-		NFTBlockHash:  []AllToken{{TokenHash: executeReq.NFT, BlockHash: strings.Split(txnDetails.BlockID, "-")[1], BlockNumber: blockNoInt}},
-		PledgeAmount:  consensusContractDetails.TotalRBTs,
-		TransactionID: txnDetails.TransactionID,
-		QuorumList:    extractQuorumDID(conensusRequest.QuorumList),
-		PledgeInfo:    PledgeInfoNFT{PledgeDetails: pds.PledgedTokens, PledgedTokenList: ConvertToNFTTokens(pds.TokenList)},
+		NFT:            NFTString,
+		ExecutorDID:    currentOwner,
+		ReceiverDID:    receiver,
+		Network:        executeReq.QuorumType,
+		Comments:       executeReq.Comment,
+		NFTValue:       executeReq.NFTValue,
+		NFTData:        executeReq.NFTData,
+		NFTBlockNumber: blockNoInt,
+		NFTBlockHash:   strings.Split(txnDetails.BlockID, "-")[1],
+		PledgeAmount:   consensusContractDetails.TotalRBTs,
+		TransactionID:  txnDetails.TransactionID,
+		QuorumList:     extractQuorumDID(conensusRequest.QuorumList),
+		PledgeInfo:     PledgeInfoNFT{PledgeDetails: pds.PledgedTokens, PledgedTokenList: ConvertToNFTTokens(pds.TokenList)},
 	}
 
 	receiverPeerId := c.w.GetPeerID(executeReq.Receiver)

--- a/core/nft.go
+++ b/core/nft.go
@@ -241,12 +241,12 @@ func (c *Core) deployNFT(reqID string, deployReq model.DeployNFTRequest) *model.
 		OwnerDID:      nftInfo.OwnerDID,
 		PledgeAmount:  consensusContractDetails.TotalRBTs,
 		QuorumList:    extractQuorumDID(conensusRequest.QuorumList),
-		PledgeInfo:    PledgeInfo{PledgeDetails: pds.PledgedTokens, PledgedTokenList: pds.TokenList},
+		PledgeInfo:    PledgeInfoNFT{PledgeDetails: pds.PledgedTokens, PledgedTokenList: ConvertToNFTTokens(pds.TokenList)},
 		Comments:      txnDetails.Comment,
 	}
 	explorerErr := c.ec.ExplorerNFTDeploy(eTrans)
 	if explorerErr != nil {
-		c.log.Error("Failed to send FT transaction to explorer ", "err", explorerErr)
+		c.log.Error("Failed to send NFT transaction to explorer ", "err", explorerErr)
 	}
 
 	c.log.Info("NFT Deployed successfully", "duration", dif)
@@ -430,7 +430,7 @@ func (c *Core) executeNFT(reqID string, executeReq *model.ExecuteNFTRequest) *mo
 		PledgeAmount:  consensusContractDetails.TotalRBTs,
 		TransactionID: txnDetails.TransactionID,
 		QuorumList:    extractQuorumDID(conensusRequest.QuorumList),
-		PledgeInfo:    PledgeInfo{PledgeDetails: pds.PledgedTokens, PledgedTokenList: pds.TokenList},
+		PledgeInfo:    PledgeInfoNFT{PledgeDetails: pds.PledgedTokens, PledgedTokenList: ConvertToNFTTokens(pds.TokenList)},
 	}
 
 	receiverPeerId := c.w.GetPeerID(executeReq.Receiver)

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -1426,6 +1426,7 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 			Did:                    sc.GetExecutorDID(),
 			Type:                   ExecuteType,
 			SmartContractBlockHash: newBlockId,
+			SmartContractData:      sc.GetSmartContractData(),
 		}
 
 		err = c.publishNewEvent(&newEvent)

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -382,19 +382,17 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 		return nil, nil, nil, fmt.Errorf("failed to get required quorums")
 	}
 
-	var finalQl []string
-	var errFQL error
+	var activeQuorumLists []string
+
 	if cr.Type == 2 {
-		finalQl, errFQL = c.GetFinalQuorumList(ql)
-		if errFQL != nil {
-			c.log.Error("unable to get consensus from quorum(s). err: ", errFQL)
-			return nil, nil, nil, errFQL
-		}
-		cr.QuorumList = finalQl
-		if len(finalQl) < MinQuorumRequired {
+		activeQuorumLists = c.GetActiveQuorums(ql)
+		c.log.Debug(fmt.Sprintf("Total Active Quorums: %d", len(activeQuorumLists)))
+		if len(activeQuorumLists) < MinQuorumRequired {
 			c.log.Error("quorum(s) are unavailable for this trnx")
 			return nil, nil, nil, fmt.Errorf("quorum(s) are unavailable for this trnx. retry trnx after some time")
 		}
+
+		cr.QuorumList = activeQuorumLists
 	} else {
 		cr.QuorumList = ql
 	}

--- a/core/smart_contract.go
+++ b/core/smart_contract.go
@@ -412,7 +412,9 @@ func (c *Core) ContractCallBack(peerID string, topic string, data []byte) {
 		"smart_contract_hash": newEvent.SmartContractToken,
 		"port":                c.cfg.NodePort,
 		"smart_contract_data": newEvent.SmartContractData,
+		"initiator_did":       newEvent.Did,
 	}
+
 	payLoadBytes, err := json.Marshal(payload)
 	if err != nil {
 		c.log.Error("Failed to marshal JSON", "err", err)

--- a/core/smart_contract.go
+++ b/core/smart_contract.go
@@ -301,18 +301,21 @@ func (c *Core) FetchSmartContract(requestID string, fetchSmartContractRequest *F
 		return basicResponse
 	}
 
-	smartContractOriginPeer, err := c.getPeer(smartContractToken.PeerID + "." + smartContractToken.DID, "")
-	if err != nil {
-		basicResponse.Message = fmt.Sprintf("unable to get the peer for DID: %v, err: %v ", smartContractToken.DID, err)
-		return basicResponse
-	}
+	if smartContractToken.PeerID != "" {
+		smartContractOriginPeer, err := c.getPeer(smartContractToken.PeerID+"."+smartContractToken.DID, "")
+		if err != nil {
+			basicResponse.Message = fmt.Sprintf("unable to get the peer for DID: %v, err: %v ", smartContractToken.DID, err)
+			return basicResponse
+		}
 
-	errSync := c.syncTokenChainFrom(smartContractOriginPeer, "", fetchSmartContractRequest.SmartContractToken, c.TokenType("sc"))
-	if errSync != nil {
-		basicResponse.Message = fmt.Sprintf("unable to sync token chain for contract: %v", fetchSmartContractRequest.SmartContractToken)
-		return basicResponse
+		errSync := c.syncTokenChainFrom(smartContractOriginPeer, "", fetchSmartContractRequest.SmartContractToken, c.TokenType("sc"))
+		if errSync != nil {
+			basicResponse.Message = fmt.Sprintf("unable to sync token chain for contract: %v", fetchSmartContractRequest.SmartContractToken)
+			return basicResponse
+		}
+	} else {
+		c.log.Debug(fmt.Sprintf("Unable to fetch Smart Contract %v deployer's PeerID, skipping token chain sync", fetchSmartContractRequest.SmartContractToken))
 	}
-
 
 	// Set the response values
 	basicResponse.Status = true

--- a/core/smart_contract.go
+++ b/core/smart_contract.go
@@ -45,6 +45,7 @@ type SmartContractToken struct {
 	RawCodeHash    string `json:"rawCodeHash"`
 	SchemaCodeHash string `json:"schemaCodeHash"`
 	DID            string `json:"did"`
+	PeerID         string `json:"peerID"`
 }
 
 type FetchSmartContractRequest struct {
@@ -124,6 +125,7 @@ func (c *Core) generateSmartContractToken(requestID string, smartContractTokenRe
 		RawCodeHash:    rawCodeHash,
 		SchemaCodeHash: schemaCodeHash,
 		DID:            smartContractTokenRequest.DID,
+		PeerID:         c.peerID,
 	}
 
 	if err != nil {
@@ -294,6 +296,23 @@ func (c *Core) FetchSmartContract(requestID string, fetchSmartContractRequest *F
 	}
 
 	err = c.w.CreateSmartContractToken(&wallet.SmartContract{SmartContractHash: fetchSmartContractRequest.SmartContractToken, Deployer: smartContractToken.DID, BinaryCodeHash: smartContractToken.BinaryCodeHash, RawCodeHash: smartContractToken.RawCodeHash, SchemaCodeHash: smartContractToken.SchemaCodeHash, ContractStatus: wallet.TokenIsFetched})
+	if err != nil {
+		basicResponse.Message = "unable to add Smart contract record to DB, err: " + err.Error()
+		return basicResponse
+	}
+
+	smartContractOriginPeer, err := c.getPeer(smartContractToken.PeerID + "." + smartContractToken.DID, "")
+	if err != nil {
+		basicResponse.Message = fmt.Sprintf("unable to get the peer for DID: %v, err: %v ", smartContractToken.DID, err)
+		return basicResponse
+	}
+
+	errSync := c.syncTokenChainFrom(smartContractOriginPeer, "", fetchSmartContractRequest.SmartContractToken, c.TokenType("sc"))
+	if errSync != nil {
+		basicResponse.Message = fmt.Sprintf("unable to sync token chain for contract: %v", fetchSmartContractRequest.SmartContractToken)
+		return basicResponse
+	}
+
 
 	// Set the response values
 	basicResponse.Status = true

--- a/core/smart_contract.go
+++ b/core/smart_contract.go
@@ -411,6 +411,7 @@ func (c *Core) ContractCallBack(peerID string, topic string, data []byte) {
 	payload := map[string]interface{}{
 		"smart_contract_hash": newEvent.SmartContractToken,
 		"port":                c.cfg.NodePort,
+		"smart_contract_data": newEvent.SmartContractData,
 	}
 	payLoadBytes, err := json.Marshal(payload)
 	if err != nil {

--- a/core/smart_contract.go
+++ b/core/smart_contract.go
@@ -302,7 +302,7 @@ func (c *Core) FetchSmartContract(requestID string, fetchSmartContractRequest *F
 	}
 
 	if smartContractToken.PeerID != "" {
-		smartContractOriginPeer, err := c.getPeer(smartContractToken.PeerID+"."+smartContractToken.DID, "")
+		smartContractOriginPeer, err := c.getPeer(smartContractToken.PeerID+"."+smartContractToken.DID)
 		if err != nil {
 			basicResponse.Message = fmt.Sprintf("unable to get the peer for DID: %v, err: %v ", smartContractToken.DID, err)
 			return basicResponse

--- a/core/smart_contract.go
+++ b/core/smart_contract.go
@@ -310,7 +310,7 @@ func (c *Core) FetchSmartContract(requestID string, fetchSmartContractRequest *F
 
 		errSync := c.syncTokenChainFrom(smartContractOriginPeer, "", fetchSmartContractRequest.SmartContractToken, c.TokenType("sc"))
 		if errSync != nil {
-			basicResponse.Message = fmt.Sprintf("unable to sync token chain for contract: %v", fetchSmartContractRequest.SmartContractToken)
+			basicResponse.Message = fmt.Sprintf("unable to sync token chain for contract: %v, err: %v", fetchSmartContractRequest.SmartContractToken, errSync)
 			return basicResponse
 		}
 	} else {

--- a/core/smart_contract_token_operations.go
+++ b/core/smart_contract_token_operations.go
@@ -319,15 +319,6 @@ func (c *Core) executeSmartContractToken(reqID string, executeReq *model.Execute
 	txnDetails.TotalTime = float64(dif.Milliseconds())
 	c.w.AddTransactionHistory(txnDetails)
 
-	// explorerTrans := &ExplorerTrans{
-	// 	TID:         txnDetails.TransactionID,
-	// 	ExecutorDID: did,
-	// 	TrasnType:   conensusRequest.Type,
-	// 	TokenIDs:    tokens,
-	// 	QuorumList:  conensusRequest.QuorumList,
-	// 	TokenTime:   float64(dif.Milliseconds()),
-	// 	//BlockHash:   txnDetails.BlockID,
-	// }
 	blockNoPart := strings.Split(txnDetails.BlockID, "-")[0]
 	// Convert the string part to an int
 	blockNoInt, _ := strconv.Atoi(blockNoPart)

--- a/core/smart_contract_token_operations.go
+++ b/core/smart_contract_token_operations.go
@@ -171,13 +171,13 @@ func (c *Core) deploySmartContractToken(reqID string, deployReq *model.DeploySma
 	// Convert the string part to an int
 	blockNoInt, _ := strconv.Atoi(blockNoPart)
 
-	eTrans := &ExplorerSCTrans{
+	eTrans := &ExplorerSCDeploy{
 		SCTokenHash:        deployReq.SmartContractToken,
+		SCTokenValue:       deployReq.RBTAmount,
 		SCBlockHash:        strings.Split(txnDetails.BlockID, "-")[1],
 		SCBlockNumber:      blockNoInt,
 		TransactionID:      txnDetails.TransactionID,
 		Network:            conensusRequest.Type,
-		ExecutorDID:        "''",
 		DeployerDID:        did,
 		Creator:            did,
 		PledgeAmount:       deployReq.RBTAmount,
@@ -186,7 +186,7 @@ func (c *Core) deploySmartContractToken(reqID string, deployReq *model.DeploySma
 		CommittedTokenList: tokenListForExplorer,
 		Comments:           deployReq.Comment,
 	}
-	c.ec.ExplorerSCTransaction(eTrans)
+	c.ec.ExplorerSCDeploy(eTrans)
 
 	c.log.Info("Smart Contract Token Deployed successfully", "duration", dif)
 	resp.Status = true
@@ -333,19 +333,18 @@ func (c *Core) executeSmartContractToken(reqID string, executeReq *model.Execute
 	blockNoInt, _ := strconv.Atoi(blockNoPart)
 
 	eTrans := &ExplorerSCTrans{
-		SCTokenHash:        executeReq.SmartContractToken,
-		SCBlockHash:        strings.Split(txnDetails.BlockID, "-")[1],
-		SCBlockNumber:      blockNoInt,
-		TransactionID:      txnDetails.TransactionID,
-		Network:            consensusRequest.Type,
-		ExecutorDID:        did,
-		DeployerDID:        smartContractInfo.OwnerDID,
-		Creator:            smartContractInfo.OwnerDID,
-		QuorumList:         extractQuorumDID(consensusRequest.QuorumList),
-		PledgeAmount:       smartContractValue,
-		PledgeInfo:         PledgeInfo{PledgeDetails: pds.PledgedTokens, PledgedTokenList: pds.TokenList},
-		CommittedTokenList: []Token{},
-		Comments:           executeReq.Comment,
+		SCTokenHash:   executeReq.SmartContractToken,
+		SCBlockHash:   strings.Split(txnDetails.BlockID, "-")[1],
+		SCBlockNumber: blockNoInt,
+		TransactionID: txnDetails.TransactionID,
+		Network:       consensusRequest.Type,
+		ExecutorDID:   did,
+		DeployerDID:   smartContractInfo.OwnerDID,
+		Creator:       smartContractInfo.OwnerDID,
+		QuorumList:    extractQuorumDID(consensusRequest.QuorumList),
+		PledgeAmount:  smartContractValue,
+		PledgeInfo:    PledgeInfo{PledgeDetails: pds.PledgedTokens, PledgedTokenList: pds.TokenList},
+		Comments:      executeReq.Comment,
 	}
 	c.ec.ExplorerSCTransaction(eTrans)
 	/* newEvent := model.NewContractEvent{

--- a/core/smart_contract_token_operations.go
+++ b/core/smart_contract_token_operations.go
@@ -177,7 +177,7 @@ func (c *Core) deploySmartContractToken(reqID string, deployReq *model.DeploySma
 		SCBlockNumber:      blockNoInt,
 		TransactionID:      txnDetails.TransactionID,
 		Network:            conensusRequest.Type,
-		ExecutorDID:        "",
+		ExecutorDID:        "''",
 		DeployerDID:        did,
 		Creator:            did,
 		PledgeAmount:       deployReq.RBTAmount,

--- a/core/wallet/nft.go
+++ b/core/wallet/nft.go
@@ -50,17 +50,17 @@ func (w *Wallet) GetNFTsByDid(did string) ([]NFT, error) {
 }
 
 // GetNFT get NFT from db
-func (w *Wallet) GetNFT(did string, nft string, lock bool) (*NFT, error) {
+func (w *Wallet) GetNFT(nft string, lock bool) (*NFT, error) {
 	var tkns NFT
 	w.l.Lock()
 	defer w.l.Unlock()
 	if lock {
-		err := w.s.Read(NFTTokenStorage, &tkns, "did=? AND token_id=? AND token_status <>?", did, nft, TokenIsLocked)
+		err := w.s.Read(NFTTokenStorage, &tkns, "token_id=? AND token_status <>?", nft, TokenIsLocked)
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		err := w.s.Read(NFTTokenStorage, &tkns, "did=? AND token_id=?", did, nft)
+		err := w.s.Read(NFTTokenStorage, &tkns, "token_id=?", nft)
 		if err != nil {
 			return nil, err
 		}
@@ -70,7 +70,7 @@ func (w *Wallet) GetNFT(did string, nft string, lock bool) (*NFT, error) {
 	}
 	if lock {
 		tkns.TokenStatus = TokenIsLocked
-		err := w.s.Update(NFTTokenStorage, &tkns, "did=? AND token_id=?", did, nft)
+		err := w.s.Update(NFTTokenStorage, &tkns, "token_id=?", nft)
 		if err != nil {
 			return nil, err
 		}

--- a/core/wallet/wallet.go
+++ b/core/wallet/wallet.go
@@ -48,7 +48,7 @@ type WalletConfig struct {
 }
 
 type ChainDB struct {
-	leveldb.DB
+	*leveldb.DB
 	l sync.Mutex
 }
 
@@ -86,19 +86,19 @@ func InitWallet(s storage.Storage, dir string, log logger.Logger) (*Wallet, erro
 		w.log.Error("failed to configure token chain block storage", "err", err)
 		return nil, fmt.Errorf("failed to configure token chain block storage")
 	}
-	w.tcs.DB = *tdb
+	w.tcs.DB = tdb
 	ntdb, err := leveldb.OpenFile(dir+NFTChainStorage, op)
 	if err != nil {
 		w.log.Error("failed to configure NFT chain block storage", "err", err)
 		return nil, fmt.Errorf("failed to configure NFT chain block storage")
 	}
-	w.ntcs.DB = *ntdb
+	w.ntcs.DB = ntdb
 	dtdb, err := leveldb.OpenFile(dir+DataChainStorage, op)
 	if err != nil {
 		w.log.Error("failed to configure data chain block storage", "err", err)
 		return nil, fmt.Errorf("failed to configure data chain block storage")
 	}
-	w.dtcs.DB = *dtdb
+	w.dtcs.DB = dtdb
 	err = w.s.Init(DIDStorage, &DIDType{}, true)
 	if err != nil {
 		w.log.Error("Failed to initialize DID storage", "err", err)
@@ -163,14 +163,14 @@ func InitWallet(s storage.Storage, dir string, log logger.Logger) (*Wallet, erro
 		w.log.Error("failed to configure token chain block storage", "err", err)
 		return nil, fmt.Errorf("failed to configure token chain block storage")
 	}
-	w.smartContractTokenChainStorage.DB = *smartcontracTokenchainstorageDB
+	w.smartContractTokenChainStorage.DB = smartcontracTokenchainstorageDB
 
 	FTtokenStorageDB, err := leveldb.OpenFile(dir+FTChainStorage, op)
 	if err != nil {
 		w.log.Error("failed to configure token chain block storage", "err", err)
 		return nil, fmt.Errorf("failed to configure token chain block storage")
 	}
-	w.FTChainStorage.DB = *FTtokenStorageDB
+	w.FTChainStorage.DB = FTtokenStorageDB
 	err = w.s.Init(CallBackUrlStorage, &CallBackUrl{}, true)
 	if err != nil {
 		w.log.Error("Failed to initialize Smart Contract Callback Url storage", "err", err)

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -1369,9 +1369,6 @@ const docTemplate = `{
             "properties": {
                 "did": {
                     "type": "string"
-                },
-                "public_key": {
-                    "type": "string"
                 }
             }
         },
@@ -1604,6 +1601,9 @@ const docTemplate = `{
                 "comment": {
                     "type": "string"
                 },
+                "executor": {
+                    "type": "string"
+                },
                 "nft": {
                     "type": "string"
                 },
@@ -1612,9 +1612,6 @@ const docTemplate = `{
                 },
                 "nft_value": {
                     "type": "number"
-                },
-                "owner": {
-                    "type": "string"
                 },
                 "quorum_type": {
                     "type": "integer"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -1361,9 +1361,6 @@
             "properties": {
                 "did": {
                     "type": "string"
-                },
-                "public_key": {
-                    "type": "string"
                 }
             }
         },
@@ -1596,6 +1593,9 @@
                 "comment": {
                     "type": "string"
                 },
+                "executor": {
+                    "type": "string"
+                },
                 "nft": {
                     "type": "string"
                 },
@@ -1604,9 +1604,6 @@
                 },
                 "nft_value": {
                     "type": "number"
-                },
-                "owner": {
-                    "type": "string"
                 },
                 "quorum_type": {
                     "type": "integer"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -11,8 +11,6 @@ definitions:
     properties:
       did:
         type: string
-      public_key:
-        type: string
     type: object
   model.FTInfo:
     properties:
@@ -164,14 +162,14 @@ definitions:
     properties:
       comment:
         type: string
+      executor:
+        type: string
       nft:
         type: string
       nft_data:
         type: string
       nft_value:
         type: number
-      owner:
-        type: string
       quorum_type:
         type: integer
       receiver:

--- a/server/config.go
+++ b/server/config.go
@@ -40,12 +40,12 @@ func (s *Server) APIAddBootStrap(req *ensweb.Request) *ensweb.Result {
 		s.log.Error("bootstrap Peers required to add")
 		return s.BasicResponse(req, false, "Bootstrap Peers required to add", nil)
 	}
-	for _, peer := range m.Peers {
-		if !strings.HasSuffix(peer, "/") {
-			s.log.Error(fmt.Sprintf("Invalid bootstrap peer : %s", peer))
-			return s.BasicResponse(req, false, "Invalid bootstrap peer", nil)
-		}
-	}
+	// for _, peer := range m.Peers {
+	// 	if !strings.HasSuffix(peer, "/") {
+	// 		s.log.Error(fmt.Sprintf("Invalid bootstrap peer : %s", peer))
+	// 		return s.BasicResponse(req, false, "Invalid bootstrap peer", nil)
+	// 	}
+	// }
 	err = s.c.AddBootStrap(m.Peers)
 	if err != nil {
 		return s.BasicResponse(req, false, "Failed to add bootstrap peers, "+err.Error(), nil)

--- a/server/nft.go
+++ b/server/nft.go
@@ -204,7 +204,7 @@ func (s *Server) APIGetNFTsByDid(req *ensweb.Request) *ensweb.Result {
 
 type ExecuteNFTSwaggoInput struct {
 	NFT        string  `json:"nft"`
-	Owner      string  `json:"owner"`
+	Executor   string  `json:"executor"`
 	Receiver   string  `json:"receiver"`
 	QuorumType int     `json:"quorum_type"`
 	Comment    string  `json:"comment"`
@@ -227,7 +227,7 @@ func (s *Server) APIExecuteNFT(req *ensweb.Request) *ensweb.Result {
 	if err != nil {
 		return s.BasicResponse(req, false, "Invalid input", err)
 	}
-	_, did, ok := util.ParseAddress(executeReq.Owner)
+	_, did, ok := util.ParseAddress(executeReq.Executor)
 	if !ok {
 		return s.BasicResponse(req, false, "Invalid Owner address", nil)
 	}
@@ -237,8 +237,8 @@ func (s *Server) APIExecuteNFT(req *ensweb.Request) *ensweb.Result {
 		return s.BasicResponse(req, false, "Invalid NFT", nil)
 	}
 	is_alphanumeric = regexp.MustCompile(`^[a-zA-Z0-9]*$`).MatchString(did)
-	s.log.Info("The did trying to transfer the nft :", executeReq.Owner)
-	if !strings.HasPrefix(executeReq.Owner, "bafybmi") || len(executeReq.Owner) != 59 || !is_alphanumeric {
+	s.log.Info("The did trying to transfer the nft :", executeReq.Executor)
+	if !strings.HasPrefix(executeReq.Executor, "bafybmi") || len(executeReq.Executor) != 59 || !is_alphanumeric {
 		s.log.Error("Invalid owner DID")
 		return s.BasicResponse(req, false, "Invalid owner DID", nil)
 	}

--- a/server/smart_contract.go
+++ b/server/smart_contract.go
@@ -313,13 +313,13 @@ func (s *Server) APIFetchSmartContract(req *ensweb.Request) *ensweb.Result {
 		}
 	}
 
-	s.c.AddWebReq(req)
-	go func() {
-		basicResponse := s.c.FetchSmartContract(req.ID, &fetchSC)
-		fmt.Printf("Basic Response server:  %+v\n", *&basicResponse.Message)
-	}()
-	return s.BasicResponse(req, true, "Smart contract fetched successfully", nil)
+	basicResponse := s.c.FetchSmartContract("", &fetchSC)
 
+	if !basicResponse.Status {
+		return s.BasicResponse(req, false, fmt.Sprintf("failed to fetch Smart Contract: %v", basicResponse.Message), nil)
+	}
+
+	return s.BasicResponse(req, true, "Smart Contract fetched successfully", nil)
 }
 
 func (s *Server) APIPublishContract(request *ensweb.Request) *ensweb.Result {


### PR DESCRIPTION
Smart Contracts:

- Added the following request parameters during API call being made to callback URL, which avoids the need for recalling Rubix Endpoints from the Contract Linker functions:
  - `smart_contract_data`: Input being passed to the WASM Contract
  - `initiator_did`: DID which initiated the Execute Smart Contract API transaction
 
- Added `initiatorSignature`, `signedMessage` and `initiatorDid` in the `/api/get-smart-contract-token-chain-data` API's reponse

- PeerID has been added in the Smart Contract IPFS Info enabling the Smart Contract fetch operation to sync the token chain as well

NFT:

- Added `transactionID` in the `/api/get-nft-token-chain-data` API's reponse

- Fixed NFT self-execution by allowing non-owner DIDs to execute the NFT which earlier was failing

- Creation of NFT will only involve adding the files to IPFS. Therefore, the action to add new NFT record's into DB has been shifted under Deploy NFT API, making it independed of Create NFT API. @Allen-Cherian  This needs to be replicated for Smart Contract as well.

Other Fixes:

- Under `ChainDB` struct, changed the embedded struct to reference type (from `level.DB` to `*level.DB`). Earlier, the SSTable were not generated because having `level.DB` caused issues with levelDB internal Mutex's state.  This change solves the issue allowing bulk data ( > 12000 records) to be created without any panic issues

- Loggers added in the Rubix Daemon to show peer IDs of Bootstrap nodes that are connected and display errors upon failed attempt to connect.
