### PR TITLE
fixing getalldid issue with DIDs created with CreateDidFromPubKey

### DIFF
--- a/server/did.go
+++ b/server/did.go
@@ -282,6 +282,10 @@ func (s *Server) APICreateDIDFromPubKey(req *ensweb.Request) *ensweb.Result {
 		PubKeyFile: "",
 	}
 
+	if !s.cfg.EnableAuth {
+		didCreate.Dir = DIDRootDir
+	}
+
 	//pass the public key and other required data to create a did
 	did, err := s.c.CreateDIDFromPubKey(&didCreate, didReq.PubKey)
 	if err != nil {


### PR DESCRIPTION
For DIDs created with the api : /api/request-did-for-piubkey, the did_dir column in DIDTable was not being updated as "root". Due to which DID was not treated as native DID while fetching all DIDs of the node using API : /api/getalldid. This PR is resolving this issue by properly enabling verift=ying the native DIDs and updating the did_dir column of those DIDs.