### PR TITLE
Fix errors with FTInfo json variable names

### DIFF
--- a/core/model/ft.go
+++ b/core/model/ft.go
@@ -29,3 +29,9 @@ type FTInfo struct {
 	FTCount    int    `json:"ft_count"`
 	CreatorDID string `json:"creator_did"`
 }
+
+type FTInfoForExplorer struct {
+	FTName     string `json:"ft_symbol"`
+	FTCount    int    `json:"ft_balance"`
+	CreatorDID string `json:"creator_did"`
+}

--- a/core/model/ft.go
+++ b/core/model/ft.go
@@ -25,7 +25,7 @@ type GetFTInfo struct {
 }
 
 type FTInfo struct {
-	FTName     string `json:"ft_symbol"`
-	FTCount    int    `json:"ft_balance"`
+	FTName     string `json:"ft_name"`
+	FTCount    int    `json:"ft_count"`
 	CreatorDID string `json:"creator_did"`
 }


### PR DESCRIPTION
This PR is reverting back the json variable names in the response of the API : /api/get-ft-info-by-did
Reverting variables from 

1. `ft_balance` to `ft_count`
2. `ft_symbol` to `ft_name`

 And keeping the variables intact for Explorer