### PR TITLE
fix: FT tokens now correctly set to pending status on receiver

### DIFF
--- a/core/wallet/ft_receiver_optimized.go
+++ b/core/wallet/ft_receiver_optimized.go
@@ -190,7 +190,7 @@ func (w *Wallet) OptimizedFTTokensReceived(did string, ti []contract.TokenInfo, 
 			CreatorDID:     FTOwner,
 			FTName:         ftInfo.FTName,
 			DID:            did,
-			TokenStatus:    TokenIsFree,
+			TokenStatus:    TokenIsPending,
 			TransactionID:  b.GetTid(),
 			TokenStateHash: tokenHashMap[tokenInfo.Token],
 		}
@@ -238,7 +238,7 @@ func (w *Wallet) OptimizedFTTokensReceived(did string, ti []contract.TokenInfo, 
 		// Update token status
 		FTInfo.FTName = ftInfo.FTName
 		FTInfo.DID = did
-		FTInfo.TokenStatus = TokenIsFree
+		FTInfo.TokenStatus = TokenIsPending
 		FTInfo.TransactionID = b.GetTid()
 		FTInfo.TokenStateHash = tokenHashMap[tokenInfo.Token]
 

--- a/core/wallet/ft_receiver_parallel.go
+++ b/core/wallet/ft_receiver_parallel.go
@@ -640,7 +640,7 @@ func (pfr *ParallelFTReceiver) processSingleToken(
 			CreatorDID:     ftOwner,
 			FTName:         ftInfo.FTName,
 			DID:            did,
-			TokenStatus:    TokenIsFree,
+			TokenStatus:    TokenIsPending,
 			TransactionID:  b.GetTid(),
 			TokenStateHash: hashResult.Hash,
 		}
@@ -693,7 +693,7 @@ func (pfr *ParallelFTReceiver) processSingleToken(
 			
 			ftEntry.FTName = ftInfo.FTName
 			ftEntry.DID = did
-			ftEntry.TokenStatus = TokenIsFree
+			ftEntry.TokenStatus = TokenIsPending
 			ftEntry.TransactionID = b.GetTid()
 			ftEntry.TokenStateHash = hashResult.Hash
 			


### PR DESCRIPTION
FT tokens were incorrectly being set to TokenIsFree status immediately upon receipt, causing token confirmation to fail with 'tokenchain does not exist' error.

Changes:
- OptimizedFTTokensReceived: Set TokenStatus to TokenIsPending for new tokens
- OptimizedFTTokensReceived: Set TokenStatus to TokenIsPending for existing tokens
- ParallelFTTokensReceived: Set TokenStatus to TokenIsPending in both create and update paths
- Regular FTTokensReceived (<=50 tokens) already had correct TokenIsPending status

This ensures FT tokens remain in pending state until consensus finality is confirmed via the token confirmation API.