### PR TITLE
Introduce High-Value FT (HVFT) Support — Create, Transfer & Burn Enhancements

### DIFF
--- a/block/block.go
+++ b/block/block.go
@@ -59,7 +59,8 @@ const (
 	TokenExecutedType     string = "10"
 	TokenContractCommited string = "11"
 	TokenPinnedAsService  string = "12"
-	TokenIsBurntForFT     string = "13"
+	TokenLockedForFT      string = "13"
+	TokenUnlocked         string = "14"
 )
 
 const (
@@ -849,4 +850,13 @@ func (b *Block) GetPledgedTokens() {
 	pledgedInfo := util.GetFromMap(b.bm, TCPledgeDetailsKey)
 	fmt.Println(pledgedInfo)
 	// return
+}
+
+func (b *Block) GetRBTLockStatus(token string) (int, error) {
+	gtm := b.getGenesisTokenMap(token)
+	if gtm == nil {
+		return 0, fmt.Errorf("invalid token chain block, missing genesis block")
+	}
+	status := util.GetIntFromMap(gtm, GIRBTLockStatusKey)
+	return status, nil
 }

--- a/block/genesis.go
+++ b/block/genesis.go
@@ -34,6 +34,12 @@ const (
 	GIGrandParentIDKey      string = "6"
 	GICommitedTokensKey     string = "7"
 	GISmartContractValueKey string = "8"
+	GIRBTLockStatusKey      string = "9"
+)
+
+const (
+	RBTNotLocked int = iota
+	RBTLocked
 )
 
 type GenesisTokenInfo struct {
@@ -48,6 +54,7 @@ type GenesisTokenInfo struct {
 	SmartContractValue float64       `json:"smartContractValue"`
 	NFTValue           float64       `json:"nftValue"`
 	NFTData            string        `json:"nftData"`
+	RBTLockStatus      int           `json:"rbtLockStatus"`
 }
 
 type GenesisBlock struct {
@@ -71,6 +78,7 @@ func newGenesisInfo(gi *GenesisTokenInfo) map[string]interface{} {
 	if gi.GrandParentID != nil {
 		ngib[GIGrandParentIDKey] = gi.GrandParentID
 	}
+	ngib[GIRBTLockStatusKey] = gi.RBTLockStatus
 	//To add commited tokeninfo
 	newCommitedTokensBlock := make(map[string]interface{})
 	for _, tokensInfo := range gi.CommitedTokens {

--- a/client/ft.go
+++ b/client/ft.go
@@ -7,7 +7,7 @@ import (
 	"github.com/rubixchain/rubixgoplatform/setup"
 )
 
-func (c *Client) CreateFT(did string, ftName string, ftCount int, ftValue float64, ftNumStartIndex int, fromRBT bool) (*model.BasicResponse, error) {
+func (c *Client) CreateFT(did string, ftName string, ftCount int, ftValue float64, ftNumStartIndex int, fromRBT bool, isHighValueFt bool) (*model.BasicResponse, error) {
 	createFTReq := model.CreateFTReq{
 		DID:             did,
 		FTName:          ftName,
@@ -15,6 +15,7 @@ func (c *Client) CreateFT(did string, ftName string, ftCount int, ftValue float6
 		FTValue:         ftValue,
 		FTNumStartIndex: ftNumStartIndex,
 		FromRBT:         fromRBT,
+		IsHighValueFT:   isHighValueFt,
 	}
 	var basicresponse model.BasicResponse
 	err := c.sendJSONRequest("POST", setup.APICreateFT, nil, &createFTReq, &basicresponse)

--- a/client/ft.go
+++ b/client/ft.go
@@ -8,6 +8,12 @@ import (
 )
 
 func (c *Client) CreateFT(did string, ftName string, ftCount int, ftValue float64, ftNumStartIndex int, fromRBT bool, isHighValueFt bool) (*model.BasicResponse, error) {
+	// If high-value FT mode is enabled, override ftCount to 1
+	if isHighValueFt {
+		ftCount = 1
+		c.log.Info("High-value FT mode enabled, setting ft_count to 1")
+	}
+
 	createFTReq := model.CreateFTReq{
 		DID:             did,
 		FTName:          ftName,

--- a/client/ft.go
+++ b/client/ft.go
@@ -7,13 +7,14 @@ import (
 	"github.com/rubixchain/rubixgoplatform/setup"
 )
 
-func (c *Client) CreateFT(did string, ftName string, ftCount int, wholeToken int, ftNumStartIndex int) (*model.BasicResponse, error) {
+func (c *Client) CreateFT(did string, ftName string, ftCount int, ftValue float64, ftNumStartIndex int, fromRBT bool) (*model.BasicResponse, error) {
 	createFTReq := model.CreateFTReq{
 		DID:             did,
 		FTName:          ftName,
 		FTCount:         ftCount,
-		TokenCount:      wholeToken,
+		FTValue:         ftValue,
 		FTNumStartIndex: ftNumStartIndex,
+		FromRBT:         fromRBT,
 	}
 	var basicresponse model.BasicResponse
 	err := c.sendJSONRequest("POST", setup.APICreateFT, nil, &createFTReq, &basicresponse)
@@ -56,6 +57,16 @@ func (c *Client) FixFTCreator() (*model.BasicResponse, error) {
 func (c *Client) GetFTCreatorStats() (*model.BasicResponse, error) {
 	var basicresponse model.BasicResponse
 	err := c.sendJSONRequest("GET", setup.APIGetFTCreatorStats, nil, nil, &basicresponse)
+	if err != nil {
+		return nil, err
+	}
+	return &basicresponse, nil
+}
+
+func (c *Client) BurnFT(burnFTReq *model.BurnFTReq) (*model.BasicResponse, error) {
+
+	var basicresponse model.BasicResponse
+	err := c.sendJSONRequest("POST", setup.APIBurnFT, nil, &burnFTReq, &basicresponse)
 	if err != nil {
 		return nil, err
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -369,6 +369,7 @@ type Command struct {
 	backupDB                     bool
 	fromRBT                      bool
 	ftvalue                      float64
+	isHighValueFT                bool
 }
 
 func showVersion() {
@@ -755,7 +756,8 @@ func Run(args []string) {
 	flag.BoolVar(&cmd.disableTrustedNetwork, "disableTrustedNetwork", false, "Disable trusted network mode to enable full DHT checks")
 	flag.BoolVar(&cmd.backupDB, "backupDB", false, "Create backup of database before starting node")
 	flag.BoolVar(&cmd.fromRBT, "fromRBT", false, "Create FT by locking RBT")
-	flag.Float64Var(&cmd.ftvalue, "ftValue", 0.0, "value of the ft to be minted")
+	flag.Float64Var(&cmd.ftvalue, "ftValue", 0.0, "value of the ft to be minted or transferred")
+	flag.BoolVar(&cmd.isHighValueFT, "isHighValueFT", false, "Enable high-value FT transfer mode (uses ftValue for transfer amount)")
 
 	if len(os.Args) < 2 {
 		fmt.Println("Invalid Command")

--- a/command/command.go
+++ b/command/command.go
@@ -113,10 +113,11 @@ const (
 	GetFTTxnDetailsCmd             string = "get-ft-txn-details"
 	ArbitrarySignCmd               string = "sign"
 	VerifySignatureCmd             string = "verify-signature"
-  AsyncFTStatusCmd               string = "asyncftstatus"
+	AsyncFTStatusCmd               string = "asyncftstatus"
 	SetAsyncFTStatusCmd            string = "setasyncftstatus"
 	FixFTCreatorCmd                string = "fix-ft-creator"
 	GetFTCreatorStatsCmd           string = "get-ft-creator-stats"
+	BurnFTCmd                      string = "burn-ft"
 )
 
 var commands = []string{VersionCmd,
@@ -192,6 +193,7 @@ var commands = []string{VersionCmd,
 	SetAsyncFTStatusCmd,
 	FixFTCreatorCmd,
 	GetFTCreatorStatsCmd,
+	BurnFTCmd,
 }
 
 var commandsHelp = []string{"To get tool version",
@@ -264,6 +266,7 @@ var commandsHelp = []string{"To get tool version",
 	"This command will set the async FT response status",
 	"This command will fix FT tokens that have peer ID as CreatorDID",
 	"This command will get statistics about FT token creators",
+	"This command will burn FT",
 }
 
 type Command struct {
@@ -364,6 +367,8 @@ type Command struct {
 	enableTrustedNetwork         bool
 	disableTrustedNetwork        bool
 	backupDB                     bool
+	fromRBT                      bool
+	ftvalue                      float64
 }
 
 func showVersion() {
@@ -749,6 +754,8 @@ func Run(args []string) {
 	flag.BoolVar(&cmd.enableTrustedNetwork, "enableTrustedNetwork", true, "Enable trusted network mode (skips DHT checks) - enabled by default")
 	flag.BoolVar(&cmd.disableTrustedNetwork, "disableTrustedNetwork", false, "Disable trusted network mode to enable full DHT checks")
 	flag.BoolVar(&cmd.backupDB, "backupDB", false, "Create backup of database before starting node")
+	flag.BoolVar(&cmd.fromRBT, "fromRBT", false, "Create FT by locking RBT")
+	flag.Float64Var(&cmd.ftvalue, "ftValue", 0.0, "value of the ft to be minted")
 
 	if len(os.Args) < 2 {
 		fmt.Println("Invalid Command")
@@ -981,6 +988,8 @@ func Run(args []string) {
 		cmd.fixFTCreator()
 	case GetFTCreatorStatsCmd:
 		cmd.getFTCreatorStats()
+	case BurnFTCmd:
+		cmd.burnFT()
 	default:
 		cmd.log.Error("Invalid command")
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -118,7 +118,6 @@ const (
 	SetAsyncFTStatusCmd            string = "setasyncftstatus"
 	FixFTCreatorCmd                string = "fix-ft-creator"
 	GetFTCreatorStatsCmd           string = "get-ft-creator-stats"
-	BurnFTCmd                      string = "burn-ft"
 )
 
 var commands = []string{VersionCmd,
@@ -993,8 +992,6 @@ func Run(args []string) {
 		cmd.fixFTCreator()
 	case GetFTCreatorStatsCmd:
 		cmd.getFTCreatorStats()
-	case BurnFTCmd:
-		cmd.burnFT()
 	default:
 		cmd.log.Error("Invalid command")
 	}

--- a/command/command.go
+++ b/command/command.go
@@ -99,6 +99,7 @@ const (
 	CreateFTCmd                    string = "create-ft"
 	DumpFTTokenChainCmd            string = "dump-ft"
 	TransferFTCmd                  string = "transfer-ft"
+	BurnFTCmd                      string = "burn-ft"
 	GetFTInfoCmd                   string = "get-ft-info-by-did"
 	ValidateTokenCmd               string = "validatetoken"
 	DumpNFTTokenChainCmd           string = "dump-nft-tokenchain"
@@ -945,6 +946,8 @@ func Run(args []string) {
 		cmd.dumpFTTokenchain()
 	case TransferFTCmd:
 		cmd.transferFT()
+	case BurnFTCmd:
+		cmd.burnFT()
 	case GetFTInfoCmd:
 		cmd.getFTinfo()
 	case ValidateTokenCmd:

--- a/command/ft.go
+++ b/command/ft.go
@@ -23,8 +23,16 @@ func (cmd *Command) createFT() {
 		cmd.log.Error("FT Name can't be empty")
 		return
 	}
+
+	// If high-value FT mode is enabled, set ftCount to 1
+	ftCount := cmd.ftCount
+	if cmd.isHighValueFT {
+		ftCount = 1
+		cmd.log.Info("High-value FT mode enabled, setting ft_count to 1")
+	}
+
 	switch {
-	case cmd.ftCount <= 0:
+	case ftCount <= 0:
 		cmd.log.Error("number of tokens to create must be greater than zero")
 		return
 	case cmd.ftvalue < 0.001:
@@ -34,7 +42,7 @@ func (cmd *Command) createFT() {
 		cmd.log.Error("FT value cannot have more than 3 decimal places")
 		return
 	}
-	br, err := cmd.c.CreateFT(cmd.did, cmd.ftName, cmd.ftCount, cmd.ftvalue, cmd.ftNumStartIndex, cmd.fromRBT, false)
+	br, err := cmd.c.CreateFT(cmd.did, cmd.ftName, ftCount, cmd.ftvalue, cmd.ftNumStartIndex, cmd.fromRBT, cmd.isHighValueFT)
 	if err != nil {
 		if strings.Contains(fmt.Sprint(err), "no records found") || strings.Contains(br.Message, "no records found") {
 			cmd.log.Error("Failed to create FT, No RBT available to create FT")

--- a/command/ft.go
+++ b/command/ft.go
@@ -90,9 +90,19 @@ func (cmd *Command) transferFT() {
 			return
 		}
 	}
-	if cmd.ftCount < 1 {
-		cmd.log.Error("Input transaction amount is less than minimum FT transaction amount")
-		return
+	// Validate based on transfer mode
+	if cmd.isHighValueFT {
+		// High-value FT mode: validate transfer value
+		if cmd.ftvalue <= 0 {
+			cmd.log.Error("FT transfer value must be greater than 0 for high-value FT transfer")
+			return
+		}
+	} else {
+		// Standard mode: validate count
+		if cmd.ftCount < 1 {
+			cmd.log.Error("Input transaction amount is less than minimum FT transaction amount")
+			return
+		}
 	}
 	if cmd.ftName == "" {
 		cmd.log.Error("FT name cannot be empty")
@@ -102,13 +112,15 @@ func (cmd *Command) transferFT() {
 		return
 	}
 	transferFtReq := model.TransferFTReq{
-		Receiver:   cmd.receiverAddr,
-		Sender:     cmd.senderAddr,
-		FTName:     cmd.ftName,
-		FTCount:    cmd.ftCount,
-		QuorumType: cmd.transType,
-		Comment:    cmd.transComment,
-		CreatorDID: cmd.creatorDID,
+		Receiver:        cmd.receiverAddr,
+		Sender:          cmd.senderAddr,
+		FTName:          cmd.ftName,
+		FTCount:         cmd.ftCount,
+		QuorumType:      cmd.transType,
+		Comment:         cmd.transComment,
+		CreatorDID:      cmd.creatorDID,
+		IsHighValueFT:   cmd.isHighValueFT,
+		FTTransferValue: cmd.ftvalue,
 	}
 
 	br, err := cmd.c.TransferFT(&transferFtReq)

--- a/command/ft.go
+++ b/command/ft.go
@@ -166,21 +166,21 @@ func (cmd *Command) getFTinfo() {
 
 func (cmd *Command) fixFTCreator() {
 	cmd.log.Info("Starting FT Creator fix utility...")
-	
+
 	// Call the fix FT creator API
 	br, err := cmd.c.FixFTCreator()
 	if err != nil {
 		cmd.log.Error("Failed to fix FT creators", "err", err)
 		return
 	}
-	
+
 	if !br.Status {
 		cmd.log.Error("Failed to fix FT creators", "message", br.Message)
 		return
 	}
-	
+
 	cmd.log.Info("FT Creator fix completed successfully", "message", br.Message)
-	
+
 	// Display results if any
 	if br.Result != nil {
 		if results, ok := br.Result.([]interface{}); ok && len(results) > 0 {
@@ -210,29 +210,29 @@ func (cmd *Command) fixFTCreator() {
 
 func (cmd *Command) getFTCreatorStats() {
 	cmd.log.Info("Getting FT Creator statistics...")
-	
+
 	// Call the get FT creator stats API
 	br, err := cmd.c.GetFTCreatorStats()
 	if err != nil {
 		cmd.log.Error("Failed to get FT creator stats", "err", err)
 		return
 	}
-	
+
 	if !br.Status {
 		cmd.log.Error("Failed to get FT creator stats", "message", br.Message)
 		return
 	}
-	
+
 	// Display statistics
 	if stats, ok := br.Result.(map[string]interface{}); ok {
 		fmt.Println("\n=== FT Creator Statistics ===")
 		fmt.Printf("Total FT Tokens: %v\n", stats["total_tokens"])
-		fmt.Printf("Tokens with Peer ID as Creator: %v (%v)\n", 
+		fmt.Printf("Tokens with Peer ID as Creator: %v (%v)\n",
 			stats["peer_id_creators"], stats["peer_id_percentage"])
 		fmt.Printf("Tokens with DID as Creator: %v\n", stats["did_creators"])
 		fmt.Printf("Tokens with Empty Creator: %v\n", stats["empty_creators"])
 		fmt.Printf("Unique Creators: %v\n", stats["unique_creators"])
-		
+
 		// Display top creators
 		if topCreators, ok := stats["top_creators"].([]interface{}); ok && len(topCreators) > 0 {
 			fmt.Println("\n=== Top Creators ===")
@@ -241,27 +241,56 @@ func (cmd *Command) getFTCreatorStats() {
 					creatorID := c["creator"].(string)
 					count := c["count"]
 					isPeerID := c["is_peer_id"].(bool)
-					
+
 					// Truncate long IDs for display
 					displayID := creatorID
 					if len(displayID) > 50 {
 						displayID = displayID[:47] + "..."
 					}
-					
+
 					typeStr := "DID"
 					if isPeerID {
 						typeStr = "PeerID"
 					}
-					
+
 					fmt.Printf("%d. %s (%s): %v tokens\n", i+1, displayID, typeStr, count)
 				}
 			}
 		}
-		
+
 		// Recommendation
 		if peerIDCount, ok := stats["peer_id_creators"].(float64); ok && peerIDCount > 0 {
 			fmt.Println("\n⚠️  Warning: Found", int(peerIDCount), "tokens with peer ID as creator.")
 			fmt.Println("Run 'rubixgoplatform fix-ft-creator' to fix these tokens.")
 		}
 	}
+}
+
+func (cmd *Command) burnFT() {
+	if cmd.did == "" {
+		cmd.log.Info("DID cannot be empty")
+		return
+	}
+	if cmd.ftName == "" {
+		cmd.log.Info("FT name cannot be empty")
+		return
+	}
+	burnFtReq := model.BurnFTReq{
+		DID:     cmd.did,
+		FTName:  cmd.ftName,
+		FTCount: cmd.ftCount,
+		FromRBT: cmd.fromRBT,
+	}
+	br, err := cmd.c.BurnFT(&burnFtReq)
+	if err != nil {
+		cmd.log.Error("Failed to burn FT", "err", err)
+		return
+	}
+	msg, status := cmd.SignatureResponse(br)
+	if !status {
+		cmd.log.Error("Failed to burn FT", "msg", msg)
+		return
+	}
+	cmd.log.Info("FT burned successfully")
+
 }

--- a/command/ft.go
+++ b/command/ft.go
@@ -2,6 +2,7 @@ package command
 
 import (
 	"fmt"
+	"math"
 	"regexp"
 	"strings"
 
@@ -26,18 +27,14 @@ func (cmd *Command) createFT() {
 	case cmd.ftCount <= 0:
 		cmd.log.Error("number of tokens to create must be greater than zero")
 		return
-	case cmd.rbtAmount <= 0:
-		cmd.log.Error("number of whole tokens must be a positive integer")
+	case cmd.ftvalue < 0.001:
+		cmd.log.Error("FT value must be at least 0.001")
 		return
-	case cmd.ftCount > int(cmd.rbtAmount*1000):
-		cmd.log.Error("max allowed FT count is 1000 for 1 RBT")
-		return
-	}
-	if cmd.rbtAmount != float64(int(cmd.rbtAmount)) {
-		cmd.log.Error("rbtAmount must be a positive integer")
+	case math.Round(cmd.ftvalue*1000) != cmd.ftvalue*1000:
+		cmd.log.Error("FT value cannot have more than 3 decimal places")
 		return
 	}
-	br, err := cmd.c.CreateFT(cmd.did, cmd.ftName, cmd.ftCount, int(cmd.rbtAmount), cmd.ftNumStartIndex)
+	br, err := cmd.c.CreateFT(cmd.did, cmd.ftName, cmd.ftCount, cmd.ftvalue, cmd.ftNumStartIndex, cmd.fromRBT, false)
 	if err != nil {
 		if strings.Contains(fmt.Sprint(err), "no records found") || strings.Contains(br.Message, "no records found") {
 			cmd.log.Error("Failed to create FT, No RBT available to create FT")

--- a/command/ft.go
+++ b/command/ft.go
@@ -275,22 +275,81 @@ func (cmd *Command) getFTCreatorStats() {
 	}
 }
 
+// func (cmd *Command) burnFT() {
+// 	if cmd.did == "" {
+// 		cmd.log.Info("DID cannot be empty")
+// 		return
+// 	}
+// 	if cmd.ftName == "" {
+// 		cmd.log.Info("FT name cannot be empty")
+// 		return
+// 	}
+// 	burnFtReq := model.BurnFTReq{
+// 		DID:     cmd.did,
+// 		FTName:  cmd.ftName,
+// 		FTCount: cmd.ftCount,
+// 		FromRBT: cmd.fromRBT,
+// 	}
+// 	br, err := cmd.c.BurnFT(&burnFtReq)
+// 	if err != nil {
+// 		cmd.log.Error("Failed to burn FT", "err", err)
+// 		return
+// 	}
+// 	msg, status := cmd.SignatureResponse(br)
+// 	if !status {
+// 		cmd.log.Error("Failed to burn FT", "msg", msg)
+// 		return
+// 	}
+// 	cmd.log.Info("FT burned successfully")
+
+// }
+
 func (cmd *Command) burnFT() {
+	// Validate DID
 	if cmd.did == "" {
-		cmd.log.Info("DID cannot be empty")
+		cmd.log.Error("DID cannot be empty")
 		return
 	}
+	isAlphanumericDID := regexp.MustCompile(`^[a-zA-Z0-9]*$`).MatchString(cmd.did)
+	if !isAlphanumericDID {
+		cmd.log.Error("Invalid DID. Please provide valid DID")
+		return
+	}
+	if !strings.HasPrefix(cmd.did, "bafybmi") || len(cmd.did) != 59 {
+		cmd.log.Error("Invalid DID")
+		return
+	}
+
+	// Validate FT name
 	if cmd.ftName == "" {
-		cmd.log.Info("FT name cannot be empty")
+		cmd.log.Error("FT name cannot be empty")
 		return
 	}
-	burnFtReq := model.BurnFTReq{
-		DID:     cmd.did,
-		FTName:  cmd.ftName,
-		FTCount: cmd.ftCount,
-		FromRBT: cmd.fromRBT,
+
+	// Validate based on burn mode
+	if cmd.fromRBT {
+		// FromRBT mode: burn all FTs, ftCount should be 0
+		if cmd.ftCount != 0 {
+			cmd.log.Error("FTCount should be 0 when fromRBT is true")
+			return
+		}
+	} else {
+		// Normal mode: ftCount is required
+		if cmd.ftCount <= 0 {
+			cmd.log.Error("FT count must be greater than 0 when fromRBT is false")
+			return
+		}
 	}
-	br, err := cmd.c.BurnFT(&burnFtReq)
+
+	burnFTReq := model.BurnFTReq{
+		DID:         cmd.did,
+		FTName:      cmd.ftName,
+		FTCount:     cmd.ftCount,
+		FromRBT:     cmd.fromRBT,
+		HighValueFT: cmd.isHighValueFT,
+	}
+
+	br, err := cmd.c.BurnFT(&burnFTReq)
 	if err != nil {
 		cmd.log.Error("Failed to burn FT", "err", err)
 		return
@@ -300,6 +359,5 @@ func (cmd *Command) burnFT() {
 		cmd.log.Error("Failed to burn FT", "msg", msg)
 		return
 	}
-	cmd.log.Info("FT burned successfully")
-
+	cmd.log.Info(msg)
 }

--- a/core/explorer.go
+++ b/core/explorer.go
@@ -483,11 +483,11 @@ func (c *Core) ExplorerUserCreate() []string {
 						ftInfoForExplorer := make([]model.FTInfoForExplorer, len(ftInfo))
 						for i, item := range ftInfo {
 							ftInfoForExplorer[i] = model.FTInfoForExplorer{
-								FTName:       item.FTName,
-								FTCount:      item.FTCount,
-								CreatorDID:   item.CreatorDID,
-								HighValueFT:  item.HighValueFT,
-								FTTotalValue: item.FTTotalValue,
+								FTName:     item.FTName,
+								FTCount:    item.FTCount,
+								CreatorDID: item.CreatorDID,
+								// HighValueFT:  item.HighValueFT,
+								// FTTotalValue: item.FTTotalValue,
 							}
 						}
 						balance := float64(accInfo.RBTAmount) // Convert to float64 if necessary
@@ -562,11 +562,11 @@ func (c *Core) UpdateUserInfo(dids []string) {
 			ftInfoForExplorer := make([]model.FTInfoForExplorer, len(ftInfo))
 			for i, item := range ftInfo {
 				ftInfoForExplorer[i] = model.FTInfoForExplorer{
-					FTName:       item.FTName,
-					FTCount:      item.FTCount,
-					CreatorDID:   item.CreatorDID,
-					HighValueFT:  item.HighValueFT,
-					FTTotalValue: item.FTTotalValue,
+					FTName:     item.FTName,
+					FTCount:    item.FTCount,
+					CreatorDID: item.CreatorDID,
+					// HighValueFT:  item.HighValueFT,
+					// FTTotalValue: item.FTTotalValue,
 				}
 			}
 			_ = c.s.Read(wallet.DIDStorage, &didList, "did=?", did)

--- a/core/explorer.go
+++ b/core/explorer.go
@@ -483,9 +483,11 @@ func (c *Core) ExplorerUserCreate() []string {
 						ftInfoForExplorer := make([]model.FTInfoForExplorer, len(ftInfo))
 						for i, item := range ftInfo {
 							ftInfoForExplorer[i] = model.FTInfoForExplorer{
-								FTName:     item.FTName,
-								FTCount:    item.FTCount,
-								CreatorDID: item.CreatorDID,
+								FTName:       item.FTName,
+								FTCount:      item.FTCount,
+								CreatorDID:   item.CreatorDID,
+								HighValueFT:  item.HighValueFT,
+								FTTotalValue: item.FTTotalValue,
 							}
 						}
 						balance := float64(accInfo.RBTAmount) // Convert to float64 if necessary
@@ -560,9 +562,11 @@ func (c *Core) UpdateUserInfo(dids []string) {
 			ftInfoForExplorer := make([]model.FTInfoForExplorer, len(ftInfo))
 			for i, item := range ftInfo {
 				ftInfoForExplorer[i] = model.FTInfoForExplorer{
-					FTName:     item.FTName,
-					FTCount:    item.FTCount,
-					CreatorDID: item.CreatorDID,
+					FTName:       item.FTName,
+					FTCount:      item.FTCount,
+					CreatorDID:   item.CreatorDID,
+					HighValueFT:  item.HighValueFT,
+					FTTotalValue: item.FTTotalValue,
 				}
 			}
 			_ = c.s.Read(wallet.DIDStorage, &didList, "did=?", did)

--- a/core/ft.go
+++ b/core/ft.go
@@ -60,8 +60,11 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, FTValue float6
 		return fmt.Errorf("DID crypto is not initialized, err: %v ", err)
 	}
 
-	var ftStartIndex int
-	ftStartIndex = ftNumStartIndex
+	// Compute a unique start index using FTIndexTable to avoid token_id collisions
+	ftStartIndex, err := c.allocateFTIndices(FTName, did, numFTs)
+	if err != nil {
+		return fmt.Errorf("failed to allocate FT indices: %w", err)
+	}
 
 	// Validate input parameters
 
@@ -419,6 +422,32 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, FTValue float6
 		return err
 	}
 	return nil
+}
+
+// allocateFTIndices atomically reserves a range of FT numbers for (ft_name, creator_did)
+func (c *Core) allocateFTIndices(ftName string, creatorDid string, num int) (int, error) {
+	// Read or create the FTIndex row
+	var idx wallet.FTIndex
+	readErr := c.s.Read(wallet.FTIndexStorage, &idx, "ft_name=? AND creator_did=?", ftName, creatorDid)
+	if readErr != nil && !strings.Contains(fmt.Sprint(readErr), "no records found") {
+		return 0, readErr
+	}
+	start := 0
+	if readErr == nil {
+		start = idx.FTIndex
+		idx.FTIndex = idx.FTIndex + num
+		if err := c.s.Update(wallet.FTIndexStorage, &idx, "ft_name=? AND creator_did=?", ftName, creatorDid); err != nil {
+			return 0, err
+		}
+	} else {
+		// Insert new row with end = num
+		idx = wallet.FTIndex{FTName: ftName, CreatorDID: creatorDid, FTIndex: num}
+		if err := c.s.Write(wallet.FTIndexStorage, &idx); err != nil {
+			return 0, err
+		}
+		start = 0
+	}
+	return start, nil
 }
 
 // setFTHighValueFlag upserts only the HighValueFT flag for a given (ft_name, creator_did)

--- a/core/ft.go
+++ b/core/ft.go
@@ -27,6 +27,7 @@ import (
 )
 
 func (c *Core) CreateFTs(reqID string, did string, ftcount int, ftname string, ftValue float64, ftNumStartIndex int, fromRBT bool, isHighValueFt bool) {
+	// Removed legacy backfill: rbt_lock_status now defaults to 1 via GORM default
 	err := c.createFTs(reqID, ftname, ftcount, ftValue, did, ftNumStartIndex, fromRBT, isHighValueFt)
 	br := model.BasicResponse{
 		Status:  true,
@@ -248,13 +249,14 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, FTValue float6
 				continue
 			}
 			ft := wallet.FTToken{
-				TokenID:     ftID,
-				FTName:      FTName,
-				TokenStatus: wallet.TokenIsFree,
-				TokenValue:  FTValue,
-				DID:         did,
-				CreatedAt:   time.Now(),
-				UpdatedAt:   time.Now(),
+				TokenID:       ftID,
+				FTName:        FTName,
+				TokenStatus:   wallet.TokenIsFree,
+				TokenValue:    FTValue,
+				DID:           did,
+				RBTLockStatus: RBTLockStatus,
+				CreatedAt:     time.Now(),
+				UpdatedAt:     time.Now(),
 			}
 			results <- ftResult{FTToken: ft, FTID: ftID}
 		}
@@ -427,6 +429,8 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, FTValue float6
 	return nil
 }
 
+// Legacy backfill removed as column default is set to 1 in schema
+
 func (c *Core) GetFTInfoByDID(did string) ([]model.FTInfo, error) {
 	if !c.w.IsDIDExist(did) {
 		c.log.Error("DID does not exist")
@@ -435,7 +439,7 @@ func (c *Core) GetFTInfoByDID(did string) ([]model.FTInfo, error) {
 	FT, err := c.w.GetFTsAndCount(did)
 	if err != nil && err.Error() != "no records found" {
 		c.log.Error("Failed to get tokens FTs and Count", "err", err)
-		return []model.FTInfo{}, fmt.Errorf("Failed to get tokens FTs and Count")
+		return []model.FTInfo{}, fmt.Errorf("failed to get tokens FTs and Count")
 	}
 	// Build map keyed by ft_name -> creator_did with count and total value
 	type FTBalanceSummary struct {

--- a/core/ft.go
+++ b/core/ft.go
@@ -282,7 +282,7 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, numWholeTokens
 			Comment: "Token burnt at : " + time.Now().String(),
 		}
 		tcb := &block.TokenChainBlock{
-			TransactionType: block.TokenIsBurntForFT,
+			TransactionType: block.TokenLockedForFT,
 			TokenOwner:      did,
 			TransInfo:       bti,
 			TokenValue:      wholeTokens[i].TokenValue,
@@ -434,18 +434,18 @@ func (c *Core) InitiateFTTransfer(reqID string, req *model.TransferFTReq) {
 func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model.BasicResponse {
 	st := time.Now()
 	txEpoch := int(st.Unix())
-	
+
 	// Track overall FT transaction performance
 	var txErr error
 	defer func() {
 		c.TrackOperation("tx.ft_transfer.total", map[string]interface{}{
-			"sender": req.Sender,
+			"sender":   req.Sender,
 			"receiver": req.Receiver,
 			"ft_count": req.FTCount,
-			"ft_name": req.FTName,
+			"ft_name":  req.FTName,
 		})(txErr)
 	}()
-	
+
 	resp := &model.BasicResponse{
 		Status: false,
 	}
@@ -533,14 +533,14 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 	var AllFTs []wallet.FTToken
 	var TokenInfo []contract.TokenInfo
 	var lockingErr error
-	
+
 	if req.CreatorDID != "" {
 		AllFTs, err = c.w.GetFreeFTsByNameAndCreatorDID(req.FTName, did, req.CreatorDID)
 		creatorDID = req.CreatorDID
 	} else {
 		AllFTs, err = c.w.GetFreeFTsByNameAndDID(req.FTName, did)
 	}
-	
+
 	AvailableFTCount := len(AllFTs)
 	if err != nil {
 		c.log.Error("Failed to get FTs", "err", err)
@@ -553,9 +553,9 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 			return resp
 		}
 	}
-	
+
 	FTsForTxn := AllFTs[:req.FTCount]
-	
+
 	// Fetching peer's peer id
 	if !c.w.IsDIDExist(req.Receiver) {
 		peerInfo, err := c.GetPeerDIDInfo(req.Receiver)
@@ -575,7 +575,7 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 			return resp
 		}
 	}
-	
+
 	receiverPeerID, err := c.getPeer(req.Receiver)
 	if err != nil {
 		resp.Message = "Failed to get receiver peer, " + err.Error()
@@ -626,7 +626,7 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 			TokenInfo = append(TokenInfo, ti)
 		}
 	}
-	
+
 	// Extract token IDs for later use
 	FTTokenIDs := make([]string, 0)
 	for i := range TokenInfo {
@@ -718,13 +718,13 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 			resp.Message = errMsg
 			return
 		}
-		
+
 		// Store in new FT transaction history table
 		if err := c.w.AddFTTransactionHistory(td, req.FTName, creatorDID, req.FTCount); err != nil {
 			c.log.Error("Failed to store FT transaction history", "err", err)
 			// Don't fail the transaction, just log the error
 		}
-		
+
 		// Store FT token metadata for sent transactions
 		if err := c.w.AddFTTransactionTokens(td.TransactionID, creatorDID, req.FTName, req.FTCount, "sent"); err != nil {
 			c.log.Error("Failed to store FT transaction token metadata", "err", err)
@@ -733,15 +733,15 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 
 		// Create a channel to signal explorer submission completion
 		explorerDone := make(chan struct{})
-		
-		go func ()  {
+
+		go func() {
 			defer close(explorerDone) // Signal completion when done
-			
+
 			AllTokens := make([]AllToken, len(TokenInfo))
 			for i := range TokenInfo {
 				tokenDetail := AllToken{}
 				tokenDetail.TokenHash = TokenInfo[i].Token
-				
+
 				blockNoPart := strings.Split(TokenInfo[i].BlockID, "-")[0]
 				// Convert the string part to an int
 				blockNoInt, err := strconv.Atoi(blockNoPart)
@@ -751,7 +751,7 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 				}
 				tokenDetail.BlockNumber = blockNoInt
 				tokenDetail.BlockHash = strings.Split(TokenInfo[i].BlockID, "-")[1]
-	
+
 				AllTokens[i] = tokenDetail
 			}
 
@@ -774,7 +774,7 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 			c.ec.ExplorerFTTransaction(eTrans)
 			c.log.Info("Explorer submission completed", "transaction_id", td.TransactionID)
 		}()
-		
+
 		// Pass the explorerDone channel to consensus request
 		cr.ExplorerDone = explorerDone
 
@@ -793,7 +793,7 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 			c.log.Error("Failed to update FT table after transfer ", "err", updateFTTableErr)
 			resp.Message = "Failed to update FT table after transfer"
 			return
-		}		
+		}
 		c.UpdateUserInfo([]string{did})
 		// Send final transaction completion response if not already timed out
 		select {

--- a/core/ft.go
+++ b/core/ft.go
@@ -429,41 +429,43 @@ func (c *Core) allocateFTIndices(ftName string, creatorDid string, num int) (int
 	// Read or create the FTIndex row
 	var idx wallet.FTIndex
 	readErr := c.s.Read(wallet.FTIndexStorage, &idx, "ft_name=? AND creator_did=?", ftName, creatorDid)
-	if readErr != nil && !strings.Contains(fmt.Sprint(readErr), "no records found") {
-		return 0, readErr
-	}
-	start := 0
-	if readErr == nil {
-		start = idx.FTIndex
-		idx.FTIndex = idx.FTIndex + num
-		if err := c.s.Update(wallet.FTIndexStorage, &idx, "ft_name=? AND creator_did=?", ftName, creatorDid); err != nil {
-			return 0, err
+	if readErr != nil {
+		// If the index table/row is missing, fall back to scanning existing tokens
+		errStr := fmt.Sprint(readErr)
+		if !(strings.Contains(errStr, "no records found") || strings.Contains(errStr, "no such table")) {
+			return 0, readErr
 		}
-	} else {
-		// Fallback: derive start by scanning existing FT tokens for this (ft_name, creator_did)
-		var existingTokens []wallet.FTToken
-		// Prefer CreatorDID filter; owner_did may also match creator in our flows
-		_ = c.s.Read(wallet.FTTokenStorage, &existingTokens, "ft_name=? AND (creator_did=? OR owner_did=?)", ftName, creatorDid, creatorDid)
+	}
+	// Always compute the derived maximum from existing tokens to avoid stale index collisions
+	var existingTokens []wallet.FTToken
+	_ = c.s.Read(wallet.FTTokenStorage, &existingTokens, "ft_name=? AND (creator_did=? OR owner_did=?)", ftName, creatorDid, creatorDid)
 
-		maxNum := -1
-		for i := range existingTokens {
-			// token_id format: FTName <num> DID (assuming FTName has no spaces)
-			parts := strings.Split(existingTokens[i].TokenID, " ")
-			if len(parts) >= 3 {
-				if n, convErr := strconv.Atoi(parts[1]); convErr == nil {
-					if n > maxNum {
-						maxNum = n
-					}
+	maxNum := -1
+	for i := range existingTokens {
+		// token_id format: FTName <num> DID
+		parts := strings.Split(existingTokens[i].TokenID, " ")
+		if len(parts) >= 3 {
+			if n, convErr := strconv.Atoi(parts[1]); convErr == nil {
+				if n > maxNum {
+					maxNum = n
 				}
 			}
 		}
-		start = maxNum + 1
-		// Insert new FTIndex row with end = start + num
-		idx = wallet.FTIndex{FTName: ftName, CreatorDID: creatorDid, FTIndex: start + num}
-		if err := c.s.Write(wallet.FTIndexStorage, &idx); err != nil {
-			// If FTIndex table doesn't exist or write fails, proceed without persisting; caller will still get a unique start
-			// Next call will recompute via fallback again
-		}
+	}
+
+	start := maxNum + 1
+	// If an index row exists and is ahead of derived start, honor it
+	if readErr == nil && idx.FTIndex > start {
+		start = idx.FTIndex
+	}
+
+	// Persist updated end if the table exists (ignore write errors)
+	newEnd := start + num
+	if readErr == nil {
+		idx.FTIndex = newEnd
+		_ = c.s.Update(wallet.FTIndexStorage, &idx, "ft_name=? AND creator_did=?", ftName, creatorDid)
+	} else {
+		_ = c.s.Write(wallet.FTIndexStorage, &wallet.FTIndex{FTName: ftName, CreatorDID: creatorDid, FTIndex: newEnd})
 	}
 	return start, nil
 }

--- a/core/ft.go
+++ b/core/ft.go
@@ -189,9 +189,10 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, FTValue float6
 				}
 			}
 
-			RBTLockStatus := block.RBTNotLocked
-			if fromRBT && !isHighValueFt {
-				RBTLockStatus = block.RBTLocked
+			// Default lock status is Locked (1). For high-value FT created without RBT, set NotLocked (0).
+			RBTLockStatus := block.RBTLocked
+			if isHighValueFt && !fromRBT {
+				RBTLockStatus = block.RBTNotLocked
 			}
 
 			bti := &block.TransInfo{
@@ -404,6 +405,12 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, FTValue float6
 		return err
 	}
 
+	// Set/ensure HighValueFT flag for this FT (preserved during refresh)
+	if setErr := c.setFTHighValueFlag(FTName, did, isHighValueFt); setErr != nil {
+		c.log.Error("Failed to set HighValueFT flag before refresh", "err", setErr)
+		// continue; non-fatal
+	}
+
 	// Refresh FTTable using full recompute to ensure IDs are populated
 	// Here the main issue is that, the ID in this table is string, which ideally should be integer. inorder to maintain backward compatibility we had to use this function.
 	// This needs to be updated such that the existing table will get migrated or some work around needs to be done.
@@ -412,6 +419,29 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, FTValue float6
 		return err
 	}
 	return nil
+}
+
+// setFTHighValueFlag upserts only the HighValueFT flag for a given (ft_name, creator_did)
+func (c *Core) setFTHighValueFlag(ftName string, creatorDid string, isHigh bool) error {
+	var existingFt wallet.FT
+	err := c.s.Read(wallet.FTStorage, &existingFt, "ft_name=? AND creator_did=?", ftName, creatorDid)
+	if err != nil {
+		if strings.Contains(fmt.Sprint(err), "no records found") {
+			// Insert minimal row so refresh can preserve the flag
+			newFT := &wallet.FT{
+				FTName:      ftName,
+				CreatorDID:  creatorDid,
+				HighValueFT: isHigh,
+			}
+			if writeErr := c.s.Write(wallet.FTStorage, newFT); writeErr != nil {
+				return writeErr
+			}
+			return nil
+		}
+		return err
+	}
+	existingFt.HighValueFT = isHigh
+	return c.s.Update(wallet.FTStorage, &existingFt, "ft_name=? AND creator_did=?", ftName, creatorDid)
 }
 
 func (c *Core) GetFTInfoByDID(did string) ([]model.FTInfo, error) {
@@ -1005,6 +1035,17 @@ func (c *Core) updateFTTable() error {
 			return err
 		}
 	}
+	// Read existing FTTable to preserve HighValueFT flags
+	var existing []wallet.FT
+	_ = c.s.Read(wallet.FTStorage, &existing, "1 = 1")
+	hvftMap := make(map[string]map[string]bool)
+	for i := range existing {
+		if hvftMap[existing[i].FTName] == nil {
+			hvftMap[existing[i].FTName] = make(map[string]bool)
+		}
+		hvftMap[existing[i].FTName][existing[i].CreatorDID] = existing[i].HighValueFT
+	}
+
 	err = c.s.Delete(wallet.FTStorage, &wallet.FT{}, "ft_name!=?", "")
 	ReadErr := fmt.Sprint(err)
 	if err != nil {
@@ -1015,6 +1056,10 @@ func (c *Core) updateFTTable() error {
 		return err
 	}
 	for _, Ft := range AllFTs {
+		// Preserve HighValueFT from previous table if available
+		if hvftMap[Ft.FTName] != nil {
+			Ft.HighValueFT, _ = hvftMap[Ft.FTName][Ft.CreatorDID]
+		}
 		addErr := c.s.Write(wallet.FTStorage, &Ft)
 		if addErr != nil {
 			c.log.Error("Failed to add new FT:", Ft.FTName, "Error:", addErr)

--- a/core/ft.go
+++ b/core/ft.go
@@ -24,8 +24,8 @@ import (
 	"github.com/rubixchain/rubixgoplatform/wrapper/uuid"
 )
 
-func (c *Core) CreateFTs(reqID string, did string, ftcount int, ftname string, wholeToken int, ftNumStartIndex int) {
-	err := c.createFTs(reqID, ftname, ftcount, wholeToken, did, ftNumStartIndex)
+func (c *Core) CreateFTs(reqID string, did string, ftcount int, ftname string, ftValue float64, ftNumStartIndex int, fromRBT bool, isHighValueFt bool) {
+	err := c.createFTs(reqID, ftname, ftcount, ftValue, did, ftNumStartIndex, fromRBT, isHighValueFt)
 	br := model.BasicResponse{
 		Status:  true,
 		Message: "FT created successfully",
@@ -42,7 +42,7 @@ func (c *Core) CreateFTs(reqID string, did string, ftcount int, ftname string, w
 	channel.OutChan <- &br
 }
 
-func (c *Core) createFTs(reqID string, FTName string, numFTs int, numWholeTokens int, did string, ftNumStartIndex int) error {
+func (c *Core) createFTs(reqID string, FTName string, numFTs int, FTValue float64, did string, ftNumStartIndex int, fromRBT bool, isHighValueFt bool) error {
 	if did == "" {
 		c.log.Error("DID is empty")
 		return fmt.Errorf("DID is empty")
@@ -58,44 +58,63 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, numWholeTokens
 		return fmt.Errorf("DID crypto is not initialized, err: %v ", err)
 	}
 
-	// var FT []wallet.FT
+	var existingFT wallet.FT
+	readErr := c.s.Read(wallet.FTStorage, &existingFT, "ft_name=? AND creator_did=?", FTName, did)
+	if readErr != nil {
+		c.log.Info("There is no record for FT Name: %s and creator DID: %s", FTName, did)
+	}
 
-	// c.s.Read(wallet.FTStorage, &FT, "ft_name=? AND creator_did=?", FTName, did)
-
-	// if len(FT) != 0 {
-	// 	c.log.Error("FT Name already exists")
-	// 	return fmt.Errorf("FT Name already exists")
-	// }
+	var ftStartIndex int
+	if readErr != nil && strings.Contains(fmt.Sprint(readErr), "no records found") {
+		c.log.Info("FT Name does not exist")
+		ftStartIndex = ftNumStartIndex
+	} else if readErr == nil {
+		c.log.Info("FT Name already exists")
+		ftStartIndex = existingFT.FTCreatedCount
+	} else {
+		c.log.Error("Error checking for existing FT record during creation setup", "err", readErr)
+		return fmt.Errorf("failed to check existing FT record: %w", readErr)
+	}
 
 	// Validate input parameters
 
 	switch {
 	case numFTs <= 0:
 		return fmt.Errorf("number of tokens to create must be greater than zero")
-	case numWholeTokens <= 0:
-		return fmt.Errorf("number of whole tokens must be a positive integer")
-	case numFTs > int(numWholeTokens*1000):
-		return fmt.Errorf("max allowed FT count is 1000 for 1 RBT")
+	case FTValue < 0.001:
+		return fmt.Errorf("FT value must be at least 0.001")
+	case math.Round(FTValue*1000) != FTValue*1000:
+		return fmt.Errorf("FT value cannot have more than 3 decimal places")
 	}
 
-	// Fetch whole tokens using GetToken
-	wholeTokens, err := c.GetTokens(dc, did, float64(numWholeTokens), 0)
-	if err != nil || wholeTokens == nil {
-		c.log.Error("Failed to fetch whole token for FT creation")
-		return err
-	}
-	defer c.w.ReleaseTokens(wholeTokens)
-	fractionalValue, err := c.GetPresiceFractionalValue(int(numWholeTokens), numFTs)
-	if err != nil {
-		c.log.Error("Failed to calculate FT token value", err)
-		return err
-	}
-
+	var wholeTokens []wallet.Token
+	var parentTokenIDs string
 	var parentTokenIDsArray []string
-	for _, token := range wholeTokens {
-		parentTokenIDsArray = append(parentTokenIDsArray, token.TokenID)
+
+	if fromRBT && !isHighValueFt {
+		numTokensRequired := FTValue * float64(numFTs)
+		numWholeTokens := floatPrecision(numTokensRequired, MaxDecimalPlaces)
+
+		wholeTokens, err = c.GetTokens(dc, did, numWholeTokens, 0)
+		if err != nil {
+			c.log.Error("Failed to fetch whole token for FT creation, RBTs required are: %v", numWholeTokens)
+			return err
+		}
+		if wholeTokens == nil {
+			return fmt.Errorf("no tokens available for FT creation")
+		}
+		defer c.w.ReleaseTokens(wholeTokens)
+
+		for _, token := range wholeTokens {
+			parentTokenIDsArray = append(parentTokenIDsArray, token.TokenID)
+		}
+		parentTokenIDs = strings.Join(parentTokenIDsArray, ",")
 	}
-	parentTokenIDs := strings.Join(parentTokenIDsArray, ",")
+
+	loopCount := numFTs
+	if isHighValueFt {
+		loopCount = 1
+	}
 
 	type ftJob struct {
 		Index int
@@ -107,8 +126,8 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, numWholeTokens
 	}
 
 	numWorkers := runtime.NumCPU()
-	jobs := make(chan ftJob, numFTs)
-	results := make(chan ftResult, numFTs)
+	jobs := make(chan ftJob, loopCount)
+	results := make(chan ftResult, loopCount)
 	var wg sync.WaitGroup
 
 	var completed int32
@@ -134,7 +153,7 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, numWholeTokens
 					Parents: parentTokenIDs,
 					FTNum:   i,
 					FTName:  FTName,
-					FTValue: fractionalValue,
+					FTValue: FTValue,
 				},
 			}
 
@@ -169,13 +188,23 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, numWholeTokens
 			providerMapMutex.Lock()
 			providerMaps = append(providerMaps, tpm)
 			providerMapMutex.Unlock()
-			// Progress logging (remove per-token log)
+			// Progress logging
 			newCount := atomic.AddInt32(&completed, 1)
-			currentPercent := int32(math.Floor(float64(newCount*100) / float64(numFTs)))
-			if currentPercent%10 == 0 && atomic.LoadInt32(&lastLoggedPercent) < currentPercent {
-				if atomic.CompareAndSwapInt32(&lastLoggedPercent, lastLoggedPercent, currentPercent) {
-					c.log.Info(fmt.Sprintf("FT creation progress: %d%% (%d/%d created)", currentPercent, newCount, numFTs))
+			if isHighValueFt {
+				c.log.Info(fmt.Sprintf("Creating high-value FT: %s", FTName))
+			} else {
+				currentPercent := int32(math.Floor(float64(newCount*100) / float64(loopCount)))
+				if currentPercent%10 == 0 && atomic.LoadInt32(&lastLoggedPercent) < currentPercent {
+					oldPercent := atomic.LoadInt32(&lastLoggedPercent)
+					if atomic.CompareAndSwapInt32(&lastLoggedPercent, oldPercent, currentPercent) {
+						c.log.Info(fmt.Sprintf("FT creation progress: %d%% (%d/%d created)", currentPercent, newCount, loopCount))
+					}
 				}
+			}
+
+			RBTLockStatus := block.RBTNotLocked
+			if fromRBT && !isHighValueFt {
+				RBTLockStatus = block.RBTLocked
 			}
 
 			bti := &block.TransInfo{
@@ -191,12 +220,13 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, numWholeTokens
 				TransInfo:       bti,
 				GenesisBlock: &block.GenesisBlock{
 					Info: []block.GenesisTokenInfo{{
-						Token:       ftID,
-						ParentID:    parentTokenIDs,
-						TokenNumber: i,
+						Token:         ftID,
+						ParentID:      parentTokenIDs,
+						TokenNumber:   i,
+						RBTLockStatus: RBTLockStatus,
 					}},
 				},
-				TokenValue: fractionalValue,
+				TokenValue: FTValue,
 			}
 			ctcb := make(map[string]*block.Block)
 			ctcb[ftID] = nil
@@ -219,7 +249,7 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, numWholeTokens
 				TokenID:     ftID,
 				FTName:      FTName,
 				TokenStatus: wallet.TokenIsFree,
-				TokenValue:  fractionalValue,
+				TokenValue:  FTValue,
 				DID:         did,
 				CreatedAt:   time.Now(),
 				UpdatedAt:   time.Now(),
@@ -235,16 +265,16 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, numWholeTokens
 	}
 
 	// Enqueue jobs
-	for i := ftNumStartIndex; i < ftNumStartIndex+numFTs; i++ {
+	for i := ftStartIndex; i < ftStartIndex+loopCount; i++ {
 		jobs <- ftJob{Index: i}
 	}
 	close(jobs)
 
 	// Collect results
-	newFTs := make([]wallet.FTToken, 0, numFTs)
+	newFTs := make([]wallet.FTToken, 0, loopCount)
 	var newFTTokenIDs []string
 	var firstErr error
-	for i := 0; i < numFTs; i++ {
+	for i := 0; i < loopCount; i++ {
 		res := <-results
 		if res.Err != nil && firstErr == nil {
 			firstErr = res.Err
@@ -262,55 +292,60 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, numWholeTokens
 		return firstErr
 	}
 
-	for i := range wholeTokens {
+	if fromRBT && !isHighValueFt {
+		for i := range wholeTokens {
+			ptts := RBTString
+			if wholeTokens[i].ParentTokenID != "" && wholeTokens[i].TokenValue < 1 {
+				ptts = PartString
+			}
+			ptt := c.TokenType(ptts)
 
-		release := true
-		defer c.relaseToken(&release, wholeTokens[i].TokenID)
-		ptts := RBTString
-		if wholeTokens[i].ParentTokenID != "" && wholeTokens[i].TokenValue < 1 {
-			ptts = PartString
-		}
-		ptt := c.TokenType(ptts)
-
-		bti := &block.TransInfo{
-			Tokens: []block.TransTokens{
-				{
-					Token:     wholeTokens[i].TokenID,
-					TokenType: ptt,
+			bti := &block.TransInfo{
+				Tokens: []block.TransTokens{
+					{
+						Token:     wholeTokens[i].TokenID,
+						TokenType: ptt,
+					},
 				},
-			},
-			Comment: "Token burnt at : " + time.Now().String(),
+				Comment: "Token locked for FT at : " + time.Now().String(),
+			}
+
+			tcb := &block.TokenChainBlock{
+				TransactionType: block.TokenLockedForFT,
+				TokenOwner:      did,
+				TransInfo:       bti,
+				TokenValue:      wholeTokens[i].TokenValue,
+				ChildTokens:     newFTTokenIDs,
+			}
+
+			ctcb := make(map[string]*block.Block)
+			ctcb[wholeTokens[i].TokenID] = c.w.GetLatestTokenBlock(wholeTokens[i].TokenID, ptt)
+
+			blk := block.CreateNewBlock(ctcb, tcb)
+			if blk == nil {
+				return fmt.Errorf("failed to create new block")
+			}
+
+			err = blk.UpdateSignature(dc)
+			if err != nil {
+				c.log.Error("FT creation failed, failed to update signature", "err", err)
+				return err
+			}
+
+			err = c.w.AddTokenBlock(wholeTokens[i].TokenID, blk)
+			if err != nil {
+				c.log.Error("FT creation failed, failed to add token block", "err", err)
+				return err
+			}
+
+			// Mark the token as locked for FT
+			wholeTokens[i].TokenStatus = wallet.TokenIsLockedForFT
+			err = c.w.UpdateToken(&wholeTokens[i])
+			if err != nil {
+				c.log.Error("FT token creation failed, failed to update token status", "err", err)
+				return err
+			}
 		}
-		tcb := &block.TokenChainBlock{
-			TransactionType: block.TokenLockedForFT,
-			TokenOwner:      did,
-			TransInfo:       bti,
-			TokenValue:      wholeTokens[i].TokenValue,
-			ChildTokens:     newFTTokenIDs,
-		}
-		ctcb := make(map[string]*block.Block)
-		ctcb[wholeTokens[i].TokenID] = c.w.GetLatestTokenBlock(wholeTokens[i].TokenID, ptt)
-		block := block.CreateNewBlock(ctcb, tcb)
-		if block == nil {
-			return fmt.Errorf("failed to create new block")
-		}
-		err = block.UpdateSignature(dc)
-		if err != nil {
-			c.log.Error("FT creation failed, failed to update signature", "err", err)
-			return err
-		}
-		err = c.w.AddTokenBlock(wholeTokens[i].TokenID, block)
-		if err != nil {
-			c.log.Error("FT creation failed, failed to add token block", "err", err)
-			return err
-		}
-		wholeTokens[i].TokenStatus = wallet.TokenIsBurntForFT
-		err = c.w.UpdateToken(&wholeTokens[i])
-		if err != nil {
-			c.log.Error("FT token creation failed, failed to update token status", "err", err)
-			return err
-		}
-		release = false
 	}
 
 	// --- Batch Write FTs to Storage using WriteBatch ---
@@ -381,10 +416,11 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, numWholeTokens
 		return err
 	}
 
-	updateFTTableErr := c.updateFTTable()
-	if updateFTTableErr != nil {
-		c.log.Error("Failed to update FT table after FT creation", "err", updateFTTableErr)
-		return updateFTTableErr
+	finalFTCreatedCount := ftStartIndex + loopCount
+	err = c.UpsertFTTable(FTName, did, finalFTCreatedCount, loopCount)
+	if err != nil {
+		c.log.Error("Failed to update FT index", "err", err)
+		return fmt.Errorf("failed to finalize FT table update: %w", err)
 	}
 	return nil
 }
@@ -874,6 +910,40 @@ func (c *Core) GetPresiceFractionalValue(a, b int) (float64, error) {
 		}
 	}
 	return result, nil
+}
+
+func (c *Core) UpsertFTTable(ftName string, creatorDid string, newTotalFTCreatedCount int, numFTsCreatedInThisCall int) error {
+	var existingFt wallet.FT
+
+	err := c.s.Read(wallet.FTStorage, &existingFt, "ft_name=? AND creator_did=?", ftName, creatorDid)
+	if err != nil {
+		if strings.Contains(fmt.Sprint(err), "no records found") {
+			newFT := &wallet.FT{
+				FTName:           ftName,
+				CreatorDID:       creatorDid,
+				FTCreatedCount:   newTotalFTCreatedCount,
+				FTAvailableCount: numFTsCreatedInThisCall,
+				FTCount:          numFTsCreatedInThisCall, // Keep old field in sync for backwards compatibility
+			}
+
+			if writeErr := c.s.Write(wallet.FTStorage, newFT); writeErr != nil {
+				return fmt.Errorf("failed to insert new record: %w", writeErr)
+			}
+			c.log.Info("New FT record created")
+			return nil
+		}
+		return fmt.Errorf("error checking for existing record: %w", err)
+	}
+
+	existingFt.FTCreatedCount = newTotalFTCreatedCount
+	existingFt.FTAvailableCount += numFTsCreatedInThisCall
+	existingFt.FTCount = existingFt.FTAvailableCount // Keep old field in sync for backwards compatibility
+
+	updateErr := c.s.Update(wallet.FTStorage, &existingFt, "ft_name=? AND creator_did=?", ftName, creatorDid)
+	if updateErr != nil {
+		return fmt.Errorf("failed to update FT index: %w", updateErr)
+	}
+	return nil
 }
 
 func (c *Core) updateFTTable() error {

--- a/core/ft.go
+++ b/core/ft.go
@@ -60,10 +60,36 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, FTValue float6
 		return fmt.Errorf("DID crypto is not initialized, err: %v ", err)
 	}
 
-	// Compute a unique start index using FTIndexTable to avoid token_id collisions
-	ftStartIndex, err := c.allocateFTIndices(FTName, did, numFTs)
-	if err != nil {
-		return fmt.Errorf("failed to allocate FT indices: %w", err)
+	// Decide start index strategy based on FT type
+	// - High value FT: auto-allocate using FTIndex (with fallback scan)
+	// - Standard FT: honor provided ftNumStartIndex and validate no collisions
+	var ftStartIndex int
+	if isHighValueFt {
+		var allocErr error
+		ftStartIndex, allocErr = c.allocateFTIndices(FTName, did, numFTs)
+		if allocErr != nil {
+			return fmt.Errorf("failed to allocate FT indices: %w", allocErr)
+		}
+	} else {
+		ftStartIndex = ftNumStartIndex
+		// Validate that the requested range does not collide with existing tokens
+		var existingTokens []wallet.FTToken
+		_ = c.s.Read(wallet.FTTokenStorage, &existingTokens, "ft_name=? AND (creator_did=? OR owner_did=?)", FTName, did, did)
+
+		existingNums := make(map[int]struct{})
+		for i := range existingTokens {
+			parts := strings.Split(existingTokens[i].TokenID, " ")
+			if len(parts) >= 3 {
+				if n, convErr := strconv.Atoi(parts[1]); convErr == nil {
+					existingNums[n] = struct{}{}
+				}
+			}
+		}
+		for n := ftStartIndex; n < ftStartIndex+numFTs; n++ {
+			if _, exists := existingNums[n]; exists {
+				return fmt.Errorf("FT number %d already exists for ft_name=%s and creator_did=%s", n, FTName, did)
+			}
+		}
 	}
 
 	// Validate input parameters

--- a/core/ft.go
+++ b/core/ft.go
@@ -27,7 +27,6 @@ import (
 )
 
 func (c *Core) CreateFTs(reqID string, did string, ftcount int, ftname string, ftValue float64, ftNumStartIndex int, fromRBT bool, isHighValueFt bool) {
-	// Removed legacy backfill: rbt_lock_status now defaults to 1 via GORM default
 	err := c.createFTs(reqID, ftname, ftcount, ftValue, did, ftNumStartIndex, fromRBT, isHighValueFt)
 	br := model.BasicResponse{
 		Status:  true,
@@ -61,23 +60,8 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, FTValue float6
 		return fmt.Errorf("DID crypto is not initialized, err: %v ", err)
 	}
 
-	var existingFT wallet.FT
-	readErr := c.s.Read(wallet.FTStorage, &existingFT, "ft_name=? AND creator_did=?", FTName, did)
-	if readErr != nil {
-		c.log.Info("There is no record for FT Name: %s and creator DID: %s", FTName, did)
-	}
-
 	var ftStartIndex int
-	if readErr != nil && strings.Contains(fmt.Sprint(readErr), "no records found") {
-		c.log.Info("FT Name does not exist")
-		ftStartIndex = ftNumStartIndex
-	} else if readErr == nil {
-		c.log.Info("FT Name already exists")
-		ftStartIndex = existingFT.FTCreatedCount
-	} else {
-		c.log.Error("Error checking for existing FT record during creation setup", "err", readErr)
-		return fmt.Errorf("failed to check existing FT record: %w", readErr)
-	}
+	ftStartIndex = ftNumStartIndex
 
 	// Validate input parameters
 
@@ -420,16 +404,15 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, FTValue float6
 		return err
 	}
 
-	finalFTCreatedCount := ftStartIndex + loopCount
-	err = c.UpsertFTTable(FTName, did, finalFTCreatedCount, loopCount, isHighValueFt)
-	if err != nil {
-		c.log.Error("Failed to update FT index", "err", err)
-		return fmt.Errorf("failed to finalize FT table update: %w", err)
+	// Refresh FTTable using full recompute to ensure IDs are populated
+	// Here the main issue is that, the ID in this table is string, which ideally should be integer. inorder to maintain backward compatibility we had to use this function.
+	// This needs to be updated such that the existing table will get migrated or some work around needs to be done.
+	if err := c.updateFTTable(); err != nil {
+		c.log.Error("Failed to update FT table after FT creation", "err", err)
+		return err
 	}
 	return nil
 }
-
-// Legacy backfill removed as column default is set to 1 in schema
 
 func (c *Core) GetFTInfoByDID(did string) ([]model.FTInfo, error) {
 	if !c.w.IsDIDExist(did) {
@@ -969,21 +952,18 @@ func (c *Core) GetPresiceFractionalValue(a, b int) (float64, error) {
 	return result, nil
 }
 
-func (c *Core) UpsertFTTable(ftName string, creatorDid string, newTotalFTCreatedCount int, numFTsCreatedInThisCall int, isHighValue bool) error {
+func (c *Core) UpsertFTTable(ftName string, creatorDid string, _ int, numFTsCreatedInThisCall int, isHighValue bool) error {
 	var existingFt wallet.FT
 
 	err := c.s.Read(wallet.FTStorage, &existingFt, "ft_name=? AND creator_did=?", ftName, creatorDid)
 	if err != nil {
 		if strings.Contains(fmt.Sprint(err), "no records found") {
 			newFT := &wallet.FT{
-				FTName:           ftName,
-				CreatorDID:       creatorDid,
-				FTCreatedCount:   newTotalFTCreatedCount,
-				FTAvailableCount: numFTsCreatedInThisCall,
-				FTCount:          numFTsCreatedInThisCall, // Keep old field in sync for backwards compatibility
-				HighValueFT:      isHighValue,
+				FTName:      ftName,
+				CreatorDID:  creatorDid,
+				FTCount:     numFTsCreatedInThisCall,
+				HighValueFT: isHighValue,
 			}
-
 			if writeErr := c.s.Write(wallet.FTStorage, newFT); writeErr != nil {
 				return fmt.Errorf("failed to insert new record: %w", writeErr)
 			}
@@ -993,9 +973,7 @@ func (c *Core) UpsertFTTable(ftName string, creatorDid string, newTotalFTCreated
 		return fmt.Errorf("error checking for existing record: %w", err)
 	}
 
-	existingFt.FTCreatedCount = newTotalFTCreatedCount
-	existingFt.FTAvailableCount += numFTsCreatedInThisCall
-	existingFt.FTCount = existingFt.FTAvailableCount // Keep old field in sync for backwards compatibility
+	existingFt.FTCount += numFTsCreatedInThisCall
 	existingFt.HighValueFT = isHighValue
 
 	updateErr := c.s.Update(wallet.FTStorage, &existingFt, "ft_name=? AND creator_did=?", ftName, creatorDid)

--- a/core/ft.go
+++ b/core/ft.go
@@ -7,6 +7,7 @@ import (
 	"log"
 	"math"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -1553,4 +1554,382 @@ func (c *Core) GetClosestTokens(dc did.DIDCrypto, ownerDID string, targetValue f
 	}
 
 	return nil, fmt.Errorf("unable to fulfill the request: no suitable token combination or split possible")
+}
+
+// findTokenOfValue finds and returns a token with the specified value from the slice
+func findTokenOfValue(tokens []wallet.FTToken, value float64) wallet.FTToken {
+	for _, t := range tokens {
+		if t.TokenValue == value {
+			return t
+		}
+	}
+	return wallet.FTToken{} // Return zero value if not found
+}
+
+// burnSingleFT burns a single FT token and updates its status
+func (c *Core) burnSingleFT(ft wallet.FTToken, did string, dc did.DIDCrypto) error {
+	// Create FT burn info
+	ftInfo := &block.TransInfo{
+		Tokens: []block.TransTokens{
+			{
+				Token:     ft.TokenID,
+				TokenType: c.TokenType(FTString),
+			},
+		},
+		Comment: "FT burnt at : " + time.Now().String(),
+	}
+
+	// Create burn block
+	ftBurntBlock := &block.TokenChainBlock{
+		TransactionType: block.TokenBurntType,
+		TokenOwner:      did,
+		TransInfo:       ftInfo,
+		TokenValue:      ft.TokenValue,
+	}
+
+	ftBurntBlockMap := make(map[string]*block.Block)
+	ftBurntBlockMap[ft.TokenID] = c.w.GetLatestTokenBlock(ft.TokenID, c.TokenType(FTString))
+
+	newBlock := block.CreateNewBlock(ftBurntBlockMap, ftBurntBlock)
+	if newBlock == nil {
+		return fmt.Errorf("failed to create FT burnt block")
+	}
+
+	err := newBlock.UpdateSignature(dc)
+	if err != nil {
+		return fmt.Errorf("failed to update FT burnt block signature")
+	}
+
+	err = c.w.AddTokenBlock(ft.TokenID, newBlock)
+	if err != nil {
+		return fmt.Errorf("failed to add FT burnt block")
+	}
+
+	FTTokenDetails, err := c.w.ReadFTToken(ft.TokenID)
+	if err != nil {
+		if strings.Contains(err.Error(), "no records found") {
+			return fmt.Errorf("FT token not found")
+		}
+		return fmt.Errorf("failed to read FT token details")
+	}
+	if FTTokenDetails != nil {
+		FTTokenDetails.TokenStatus = wallet.TokenIsBurnt
+		err = c.w.UpdateFTToken(FTTokenDetails)
+	}
+	return nil
+}
+
+// unlockParentRBTs unlocks parent RBTs after FT burning
+func (c *Core) unlockParentRBTs(parentTokenID string, did string, dc did.DIDCrypto) error {
+	parentTokenIDsArray := strings.Split(parentTokenID, ",")
+
+	for _, parentRBT := range parentTokenIDsArray {
+		// Get parent RBT details
+		ParentRBTDetails, err := c.w.ReadToken(parentRBT)
+		if err != nil {
+			return fmt.Errorf("failed to get parent RBT details for %s", parentRBT)
+		}
+
+		// Create unlock block
+		rbtInfo := &block.TransInfo{
+			Tokens: []block.TransTokens{
+				{
+					Token:     parentRBT,
+					TokenType: c.TokenType(RBTString),
+				},
+			},
+			Comment: "Token Unlocked after burning FT at : " + time.Now().String(),
+		}
+
+		unlockBlock := &block.TokenChainBlock{
+			TransactionType: block.TokenUnlocked,
+			TokenOwner:      did,
+			TransInfo:       rbtInfo,
+			TokenValue:      ParentRBTDetails.TokenValue,
+		}
+
+		unlockBlockMap := make(map[string]*block.Block)
+		unlockBlockMap[parentRBT] = c.w.GetLatestTokenBlock(parentRBT, c.TokenType(RBTString))
+
+		newBlock := block.CreateNewBlock(unlockBlockMap, unlockBlock)
+		if newBlock == nil {
+			return fmt.Errorf("failed to create unlock block for %s", parentRBT)
+		}
+
+		err = newBlock.UpdateSignature(dc)
+		if err != nil {
+			return fmt.Errorf("failed to update unlock block signature for %s", parentRBT)
+		}
+
+		err = c.w.AddTokenBlock(parentRBT, newBlock)
+		if err != nil {
+			return fmt.Errorf("failed to add unlock block for %s", parentRBT)
+		}
+
+		// Update token status
+		ParentRBTDetails.TokenStatus = wallet.TokenIsFree
+		err = c.w.UpdateToken(ParentRBTDetails)
+		if err != nil {
+			return fmt.Errorf("failed to update token status for %s", parentRBT)
+		}
+	}
+
+	return nil
+}
+
+// validateParentRBTsForBurning validates that parent RBTs and child FTs are consistent
+func (c *Core) validateParentRBTsForBurning(parentTokenID string, FTsToBurn []wallet.FTToken) error {
+	parentTokenIDsArray := strings.Split(parentTokenID, ",")
+
+	// Create sorted list of FT token IDs for comparison
+	var FTTokenIDsToBurn []string
+	for _, ft := range FTsToBurn {
+		FTTokenIDsToBurn = append(FTTokenIDsToBurn, ft.TokenID)
+	}
+	sort.Strings(FTTokenIDsToBurn)
+
+	var firstChildFTs []string
+
+	for parentTokenIDNumber, parentRBT := range parentTokenIDsArray {
+		// Get parent RBT details
+		_, err := c.w.ReadToken(parentRBT)
+		if err != nil {
+			return fmt.Errorf("failed to get parent RBT details for %s", parentRBT)
+		}
+
+		// Get latest block and child tokens
+		parentRBTLatestBlock := c.w.GetLatestTokenBlock(parentRBT, c.TokenType(RBTString))
+		if parentRBTLatestBlock == nil {
+			return fmt.Errorf("failed to get latest block for parent RBT %s", parentRBT)
+		}
+
+		childFTs := parentRBTLatestBlock.GetChildTokens()
+		if len(childFTs) != len(FTTokenIDsToBurn) {
+			return fmt.Errorf("FTs count (%d) does not match with the child FTs count (%d) for RBT %s",
+				len(FTTokenIDsToBurn), len(childFTs), parentRBT)
+		}
+
+		sort.Strings(childFTs)
+
+		// Validate child FTs match the FTs to be burned
+		for i := range childFTs {
+			if childFTs[i] != FTTokenIDsToBurn[i] {
+				return fmt.Errorf("child FTs do not match with the FTs to be burned for RBT %s", parentRBT)
+			}
+		}
+
+		// Ensure consistency across all parent RBTs
+		if parentTokenIDNumber == 0 {
+			firstChildFTs = childFTs
+		} else {
+			for i := range childFTs {
+				if childFTs[i] != firstChildFTs[i] {
+					return fmt.Errorf("mismatch in child FTs among parent RBTs")
+				}
+			}
+		}
+	}
+
+	return nil
+}
+
+// burnFT handles the burning of FTs with support for count-based and value-based modes
+func (c *Core) burnFT(reqID string, burnReq *model.BurnFTReq) *model.BasicResponse {
+	var RBTLockStatus int
+	resp := &model.BasicResponse{
+		Status: false,
+	}
+
+	// 1. Input validation
+	isAlphanumericDID := regexp.MustCompile(`^[a-zA-Z0-9]*$`).MatchString(burnReq.DID)
+	if !isAlphanumericDID {
+		c.log.Error("Invalid sender or receiver address. Please provide valid DID")
+		resp.Message = "Invalid sender or receiver address. Please provide valid DID"
+		return resp
+	}
+	if !strings.HasPrefix(burnReq.DID, "bafybmi") || len(burnReq.DID) != 59 {
+		c.log.Error("Invalid sender or receiver DID")
+		resp.Message = "Invalid sender or receiver DID"
+		return resp
+	}
+	if burnReq.FTName == "" {
+		c.log.Error("FT name cannot be empty")
+		resp.Message = "FT name is required"
+		return resp
+	}
+
+	// 2. Validate RBTLockStatus and FTCount combination
+	if burnReq.FromRBT && burnReq.FTCount > 0 {
+		c.log.Error("FTCount cannot be specified when FromRBT is true, Try again with FTCount as 0")
+		resp.Message = "FTCount cannot be specified when FromRBT is true, Try again with FTCount as 0"
+		return resp
+	}
+	if !burnReq.FromRBT && burnReq.FTCount <= 0 {
+		c.log.Error("FTCount is required when FromRBT is false")
+		resp.Message = "FTCount is required when FromRBT is false"
+		return resp
+	}
+
+	// 3. DID crypto setup
+	dc, err := c.SetupDID(reqID, burnReq.DID)
+	if err != nil || dc == nil {
+		c.log.Error("Failed to setup DID")
+		resp.Message = "DID crypto is not initialized"
+		return resp
+	}
+
+	// 4. Gather all available FTs
+	allFTs, err := c.w.GetFreeFTsByNameAndCreatorDID(burnReq.FTName, burnReq.DID, burnReq.DID)
+	if err != nil {
+		c.log.Error("Failed to get FTs to burn")
+		resp.Message = "Failed to get FTs to burn"
+		return resp
+	}
+	if len(allFTs) == 0 {
+		c.log.Error("No FTs available to process")
+		resp.Message = "No FTs found for burning"
+		return resp
+	}
+
+	// 5. Determine FTs to burn based on FromRBT flag
+	var FTsToBurn []wallet.FTToken
+
+	if burnReq.FromRBT {
+		// Burn all FTs when FromRBT is true
+		FTsToBurn = allFTs
+		c.log.Info("FromRBT is true, burning all available FTs")
+	} else if burnReq.HighValueFT {
+		targetValue := float64(burnReq.FTCount)
+		var selectedFTs []wallet.FTToken
+		var totalValue float64
+
+		for _, ft := range allFTs {
+			// Exact match
+			if ft.TokenValue == targetValue {
+				FTsToBurn = []wallet.FTToken{ft}
+				c.log.Info("Found exact match FT for burning")
+				break
+			}
+
+			// Accumulate FTs if their total value is still less than target
+			if totalValue+ft.TokenValue < targetValue {
+				selectedFTs = append(selectedFTs, ft)
+				totalValue += ft.TokenValue
+				continue
+			}
+
+			// This FT pushes us over the target — time to split
+			remaining := targetValue - totalValue
+			splitTokens, err := c.splitFTToken(dc, ft.DID, ft.TokenID, ft.TokenValue, remaining)
+			if err != nil {
+				c.log.Error("Failed to split FT token", "err", err)
+				resp.Message = "FT splitting failed"
+				return resp
+			}
+
+			// Add original accumulated tokens
+			selectedFTs = append(selectedFTs, findTokenOfValue(splitTokens, remaining))
+			FTsToBurn = selectedFTs
+			c.log.Info(fmt.Sprintf("Split FT and burning tokens totaling %.2f", targetValue))
+			break
+		}
+
+		if len(FTsToBurn) == 0 {
+			c.log.Error("Insufficient FT value available for burning")
+			resp.Message = fmt.Sprintf("Only total value %.2f FTs available, but %.2f requested", totalValue, targetValue)
+			return resp
+		}
+
+	} else {
+		// Burn by count (non-HighValue mode)
+		if burnReq.FTCount > len(allFTs) {
+			c.log.Error("Insufficient FTs available for burning")
+			resp.Message = fmt.Sprintf("Only %d FTs available, but %d requested", len(allFTs), burnReq.FTCount)
+			return resp
+		}
+		FTsToBurn = allFTs[:burnReq.FTCount]
+		c.log.Info(fmt.Sprintf("Burning %d FTs as requested", burnReq.FTCount))
+	}
+
+	// 6. Validate all FTs before any state changes
+	var parentTokenID string
+
+	for _, ft := range FTsToBurn {
+		// Get genesis block of FT
+		ftGenesisBlock := c.w.GetGenesisTokenBlock(ft.TokenID, c.TokenType(FTString))
+		if ftGenesisBlock == nil {
+			c.log.Error(fmt.Sprintf("Failed to get genesis block for FT: %s", ft.TokenID))
+			resp.Message = "Failed to get genesis block for FT"
+			return resp
+		}
+
+		// Validate creator DID from genesis block
+		ftCreator := ftGenesisBlock.GetOwner()
+		if ftCreator != burnReq.DID {
+			c.log.Error(fmt.Sprintf("DID %s is not the creator of FT %s", burnReq.DID, ft.TokenID))
+			resp.Message = "Unable to burn FTs, Given DID is not the creator of the FT"
+			return resp
+		}
+
+		// Validate RBT lock status when FromRBT is true
+		if burnReq.FromRBT {
+			RBTLockStatus, err = ftGenesisBlock.GetRBTLockStatus(ft.TokenID)
+			if err != nil {
+				c.log.Error("Failed to get RBT lock status")
+				resp.Message = "Failed to get RBT lock status"
+				return resp
+			}
+			if RBTLockStatus != block.RBTLocked {
+				c.log.Error("RBT is not locked, cannot burn FTs")
+				resp.Message = "RBT is not locked, cannot burn FTs"
+				return resp
+			}
+		}
+	}
+
+	// 7. Additional validation for FromRBT case
+	if burnReq.FromRBT || RBTLockStatus == block.RBTLocked {
+		err := c.validateParentRBTsForBurning(parentTokenID, FTsToBurn)
+		if err != nil {
+			c.log.Error(fmt.Sprintf("Parent RBT validation failed: %v", err))
+			resp.Message = err.Error()
+			return resp
+		}
+	}
+
+	// 8. Process parent RBT unlocking (only when FromRBT is true)
+	fmt.Println("RBTLockStatus:", RBTLockStatus)
+	if burnReq.FromRBT || RBTLockStatus == block.RBTLocked {
+		err := c.unlockParentRBTs(parentTokenID, burnReq.DID, dc)
+		if err != nil {
+			c.log.Error(fmt.Sprintf("Failed to unlock parent RBTs: %v", err))
+			resp.Message = "Failed to unlock parent RBTs"
+			return resp
+		}
+	}
+
+	// 9. Burn all FTs
+	for _, ft := range FTsToBurn {
+		err := c.burnSingleFT(ft, burnReq.DID, dc)
+		if err != nil {
+			c.log.Error(fmt.Sprintf("Failed to burn FT %s: %v", ft.TokenID, err))
+			resp.Message = fmt.Sprintf("Failed to burn FT %s", ft.TokenID)
+			return resp
+		}
+	}
+	c.log.Info("FTs burned successfully")
+	resp.Status = true
+	resp.Message = fmt.Sprintf("Successfully burned %d %v FTs", len(FTsToBurn), burnReq.FTName)
+	return resp
+}
+
+// BurnFT is the main entry point for burning FTs
+func (c *Core) BurnFT(reqID string, req *model.BurnFTReq) {
+	br := c.burnFT(reqID, req)
+	dc := c.GetWebReq(reqID)
+	if dc == nil {
+		c.log.Error("Failed to get did channels")
+		return
+	}
+	dc.OutChan <- br
 }

--- a/core/ft.go
+++ b/core/ft.go
@@ -419,7 +419,7 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, FTValue float6
 	}
 
 	finalFTCreatedCount := ftStartIndex + loopCount
-	err = c.UpsertFTTable(FTName, did, finalFTCreatedCount, loopCount)
+	err = c.UpsertFTTable(FTName, did, finalFTCreatedCount, loopCount, isHighValueFt)
 	if err != nil {
 		c.log.Error("Failed to update FT index", "err", err)
 		return fmt.Errorf("failed to finalize FT table update: %w", err)
@@ -437,22 +437,53 @@ func (c *Core) GetFTInfoByDID(did string) ([]model.FTInfo, error) {
 		c.log.Error("Failed to get tokens FTs and Count", "err", err)
 		return []model.FTInfo{}, fmt.Errorf("Failed to get tokens FTs and Count")
 	}
-	ftInfoMap := make(map[string]map[string]int)
+	// Build map keyed by ft_name -> creator_did with count and total value
+	type FTBalanceSummary struct {
+		Count int
+		Total float64
+		High  bool
+	}
+	ftInfoMap := make(map[string]map[string]*FTBalanceSummary)
 
 	// Iterate through retrieved FTs and populate the map
 	for _, t := range FT {
 		if ftInfoMap[t.FTName] == nil {
-			ftInfoMap[t.FTName] = make(map[string]int) // Initialize map for each FTName
+			ftInfoMap[t.FTName] = make(map[string]*FTBalanceSummary)
 		}
-		ftInfoMap[t.FTName][t.CreatorDID] += t.FTCount // Increment count for the specific CreatorDID
+		if ftInfoMap[t.FTName][t.CreatorDID] == nil {
+			ftInfoMap[t.FTName][t.CreatorDID] = &FTBalanceSummary{}
+		}
+		// Count is already aggregated by wallet layer; track it
+		ftInfoMap[t.FTName][t.CreatorDID].Count += t.FTCount
+		// Determine if this FT is high value by looking up FT table row
+		var meta wallet.FT
+		if readErr := c.s.Read(wallet.FTStorage, &meta, "ft_name=? AND creator_did=?", t.FTName, t.CreatorDID); readErr == nil {
+			ftInfoMap[t.FTName][t.CreatorDID].High = meta.HighValueFT
+		}
+		// If HVFT, compute total by summing token values of free tokens for this did+name
+		// We'll compute totals after the loop to avoid repeated queries
 	}
 	info := make([]model.FTInfo, 0)
-	for ftName, creatorCounts := range ftInfoMap {
-		for creatorDID, count := range creatorCounts {
+	for ftName, creators := range ftInfoMap {
+		for creatorDID, balanceSummary := range creators {
+			totalValue := 0.0
+			if balanceSummary.High {
+				// Sum token_value of free tokens for this DID+name
+				var tokens []wallet.FTToken
+				if err := c.s.Read(wallet.FTTokenStorage, &tokens, "owner_did=? AND token_status=? AND ft_name=?", did, wallet.TokenIsFree, ftName); err == nil {
+					for _, tok := range tokens {
+						if tok.CreatorDID == creatorDID {
+							totalValue += tok.TokenValue
+						}
+					}
+				}
+			}
 			info = append(info, model.FTInfo{
-				FTName:     ftName,
-				FTCount:    count,
-				CreatorDID: creatorDID,
+				FTName:       ftName,
+				FTCount:      balanceSummary.Count,
+				CreatorDID:   creatorDID,
+				HighValueFT:  balanceSummary.High,
+				FTTotalValue: totalValue,
 			})
 		}
 	}
@@ -584,12 +615,11 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 		c.log.Error("Failed to get FTs", "err", err)
 		resp.Message = "Insufficient FTs or FTs are locked or " + err.Error()
 		return resp
-	} else {
-		if req.FTCount > AvailableFTCount {
-			c.log.Error(fmt.Sprint("Insufficient balance, Available FT balance is ", AvailableFTCount, " trnx value is ", req.FTCount))
-			resp.Message = fmt.Sprint("Insufficient balance, Available FT balance is ", AvailableFTCount, " trnx value is ", req.FTCount)
-			return resp
-		}
+	}
+	if req.FTCount > AvailableFTCount {
+		c.log.Error(fmt.Sprint("Insufficient balance, Available FT balance is ", AvailableFTCount, " trnx value is ", req.FTCount))
+		resp.Message = fmt.Sprint("Insufficient balance, Available FT balance is ", AvailableFTCount, " trnx value is ", req.FTCount)
+		return resp
 	}
 
 	// Select tokens based on high-value FT mode or standard count-based mode
@@ -702,8 +732,9 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 		ReqID: reqID,
 	}
 	FTData := model.FTInfo{
-		FTName:  req.FTName,
-		FTCount: req.FTCount,
+		FTName:      req.FTName,
+		FTCount:     req.FTCount,
+		HighValueFT: req.IsHighValueFT,
 	}
 	sc := contract.CreateNewContract(sct)
 	err = sc.UpdateSignature(dc)
@@ -934,7 +965,7 @@ func (c *Core) GetPresiceFractionalValue(a, b int) (float64, error) {
 	return result, nil
 }
 
-func (c *Core) UpsertFTTable(ftName string, creatorDid string, newTotalFTCreatedCount int, numFTsCreatedInThisCall int) error {
+func (c *Core) UpsertFTTable(ftName string, creatorDid string, newTotalFTCreatedCount int, numFTsCreatedInThisCall int, isHighValue bool) error {
 	var existingFt wallet.FT
 
 	err := c.s.Read(wallet.FTStorage, &existingFt, "ft_name=? AND creator_did=?", ftName, creatorDid)
@@ -946,6 +977,7 @@ func (c *Core) UpsertFTTable(ftName string, creatorDid string, newTotalFTCreated
 				FTCreatedCount:   newTotalFTCreatedCount,
 				FTAvailableCount: numFTsCreatedInThisCall,
 				FTCount:          numFTsCreatedInThisCall, // Keep old field in sync for backwards compatibility
+				HighValueFT:      isHighValue,
 			}
 
 			if writeErr := c.s.Write(wallet.FTStorage, newFT); writeErr != nil {
@@ -960,6 +992,7 @@ func (c *Core) UpsertFTTable(ftName string, creatorDid string, newTotalFTCreated
 	existingFt.FTCreatedCount = newTotalFTCreatedCount
 	existingFt.FTAvailableCount += numFTsCreatedInThisCall
 	existingFt.FTCount = existingFt.FTAvailableCount // Keep old field in sync for backwards compatibility
+	existingFt.HighValueFT = isHighValue
 
 	updateErr := c.s.Update(wallet.FTStorage, &existingFt, "ft_name=? AND creator_did=?", ftName, creatorDid)
 	if updateErr != nil {

--- a/core/ft.go
+++ b/core/ft.go
@@ -440,12 +440,30 @@ func (c *Core) allocateFTIndices(ftName string, creatorDid string, num int) (int
 			return 0, err
 		}
 	} else {
-		// Insert new row with end = num
-		idx = wallet.FTIndex{FTName: ftName, CreatorDID: creatorDid, FTIndex: num}
-		if err := c.s.Write(wallet.FTIndexStorage, &idx); err != nil {
-			return 0, err
+		// Fallback: derive start by scanning existing FT tokens for this (ft_name, creator_did)
+		var existingTokens []wallet.FTToken
+		// Prefer CreatorDID filter; owner_did may also match creator in our flows
+		_ = c.s.Read(wallet.FTTokenStorage, &existingTokens, "ft_name=? AND (creator_did=? OR owner_did=?)", ftName, creatorDid, creatorDid)
+
+		maxNum := -1
+		for i := range existingTokens {
+			// token_id format: FTName <num> DID (assuming FTName has no spaces)
+			parts := strings.Split(existingTokens[i].TokenID, " ")
+			if len(parts) >= 3 {
+				if n, convErr := strconv.Atoi(parts[1]); convErr == nil {
+					if n > maxNum {
+						maxNum = n
+					}
+				}
+			}
 		}
-		start = 0
+		start = maxNum + 1
+		// Insert new FTIndex row with end = start + num
+		idx = wallet.FTIndex{FTName: ftName, CreatorDID: creatorDid, FTIndex: start + num}
+		if err := c.s.Write(wallet.FTIndexStorage, &idx); err != nil {
+			// If FTIndex table doesn't exist or write fails, proceed without persisting; caller will still get a unique start
+			// Next call will recompute via fallback again
+		}
 	}
 	return start, nil
 }

--- a/core/ft.go
+++ b/core/ft.go
@@ -66,7 +66,8 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, FTValue float6
 	var ftStartIndex int
 	if isHighValueFt {
 		var allocErr error
-		ftStartIndex, allocErr = c.allocateFTIndices(FTName, did, numFTs)
+		// Reserve exactly one index for HVFT
+		ftStartIndex, allocErr = c.allocateFTIndices(FTName, did, 1)
 		if allocErr != nil {
 			return fmt.Errorf("failed to allocate FT indices: %w", allocErr)
 		}

--- a/core/ft.go
+++ b/core/ft.go
@@ -19,6 +19,7 @@ import (
 	"github.com/rubixchain/rubixgoplatform/contract"
 	"github.com/rubixchain/rubixgoplatform/core/model"
 	"github.com/rubixchain/rubixgoplatform/core/wallet"
+	"github.com/rubixchain/rubixgoplatform/did"
 	"github.com/rubixchain/rubixgoplatform/rac"
 	"github.com/rubixchain/rubixgoplatform/util"
 	"github.com/rubixchain/rubixgoplatform/wrapper/uuid"
@@ -590,7 +591,27 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 		}
 	}
 
-	FTsForTxn := AllFTs[:req.FTCount]
+	// Select tokens based on high-value FT mode or standard count-based mode
+	var FTsForTxn []wallet.FTToken
+	if req.IsHighValueFT {
+		// High-value FT mode: select tokens by value
+		if req.FTTransferValue <= 0.0 {
+			c.log.Error("FT transfer value must be greater than 0 for high-value FT")
+			resp.Message = "FT transfer value is required for high-value FT transfer"
+			return resp
+		}
+		requiredValue := floatPrecision(req.FTTransferValue, MaxDecimalPlaces)
+
+		FTsForTxn, err = c.GetClosestTokens(dc, did, requiredValue, req.FTName)
+		if err != nil {
+			resp.Message = "Failed to select tokens for high-value FT: " + err.Error()
+			return resp
+		}
+		c.log.Info("Selected FTs for high-value transfer", "count", len(FTsForTxn), "total_value", requiredValue)
+	} else {
+		// Standard FT mode: select tokens by count
+		FTsForTxn = AllFTs[:req.FTCount]
+	}
 
 	// Fetching peer's peer id
 	if !c.w.IsDIDExist(req.Receiver) {
@@ -1033,4 +1054,503 @@ func (c *Core) FixAllFTTokensWithPeerIDAsCreator() ([]wallet.FTTokenFixResult, e
 // GetFTTokenCreatorStats returns statistics about FT token creators
 func (c *Core) GetFTTokenCreatorStats() (map[string]interface{}, error) {
 	return c.w.GetFTTokenCreatorStats()
+}
+
+// findBestCombination finds the optimal combination of tokens that sum to the target value
+// Uses bit manipulation to generate all possible combinations (2^n - 1)
+// Returns: exact match, or best over-match, or best under-match
+func (c *Core) findBestCombination(tokens []wallet.FTToken, targetValue float64) ([]wallet.FTToken, float64, error) {
+	c.log.Warn("Finding best combination of tokens", "targetValue", targetValue, "availableTokens", len(tokens))
+	var bestTokens []wallet.FTToken
+	bestSum := 0.0
+	n := len(tokens)
+
+	minExcess := math.MaxFloat64
+	var overMatchTokens []wallet.FTToken
+	overMatchSum := 0.0
+
+	for i := 1; i < (1 << n); i++ {
+		var currentTokens []wallet.FTToken
+		sum := 0.0
+		for j := 0; j < n; j++ {
+			if i&(1<<j) != 0 {
+				currentTokens = append(currentTokens, tokens[j])
+				sum += tokens[j].TokenValue
+			}
+		}
+
+		if sum == targetValue {
+			return currentTokens, sum, nil // Exact match
+		}
+
+		if sum < targetValue && sum > bestSum {
+			bestTokens = make([]wallet.FTToken, len(currentTokens))
+			copy(bestTokens, currentTokens)
+			bestSum = sum
+		}
+
+		if sum > targetValue && (sum-targetValue) < minExcess {
+			overMatchTokens = make([]wallet.FTToken, len(currentTokens))
+			copy(overMatchTokens, currentTokens)
+			overMatchSum = sum
+			minExcess = sum - targetValue
+		}
+	}
+
+	if len(overMatchTokens) > 0 {
+		return overMatchTokens, overMatchSum, nil
+	}
+
+	if len(bestTokens) > 0 {
+		return bestTokens, bestSum, nil
+	}
+
+	return nil, 0, fmt.Errorf("no valid combination found")
+}
+
+// findClosestToken finds and locks a single token with value closest to the target
+func (c *Core) findClosestToken(ownerDID string, targetValue float64) ([]wallet.FTToken, error) {
+	var tokens []wallet.FTToken
+	err := c.s.Read(wallet.FTTokenStorage, &tokens, "owner_did=? AND token_status=?", ownerDID, wallet.TokenIsFree)
+	if err != nil {
+		c.log.Error("Failed to query all free tokens", "err", err)
+		return nil, err
+	}
+	if len(tokens) == 0 {
+		c.log.Error("No free tokens found for owner DID", "owner_did", ownerDID)
+		return nil, fmt.Errorf("no free tokens found for owner DID %s", ownerDID)
+	}
+
+	// Find the token with value closest to targetValue
+	var closestToken wallet.FTToken
+	minDiff := int64(math.MaxInt64)
+	for _, token := range tokens {
+		diff := int64(math.Abs(float64(token.TokenValue - targetValue)))
+		if diff < minDiff {
+			minDiff = diff
+			closestToken = token
+		}
+	}
+
+	// Lock the closest token
+	closestToken.TokenStatus = wallet.TokenIsLocked
+	err = c.s.Update(wallet.FTTokenStorage, &closestToken, "owner_did=? AND token_id=?", ownerDID, closestToken.TokenID)
+	if err != nil {
+		c.log.Error("Failed to lock closest token", "err", err, "token_id", closestToken.TokenID)
+		return nil, err
+	}
+	c.log.Debug("Selected closest token", "token_id", closestToken.TokenID, "value", closestToken.TokenValue, "targetValue", targetValue)
+	return []wallet.FTToken{closestToken}, nil
+}
+
+// splitFTToken splits a single FT token into two new tokens (target value + balance)
+// Burns the parent token and creates two child tokens
+func (c *Core) splitFTToken(dc did.DIDCrypto, did, token string, currentTokenValue float64, newTokenValue float64) ([]wallet.FTToken, error) {
+	if dc == nil {
+		return nil, fmt.Errorf("did crypto is not initialised")
+	}
+	t, err := c.w.ReadFTToken(token)
+	if err != nil || t == nil {
+		return nil, fmt.Errorf("failed to get the specified token or the ft token does not exist")
+	}
+	if t.TokenStatus != wallet.TokenIsFree {
+		return nil, fmt.Errorf("token is not free, current status: %d", t.TokenStatus)
+	}
+	release := true
+	defer c.relaseToken(&release, token)
+	tokenType := c.TokenType(FTString)
+
+	parentBlockDetails := c.w.GetGenesisTokenBlock(token, tokenType)
+	p, gp, err := parentBlockDetails.GetParentDetials(token)
+	if gp == nil {
+		gp = make([]string, 0)
+	}
+	if p != "" {
+		gp = append(gp, p)
+	}
+	if err != nil {
+		c.log.Error("failed to get parent details", "err", err)
+		return nil, err
+	}
+
+	// Create RAC block for target token
+	targetFT := &rac.RacType{
+		Type:        c.RACFTType(),
+		DID:         t.CreatorDID,
+		TotalSupply: 1,
+		TimeStamp:   time.Now().String(),
+		FTInfo: &rac.RacFTInfo{
+			Parents: token,
+			FTNum:   1,
+			FTName:  t.FTName,
+			FTValue: newTokenValue,
+		},
+	}
+	racBlocks, err := rac.CreateRac(targetFT)
+	if err != nil {
+		c.log.Error("Failed to create RAC block", "err", err)
+		return nil, err
+	}
+
+	if len(racBlocks) != 1 {
+		return nil, fmt.Errorf("failed to create RAC block")
+	}
+
+	err = racBlocks[0].UpdateSignature(dc)
+	if err != nil {
+		c.log.Error("Failed to update DID signature", "err", err)
+		return nil, err
+	}
+
+	ftnumString := strconv.Itoa(1)
+	parts := []string{t.FTName, ftnumString, did, time.Now().String()}
+	result := strings.Join(parts, " ")
+	byteArray := []byte(result)
+	ftBuffer := bytes.NewBuffer(byteArray)
+	ftID, err := c.w.Add(ftBuffer, did, wallet.AddFunc)
+	if err != nil {
+		c.log.Error("Failed to create FT, Failed to add token to IPFS", "err", err)
+		return nil, err
+	}
+	c.log.Info("FT created: " + ftID + " FT Num: " + ftnumString)
+	targetFtId := ftID
+	c.log.Info("The target FT Id is :", targetFtId)
+
+	RBTLockStatus := block.RBTNotLocked
+	bti := &block.TransInfo{
+		Tokens: []block.TransTokens{
+			{
+				Token:     ftID,
+				TokenType: c.TokenType(FTString),
+			},
+		},
+		Comment: "FT generated at : " + time.Now().String() + " for FT Name : " + t.FTName,
+	}
+	tcb := &block.TokenChainBlock{
+		TransactionType: block.TokenGeneratedType,
+		TokenOwner:      t.CreatorDID,
+		TransInfo:       bti,
+		GenesisBlock: &block.GenesisBlock{
+			Info: []block.GenesisTokenInfo{
+				{
+					Token:         ftID,
+					ParentID:      token,
+					TokenNumber:   1,
+					RBTLockStatus: RBTLockStatus,
+				},
+			},
+		},
+		TokenValue: newTokenValue,
+	}
+	ctcb := make(map[string]*block.Block)
+	ctcb[ftID] = nil
+	blk := block.CreateNewBlock(ctcb, tcb)
+	if blk == nil {
+		return nil, fmt.Errorf("failed to create new block")
+	}
+	err = blk.UpdateSignature(dc)
+	if err != nil {
+		c.log.Error("FT creation failed, failed to update signature", "err", err)
+		return nil, err
+	}
+	err = c.w.AddTokenBlock(ftID, blk)
+	if err != nil {
+		c.log.Error("Failed to create FT, failed to add token chain block", "err", err)
+		return nil, err
+	}
+
+	// Create the new target token
+	targetFtInfo := wallet.FTToken{
+		TokenID:       ftID,
+		FTName:        t.FTName,
+		TokenStatus:   wallet.TokenIsFree,
+		TokenValue:    newTokenValue,
+		DID:           did,
+		RBTLockStatus: RBTLockStatus,
+		CreatorDID:    t.CreatorDID,
+	}
+
+	err = c.w.CreateFT(&targetFtInfo)
+	if err != nil {
+		c.log.Error("Failed to write FT details in FT tokens table", "err", err)
+		return nil, err
+	}
+
+	// Create balance token
+	balanceValue := currentTokenValue - newTokenValue
+	balanceFT := &rac.RacType{
+		Type:        c.RACFTType(),
+		DID:         t.CreatorDID,
+		TotalSupply: 1,
+		TimeStamp:   time.Now().String(),
+		FTInfo: &rac.RacFTInfo{
+			Parents: token,
+			FTNum:   2,
+			FTName:  t.FTName,
+			FTValue: balanceValue,
+		},
+	}
+	balanceFTRacBlocks, err := rac.CreateRac(balanceFT)
+	if err != nil {
+		c.log.Error("Failed to create RAC block", "err", err)
+		return nil, err
+	}
+
+	if len(balanceFTRacBlocks) != 1 {
+		return nil, fmt.Errorf("failed to create RAC block")
+	}
+
+	err = balanceFTRacBlocks[0].UpdateSignature(dc)
+	if err != nil {
+		c.log.Error("Failed to update DID signature", "err", err)
+		return nil, err
+	}
+
+	ftnumString2 := strconv.Itoa(2)
+	balanceFtdetailsAddedtoIpfs := []string{t.FTName, ftnumString2, did, time.Now().String()}
+	result2 := strings.Join(balanceFtdetailsAddedtoIpfs, " ")
+	byteArray2 := []byte(result2)
+	ftBuffer2 := bytes.NewBuffer(byteArray2)
+	balanceFtID, err := c.w.Add(ftBuffer2, did, wallet.AddFunc)
+	if err != nil {
+		c.log.Error("Failed to create FT, Failed to add token to IPFS", "err", err)
+		return nil, err
+	}
+	c.log.Info("FT created: " + ftID + " FT Num: " + ftnumString)
+
+	c.log.Info("The target FT Id is :", balanceFtID)
+
+	bti2 := &block.TransInfo{
+		Tokens: []block.TransTokens{
+			{
+				Token:     balanceFtID,
+				TokenType: c.TokenType(FTString),
+			},
+		},
+		Comment: "FT generated at : " + time.Now().String() + " for FT Name : " + t.FTName,
+	}
+	tcb2 := &block.TokenChainBlock{
+		TransactionType: block.TokenGeneratedType,
+		TokenOwner:      t.CreatorDID,
+		TransInfo:       bti2,
+		GenesisBlock: &block.GenesisBlock{
+			Info: []block.GenesisTokenInfo{
+				{
+					Token:         balanceFtID,
+					ParentID:      token,
+					TokenNumber:   2,
+					RBTLockStatus: RBTLockStatus,
+				},
+			},
+		},
+		TokenValue: balanceValue,
+	}
+	ctcb2 := make(map[string]*block.Block)
+	ctcb2[balanceFtID] = nil
+	blk2 := block.CreateNewBlock(ctcb2, tcb2)
+	if blk2 == nil {
+		return nil, fmt.Errorf("failed to create new block")
+	}
+	err = blk2.UpdateSignature(dc)
+	if err != nil {
+		c.log.Error("FT creation failed, failed to update signature", "err", err)
+		return nil, err
+	}
+	err = c.w.AddTokenBlock(balanceFtID, blk2)
+	if err != nil {
+		c.log.Error("Failed to create FT, failed to add token chain block", "err", err)
+		return nil, err
+	}
+
+	// Create the balance token
+	balanceFTInfo := wallet.FTToken{
+		TokenID:       balanceFtID,
+		FTName:        t.FTName,
+		TokenStatus:   wallet.TokenIsFree,
+		TokenValue:    balanceValue,
+		DID:           did,
+		RBTLockStatus: RBTLockStatus,
+		CreatorDID:    t.CreatorDID,
+	}
+
+	err = c.w.CreateFT(&balanceFTInfo)
+	if err != nil {
+		c.log.Error("Failed to write FT details in FT tokens table", "err", err)
+		return nil, err
+	}
+
+	// Burn the parent token
+	ftBurnBlock := &block.TransInfo{
+		Tokens: []block.TransTokens{
+			{
+				Token:     token,
+				TokenType: tokenType,
+			},
+		},
+		Comment: "Token burnt at : " + time.Now().String(),
+	}
+	parentFtBlock := &block.TokenChainBlock{
+		TransactionType: block.TokenBurntType,
+		TokenOwner:      did,
+		TransInfo:       ftBurnBlock,
+		TokenValue:      currentTokenValue,
+		ChildTokens:     []string{targetFtId, balanceFtID},
+	}
+	ctcb3 := make(map[string]*block.Block)
+	ctcb3[token] = c.w.GetLatestTokenBlock(token, tokenType)
+	parentBlockDetails = block.CreateNewBlock(ctcb3, parentFtBlock)
+	if parentBlockDetails == nil {
+		return nil, fmt.Errorf("failed to create new block")
+	}
+	err = parentBlockDetails.UpdateSignature(dc)
+	if err != nil {
+		c.log.Error("part token creation failed, failed to update signature", "err", err)
+		return nil, err
+	}
+	err = c.w.AddTokenBlock(token, parentBlockDetails)
+	if err != nil {
+		c.log.Error("part token creation failed, failed to add token block", "err", err)
+		return nil, err
+	}
+	t.TokenStatus = wallet.TokenIsBurnt
+	err = c.s.Update(wallet.FTTokenStorage, &t, "owner_did=? AND token_id=?", did, t.TokenID)
+	if err != nil {
+		c.log.Error("failed to update the token status to token is burned")
+	}
+
+	var ftTokens []wallet.FTToken
+	ftTokens = append(ftTokens, balanceFTInfo, targetFtInfo)
+
+	return ftTokens, nil
+}
+
+// GetClosestTokens finds the optimal combination of FT tokens to match a target value
+// Implements multiple strategies: exact match, best combination, token splitting
+func (c *Core) GetClosestTokens(dc did.DIDCrypto, ownerDID string, targetValue float64, FTName string) ([]wallet.FTToken, error) {
+	c.log.Warn("GetClosestTokens called", "owner_did", ownerDID, "target_value", targetValue, "ft_name", FTName)
+	var tokens []wallet.FTToken
+
+	err := c.s.Read(wallet.FTTokenStorage, &tokens, "owner_did=? AND token_status=? AND ft_name=?", ownerDID, wallet.TokenIsFree, FTName)
+	if err != nil {
+		c.log.Error("Failed to query free tokens", "err", err)
+		return nil, err
+	}
+
+	if len(tokens) == 0 {
+		c.log.Warn("No tokens available")
+		return nil, fmt.Errorf("insufficient balance")
+	}
+
+	// Step 1: Check total available balance
+	total := 0.0
+	for _, t := range tokens {
+		total += t.TokenValue
+	}
+	if total < targetValue {
+		c.log.Warn("Total balance is less than target", "total", total, "required", targetValue)
+		return nil, fmt.Errorf("insufficient balance")
+	}
+
+	// Step 2: Check for exact match
+	for _, token := range tokens {
+		c.log.Warn("Checking for exact match", "token_value", token.TokenValue, "target_value", targetValue)
+		if token.TokenValue == targetValue {
+			token.TokenStatus = wallet.TokenIsLocked
+			err := c.s.Update(wallet.FTTokenStorage, &token, "owner_did=? AND token_id=?", ownerDID, token.TokenID)
+			if err != nil {
+				return nil, err
+			}
+			return []wallet.FTToken{token}, nil
+		}
+	}
+
+	// Step 3: Try to find exact combination
+	selectedTokens, sum, err := c.findBestCombination(tokens, targetValue)
+	c.log.Warn("Best combination found", "sum", sum, "target_value", targetValue)
+	if err == nil && sum == targetValue {
+		for i := range selectedTokens {
+			selectedTokens[i].TokenStatus = wallet.TokenIsLocked
+			err := c.s.Update(wallet.FTTokenStorage, &selectedTokens[i], "owner_did=? AND token_id=?", ownerDID, selectedTokens[i].TokenID)
+			if err != nil {
+				return nil, err
+			}
+		}
+		return selectedTokens, nil
+	}
+
+	// Step 4: Try to split a token from an over-sum combination
+	if err == nil && sum > targetValue {
+		c.log.Warn("Trying to split a token from an over-sum combination", "sum", sum, "target_value", targetValue)
+		excess := sum - targetValue
+		c.log.Warn("Excess value to split", "excess", excess)
+		for i, token := range selectedTokens {
+			if token.TokenValue > excess {
+				splitTokens, splitErr := c.splitFTToken(dc, ownerDID, token.TokenID, token.TokenValue, excess)
+				if splitErr != nil {
+					continue
+				}
+
+				var splitOutToken *wallet.FTToken
+				desiredValue := token.TokenValue - excess
+				for _, t := range splitTokens {
+					if t.TokenValue == desiredValue {
+						splitOutToken = &t
+						break
+					}
+				}
+				if splitOutToken == nil {
+					continue
+				}
+
+				// Build final list excluding the burned token
+				var finalTokens []wallet.FTToken
+				for j, t := range selectedTokens {
+					if j == i {
+						continue // skip burned token
+					}
+					t.TokenStatus = wallet.TokenIsLocked
+					err := c.s.Update(wallet.FTTokenStorage, &t, "owner_did=? AND token_id=?", ownerDID, t.TokenID)
+					if err != nil {
+						return nil, err
+					}
+					finalTokens = append(finalTokens, t)
+				}
+				c.log.Info("Split Token Found", "expected", desiredValue, "actual", splitOutToken.TokenValue)
+				splitOutToken.TokenStatus = wallet.TokenIsLocked
+				err := c.s.Update(wallet.FTTokenStorage, splitOutToken, "owner_did=? AND token_id=?", ownerDID, splitOutToken.TokenID)
+				if err != nil {
+					return nil, err
+				}
+				finalTokens = append(finalTokens, *splitOutToken)
+				return finalTokens, nil
+			}
+		}
+	}
+
+	// Step 5: Try to find a single token > targetValue for split
+	for _, token := range tokens {
+		c.log.Warn("Checking for single token split", "token_value", token.TokenValue, "target_value", targetValue)
+		if token.TokenValue > targetValue {
+			splitTokens, splitErr := c.splitFTToken(dc, ownerDID, token.TokenID, token.TokenValue, targetValue)
+			if splitErr != nil {
+				continue
+			}
+
+			var splitOutToken *wallet.FTToken
+			for _, t := range splitTokens {
+				if t.TokenValue == targetValue {
+					splitOutToken = &t
+					break
+				}
+			}
+			if splitOutToken == nil {
+				continue
+			}
+
+			splitOutToken.TokenStatus = wallet.TokenIsLocked
+			return []wallet.FTToken{*splitOutToken}, nil
+		}
+	}
+
+	return nil, fmt.Errorf("unable to fulfill the request: no suitable token combination or split possible")
 }

--- a/core/model/ft.go
+++ b/core/model/ft.go
@@ -29,16 +29,19 @@ type GetFTInfo struct {
 }
 
 type FTInfo struct {
-	FTName      string `json:"ft_name"`
-	FTCount     int    `json:"ft_count"`
-	CreatorDID  string `json:"creator_did"`
-	HighValueFT bool   `json:"high_value_ft"`
+	FTName       string  `json:"ft_name"`
+	FTCount      int     `json:"ft_count"`
+	CreatorDID   string  `json:"creator_did"`
+	HighValueFT  bool    `json:"high_value_ft"`
+	FTTotalValue float64 `json:"ft_total_value"`
 }
 
 type FTInfoForExplorer struct {
-	FTName     string `json:"ft_symbol"`
-	FTCount    int    `json:"ft_balance"`
-	CreatorDID string `json:"creator_did"`
+	FTName       string  `json:"ft_symbol"`
+	FTCount      int     `json:"ft_balance"`
+	CreatorDID   string  `json:"creator_did"`
+	HighValueFT  bool    `json:"high_value_ft"`
+	FTTotalValue float64 `json:"ft_total_value"`
 }
 
 type BurnFTReq struct {

--- a/core/model/ft.go
+++ b/core/model/ft.go
@@ -1,22 +1,26 @@
 package model
 
 type CreateFTReq struct {
-	DID             string `json:"did"`
-	FTName          string `json:"ft_name"`
-	FTCount         int    `json:"ft_count"`
-	TokenCount      int    `json:"token_count"`
-	FTNumStartIndex int    `json:"ft_num_start_index"`
+	DID             string  `json:"did"`
+	FTName          string  `json:"ft_name"`
+	FTCount         int     `json:"ft_count"`
+	FTValue         float64 `json:"ft_value"`
+	FTNumStartIndex int     `json:"ft_num_start_index"`
+	FromRBT         bool    `json:"from_rbt"`
+	IsHighValueFT   bool    `json:"is_high_value"`
 }
 
 type TransferFTReq struct {
-	Receiver   string `json:"receiver"`
-	Sender     string `json:"sender"`
-	FTName     string `json:"ft_name"`
-	FTCount    int    `json:"ft_count"`
-	Comment    string `json:"comment"`
-	QuorumType int    `json:"quorum_type"`
-	Password   string `json:"password"`
-	CreatorDID string `json:"creatorDID"`
+	Receiver        string  `json:"receiver"`
+	Sender          string  `json:"sender"`
+	FTName          string  `json:"ft_name"`
+	FTCount         int     `json:"ft_count"`
+	Comment         string  `json:"comment"`
+	QuorumType      int     `json:"quorum_type"`
+	Password        string  `json:"password"`
+	CreatorDID      string  `json:"creatorDID"`
+	IsHighValueFT   bool    `json:"is_high_value"`
+	FTTransferValue float64 `json:"ft_value"`
 }
 
 type GetFTInfo struct {
@@ -25,13 +29,22 @@ type GetFTInfo struct {
 }
 
 type FTInfo struct {
-	FTName     string `json:"ft_name"`
-	FTCount    int    `json:"ft_count"`
-	CreatorDID string `json:"creator_did"`
+	FTName      string `json:"ft_name"`
+	FTCount     int    `json:"ft_count"`
+	CreatorDID  string `json:"creator_did"`
+	HighValueFT bool   `json:"high_value_ft"`
 }
 
 type FTInfoForExplorer struct {
 	FTName     string `json:"ft_symbol"`
 	FTCount    int    `json:"ft_balance"`
 	CreatorDID string `json:"creator_did"`
+}
+
+type BurnFTReq struct {
+	DID         string `json:"did"`
+	FTName      string `json:"ft_name"`
+	FTCount     int    `json:"ft_count"`
+	FromRBT     bool   `json:"from_rbt"`
+	HighValueFT bool   `json:"high_value_ft"`
 }

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -82,7 +82,7 @@ type ConensusRequest struct {
 	NFT                string       `json:"nft"`
 	FTinfo             model.FTInfo `json:"ft_info"`
 	// TransTokenSyncInfo map[string]GenesisAndLatestBlocks `json:"tokens_sync_info"`
-	ExplorerDone       chan struct{} `json:"-"` // Channel to signal explorer submission completion
+	ExplorerDone chan struct{} `json:"-"` // Channel to signal explorer submission completion
 }
 
 type ConensusReply struct {
@@ -451,9 +451,14 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 	case SmartContractExecuteMode, NFTExecuteMode:
 		reqPledgeTokens = sc.GetTotalRBTs()
 	case FTTransferMode:
-		ti := sc.GetTransTokenInfo()
-		for i := range ti {
-			reqPledgeTokens = reqPledgeTokens + ti[i].TokenValue
+		// For high-value FT, enforce fixed pledge requirement of 10
+		if cr.FTinfo.HighValueFT {
+			reqPledgeTokens = 10
+		} else {
+			ti := sc.GetTransTokenInfo()
+			for i := range ti {
+				reqPledgeTokens = reqPledgeTokens + ti[i].TokenValue
+			}
 		}
 	}
 	minValue := MinDecimalValue(MaxDecimalPlaces)
@@ -1087,7 +1092,7 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 				if cr.ExplorerDone != nil {
 					c.log.Info("Waiting for explorer submission to complete before sending confirmation",
 						"transaction_id", cr.TransactionID)
-					
+
 					select {
 					case <-cr.ExplorerDone:
 						c.log.Info("Explorer submission completed, proceeding with receiver confirmation",
@@ -1097,20 +1102,20 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 							"transaction_id", cr.TransactionID)
 					}
 				}
-				
+
 				// Calculate initial delay based on token count to allow receiver processing
 				tokenCount := len(ti)
 				var initialDelay time.Duration
-				
+
 				// Since we already waited for explorer submission, receiver has had time to start processing
 				// Use more realistic delays based on observed parallel performance
 				baseDelay := 2 * time.Second // Network latency + setup
-				
+
 				// Adjusted processing time based on parallel receiver performance
 				// Observed: ~12.5 tokens/second with parallel processing
 				// Use 15 tokens/sec for calculation since receiver started during explorer wait
 				processingTime := time.Duration(tokenCount/15) * time.Second
-				
+
 				// Reduced buffer since we already waited for explorer
 				var buffer time.Duration
 				switch {
@@ -1123,9 +1128,9 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 				default:
 					buffer = 3 * time.Second
 				}
-				
+
 				initialDelay = baseDelay + processingTime + buffer
-				
+
 				// Cap maximum delay at 30 seconds since we already waited for explorer
 				maxDelay := 30 * time.Second
 				if initialDelay > maxDelay {
@@ -1135,13 +1140,13 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 						"token_count", tokenCount)
 					initialDelay = maxDelay
 				}
-				
+
 				// Sleep before first attempt to let receiver process
 				c.log.Info("Waiting for receiver to process tokens before confirmation",
 					"delay", initialDelay,
 					"token_count", tokenCount)
 				time.Sleep(initialDelay)
-				
+
 				// Adaptive retry parameters based on token count
 				var backoff time.Duration
 				switch {
@@ -1158,15 +1163,15 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 					// Very large transfers need significant retry spacing
 					backoff = 120 * time.Second
 				}
-				
+
 				maxBackoff := 5 * time.Minute
 				maxRetries := 10
 				totalTimeout := 30 * time.Minute
-				
+
 				// Create timeout context
 				ctx, cancel := context.WithTimeout(context.Background(), totalTimeout)
 				defer cancel()
-				
+
 				for currAttempt := 1; currAttempt <= maxRetries; currAttempt++ {
 					// Check if context is cancelled
 					select {
@@ -1186,7 +1191,7 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 							tid,
 							receiverAddr,
 						))
-						
+
 						// If this is the last attempt, log the final error
 						if currAttempt == maxRetries {
 							c.log.Error("Failed to send FT token confirmation after all retries",
@@ -1195,14 +1200,14 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 								"attempts", maxRetries,
 								"error", err)
 						}
-						
+
 						// Wait with context awareness
 						select {
 						case <-ctx.Done():
 							return
 						case <-time.After(backoff):
 						}
-						
+
 						backoff = time.Duration(float64(backoff) * 1.5)
 						if backoff > maxBackoff {
 							backoff = maxBackoff

--- a/core/wallet/ft.go
+++ b/core/wallet/ft.go
@@ -13,7 +13,7 @@ type FTToken struct {
 	TokenValue     float64   `gorm:"column:token_value"`
 	TokenStateHash string    `gorm:"column:token_state_hash"`
 	TransactionID  string    `gorm:"column:transaction_id"`
-	RBTLockStatus  int       `gorm:"column:rbt_lock_status"`
+	RBTLockStatus  int       `gorm:"column:rbt_lock_status;default:1"`
 	CreatedAt      time.Time `gorm:"column:created_at;autoCreateTime"`
 	UpdatedAt      time.Time `gorm:"column:updated_at;autoUpdateTime"`
 }

--- a/core/wallet/ft.go
+++ b/core/wallet/ft.go
@@ -19,11 +19,9 @@ type FTToken struct {
 }
 
 type FT struct {
-	ID               string `gorm:"column:id;primaryKey;autoIncrement"`
-	FTName           string `gorm:"column:ft_name"`
-	FTCount          int    `gorm:"column:ft_count"`
-	FTCreatedCount   int    `gorm:"column:ft_created_count"`
-	FTAvailableCount int    `gorm:"column:ft_available_count"`
-	CreatorDID       string `gorm:"column:creator_did"`
-	HighValueFT      bool   `gorm:"column:high_value_ft"`
+	ID          string `gorm:"column:id;primaryKey;autoIncrement"`
+	FTName      string `gorm:"column:ft_name"`
+	FTCount     int    `gorm:"column:ft_count"`
+	CreatorDID  string `gorm:"column:creator_did"`
+	HighValueFT bool   `gorm:"column:high_value_ft"`
 }

--- a/core/wallet/ft.go
+++ b/core/wallet/ft.go
@@ -25,4 +25,5 @@ type FT struct {
 	FTCreatedCount   int    `gorm:"column:ft_created_count"`
 	FTAvailableCount int    `gorm:"column:ft_available_count"`
 	CreatorDID       string `gorm:"column:creator_did"`
+	HighValueFT      bool   `gorm:"column:high_value_ft"`
 }

--- a/core/wallet/ft.go
+++ b/core/wallet/ft.go
@@ -25,3 +25,11 @@ type FT struct {
 	CreatorDID  string `gorm:"column:creator_did"`
 	HighValueFT bool   `gorm:"column:high_value_ft"`
 }
+
+// FTIndex tracks the next FT number per (ft_name, creator_did)
+type FTIndex struct {
+	FTIndexID  int    `gorm:"column:id;primaryKey;autoIncrement"`
+	FTName     string `gorm:"column:ft_name"`
+	CreatorDID string `gorm:"column:creator_did"`
+	FTIndex    int    `gorm:"column:ft_index"`
+}

--- a/core/wallet/ft.go
+++ b/core/wallet/ft.go
@@ -13,13 +13,23 @@ type FTToken struct {
 	TokenValue     float64   `gorm:"column:token_value"`
 	TokenStateHash string    `gorm:"column:token_state_hash"`
 	TransactionID  string    `gorm:"column:transaction_id"`
+	RBTLockStatus  int       `gorm:"column:rbt_lock_status"`
 	CreatedAt      time.Time `gorm:"column:created_at;autoCreateTime"`
 	UpdatedAt      time.Time `gorm:"column:updated_at;autoUpdateTime"`
 }
 
 type FT struct {
-	ID         string `gorm:"column:id;primaryKey;autoIncrement"`
+	ID               string `gorm:"column:id;primaryKey;autoIncrement"`
+	FTName           string `gorm:"column:ft_name"`
+	FTCount          int    `gorm:"column:ft_count"`
+	FTCreatedCount   int    `gorm:"column:ft_created_count"`
+	FTAvailableCount int    `gorm:"column:ft_available_count"`
+	CreatorDID       string `gorm:"column:creator_did"`
+}
+
+type FTIndex struct {
+	FTIndexID  int    `gorm:"column:id;primaryKey;autoIncrement"`
 	FTName     string `gorm:"column:ft_name"`
-	FTCount    int    `gorm:"column:ft_count"`
 	CreatorDID string `gorm:"column:creator_did"`
+	FTIndex    int    `gorm:"column:ft_index"`
 }

--- a/core/wallet/ft.go
+++ b/core/wallet/ft.go
@@ -26,10 +26,3 @@ type FT struct {
 	FTAvailableCount int    `gorm:"column:ft_available_count"`
 	CreatorDID       string `gorm:"column:creator_did"`
 }
-
-type FTIndex struct {
-	FTIndexID  int    `gorm:"column:id;primaryKey;autoIncrement"`
-	FTName     string `gorm:"column:ft_name"`
-	CreatorDID string `gorm:"column:creator_did"`
-	FTIndex    int    `gorm:"column:ft_index"`
-}

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -33,8 +33,8 @@ const (
 	TokenPledgeIssue
 	TokenIsBeingDoubleSpent
 	TokenIsPinnedAsService
-	TokenIsBurntForFT
-	TokenIsPending // Tokens received but not yet confirmed by consensus finality
+	TokenIsLockedForFT
+	TokenIsPending                // Tokens received but not yet confirmed by consensus finality
 	QuorumPledgedForThisToken int = 20
 )
 const (
@@ -741,7 +741,7 @@ func (w *Wallet) TokensReceived(did string, ti []contract.TokenInfo, b *block.Bl
 		w.log.Info("Using optimized token receiver with batch downloads", "token_count", len(ti))
 		return w.OptimizedTokensReceived(did, ti, b, senderPeerId, receiverPeerId, pinningServiceMode, ipfsShell)
 	}
-	
+
 	w.l.Lock()
 	defer w.l.Unlock()
 	// TODO :: Needs to be address
@@ -862,7 +862,7 @@ func (w *Wallet) TokensReceived(did string, ti []contract.TokenInfo, b *block.Bl
 			// Fall back to synchronous processing
 			goto syncProcessing
 		}
-		w.log.Info("Provider details submitted for async processing", 
+		w.log.Info("Provider details submitted for async processing",
 			"transaction_id", b.GetTid(),
 			"token_count", len(providerMaps))
 		return updatedtokenhashes, nil
@@ -885,7 +885,7 @@ syncProcessing:
 // need to update in such a way that only for FTs
 func (w *Wallet) FTTokensReceived(did string, ti []contract.TokenInfo, b *block.Block, senderPeerId string, receiverPeerId string, ipfsShell *ipfsnode.Shell, ftInfo FTToken) ([]string, error) {
 	// Always use parallel FT receiver for consistent performance and no global locks
-	w.log.Info("Using parallel FT receiver", 
+	w.log.Info("Using parallel FT receiver",
 		"ft_count", len(ti),
 		"ft_name", ftInfo.FTName)
 	parallelReceiver := NewParallelFTReceiver(w)
@@ -1009,7 +1009,7 @@ func (w *Wallet) FTTokensReceivedLegacy(did string, ti []contract.TokenInfo, b *
 			// Fall back to synchronous processing
 			goto ftSyncProcessing
 		}
-		w.log.Info("FT provider details submitted for async processing", 
+		w.log.Info("FT provider details submitted for async processing",
 			"transaction_id", b.GetTid(),
 			"token_count", len(providerMaps))
 		return updatedtokenhashes, nil

--- a/core/wallet/wallet.go
+++ b/core/wallet/wallet.go
@@ -36,6 +36,7 @@ const (
 	FTStorage                      string = "FTTable"
 	FTTransactionTokenStorage      string = "FTTransactionTokens"
 	FailedFTDownloadStorage        string = "FailedFTDownloads"
+	FTIndexStorage                 string = "FTIndexTable"
 )
 
 type WalletConfig struct {

--- a/core/wallet/wallet.go
+++ b/core/wallet/wallet.go
@@ -168,6 +168,10 @@ func InitWallet(s storage.Storage, dir string, log logger.Logger) (*Wallet, erro
 	if err != nil {
 		w.log.Error("Failed to initialize FT Token storage", "err", err)
 	}
+	// Ensure FTIndexTable exists before FT operations (used for high-value FT numbering)
+	if err := w.s.Init(FTIndexStorage, &FTIndex{}, true); err != nil {
+		w.log.Error("Failed to initialize FTIndex storage", "err", err)
+	}
 	err = w.s.Init(FTStorage, &FT{}, true)
 	if err != nil {
 		w.log.Error("Failed to initialize FT storage", "err", err)

--- a/core/wallet/wallet.go
+++ b/core/wallet/wallet.go
@@ -34,6 +34,7 @@ const (
 	FTTokenStorage                 string = "FTTokenTable"
 	FTChainStorage                 string = "FTchainstorage"
 	FTStorage                      string = "FTTable"
+	FTIndexStorage                 string = "FTIndexTable"
 	FTTransactionTokenStorage      string = "FTTransactionTokens"
 	FailedFTDownloadStorage        string = "FailedFTDownloads"
 )
@@ -170,6 +171,10 @@ func InitWallet(s storage.Storage, dir string, log logger.Logger) (*Wallet, erro
 	err = w.s.Init(FTStorage, &FT{}, true)
 	if err != nil {
 		w.log.Error("Failed to initialize FT storage", "err", err)
+	}
+	err = w.s.Init(FTIndexStorage, &FTIndex{}, true)
+	if err != nil {
+		w.log.Error("Failed to initialize FT Index storage", "err", err)
 	}
 	err = w.s.Init(FTTransactionTokenStorage, &model.FTTransactionToken{}, true)
 	if err != nil {

--- a/core/wallet/wallet.go
+++ b/core/wallet/wallet.go
@@ -34,7 +34,6 @@ const (
 	FTTokenStorage                 string = "FTTokenTable"
 	FTChainStorage                 string = "FTchainstorage"
 	FTStorage                      string = "FTTable"
-	FTIndexStorage                 string = "FTIndexTable"
 	FTTransactionTokenStorage      string = "FTTransactionTokens"
 	FailedFTDownloadStorage        string = "FailedFTDownloads"
 )
@@ -171,10 +170,6 @@ func InitWallet(s storage.Storage, dir string, log logger.Logger) (*Wallet, erro
 	err = w.s.Init(FTStorage, &FT{}, true)
 	if err != nil {
 		w.log.Error("Failed to initialize FT storage", "err", err)
-	}
-	err = w.s.Init(FTIndexStorage, &FTIndex{}, true)
-	if err != nil {
-		w.log.Error("Failed to initialize FT Index storage", "err", err)
 	}
 	err = w.s.Init(FTTransactionTokenStorage, &model.FTTransactionToken{}, true)
 	if err != nil {

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -237,7 +237,7 @@ const docTemplate = `{
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/server.CreateFTReqSwaggoInput"
+                            "$ref": "#/definitions/model.CreateFTReq"
                         }
                     }
                 ],
@@ -1729,6 +1729,32 @@ const docTemplate = `{
                 }
             }
         },
+        "model.CreateFTReq": {
+            "type": "object",
+            "properties": {
+                "did": {
+                    "type": "string"
+                },
+                "from_rbt": {
+                    "type": "boolean"
+                },
+                "ft_count": {
+                    "type": "integer"
+                },
+                "ft_name": {
+                    "type": "string"
+                },
+                "ft_num_start_index": {
+                    "type": "integer"
+                },
+                "ft_value": {
+                    "type": "number"
+                },
+                "is_high_value": {
+                    "type": "boolean"
+                }
+            }
+        },
         "model.DIDFromPubKeyResponse": {
             "type": "object",
             "properties": {
@@ -1748,6 +1774,9 @@ const docTemplate = `{
                 },
                 "ft_name": {
                     "type": "string"
+                },
+                "ft_total_value": {
+                    "type": "number"
                 },
                 "high_value_ft": {
                     "type": "boolean"
@@ -1907,26 +1936,6 @@ const docTemplate = `{
                 },
                 "high_value_ft": {
                     "type": "boolean"
-                }
-            }
-        },
-        "server.CreateFTReqSwaggoInput": {
-            "type": "object",
-            "properties": {
-                "did": {
-                    "type": "string"
-                },
-                "ft_count": {
-                    "type": "integer"
-                },
-                "ft_name": {
-                    "type": "string"
-                },
-                "ft_num_start_index": {
-                    "type": "integer"
-                },
-                "token_count": {
-                    "type": "integer"
                 }
             }
         },

--- a/docs/docs.go
+++ b/docs/docs.go
@@ -52,6 +52,40 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/burn-ft": {
+            "post": {
+                "description": "This API endpoint will burn FTs and optionally unlock parent RBTs.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "FT"
+                ],
+                "summary": "Burn FTs",
+                "parameters": [
+                    {
+                        "description": "Burn FT",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.BurnFTReqSwaggoInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/check-pinned-state": {
             "delete": {
                 "description": "This API is used to check if the token state for which the token is pledged is exhausted or not.",
@@ -721,6 +755,41 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/get-failed-ft-download-status": {
+            "post": {
+                "description": "This API returns the status of failed FT downloads",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "FT"
+                ],
+                "summary": "Get Failed FT Download Status",
+                "operationId": "get-failed-ft-download-status",
+                "parameters": [
+                    {
+                        "description": "DID",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.FailedFTDownloadStatusRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/get-ft-info-by-did": {
             "get": {
                 "description": "This API endpoint retrieves the names and count of FTs of a given DID.",
@@ -1122,6 +1191,50 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/recover-lost-tokens": {
+            "post": {
+                "description": "Allows senders to recover tokens that were sent but not received by the receiver",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "FT"
+                ],
+                "summary": "Recover lost tokens",
+                "operationId": "recover-lost-tokens",
+                "parameters": [
+                    {
+                        "description": "DID of the sender",
+                        "name": "sender_did",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Transaction ID to recover tokens from",
+                        "name": "transaction_id",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/recover-token": {
             "post": {
                 "description": "This API will recover token and tokenchain from the Pinning node to the node which has pinned the token",
@@ -1192,6 +1305,67 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/remote-recover-tokens": {
+            "post": {
+                "description": "Allows Node A to trigger token recovery on Node B",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "FT"
+                ],
+                "summary": "Initiate remote token recovery",
+                "operationId": "remote-recover-tokens",
+                "parameters": [
+                    {
+                        "description": "DID of the target node where recovery should happen",
+                        "name": "target_did",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Transaction ID to recover",
+                        "name": "transaction_id",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "DID of the requesting node",
+                        "name": "requester_did",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Reason for remote recovery",
+                        "name": "reason",
+                        "in": "body",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/request-did-for-pubkey": {
             "post": {
                 "description": "This API will returns DID for corresponding public key",
@@ -1222,6 +1396,41 @@ const docTemplate = `{
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/model.DIDFromPubKeyResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/retry-failed-ft-downloads": {
+            "post": {
+                "description": "This API retries downloading failed FT tokens",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "FT"
+                ],
+                "summary": "Retry Failed FT Downloads",
+                "operationId": "retry-failed-ft-downloads",
+                "parameters": [
+                    {
+                        "description": "DID",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.RetryFailedFTDownloadsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
                         }
                     }
                 }
@@ -1539,6 +1748,9 @@ const docTemplate = `{
                 },
                 "ft_name": {
                     "type": "string"
+                },
+                "high_value_ft": {
+                    "type": "boolean"
                 }
             }
         },
@@ -1678,6 +1890,26 @@ const docTemplate = `{
                 }
             }
         },
+        "server.BurnFTReqSwaggoInput": {
+            "type": "object",
+            "properties": {
+                "did": {
+                    "type": "string"
+                },
+                "from_rbt": {
+                    "type": "boolean"
+                },
+                "ft_count": {
+                    "type": "integer"
+                },
+                "ft_name": {
+                    "type": "string"
+                },
+                "high_value_ft": {
+                    "type": "boolean"
+                }
+            }
+        },
         "server.CreateFTReqSwaggoInput": {
             "type": "object",
             "properties": {
@@ -1812,6 +2044,14 @@ const docTemplate = `{
                 }
             }
         },
+        "server.FailedFTDownloadStatusRequest": {
+            "type": "object",
+            "properties": {
+                "did": {
+                    "type": "string"
+                }
+            }
+        },
         "server.GetSmartContractTokenChainDataSwaggoInput": {
             "type": "object",
             "properties": {
@@ -1918,6 +2158,14 @@ const docTemplate = `{
                 }
             }
         },
+        "server.RetryFailedFTDownloadsRequest": {
+            "type": "object",
+            "properties": {
+                "did": {
+                    "type": "string"
+                }
+            }
+        },
         "server.SignatureResponseSwaggoInput": {
             "type": "object",
             "properties": {
@@ -1946,6 +2194,12 @@ const docTemplate = `{
                 },
                 "ft_name": {
                     "type": "string"
+                },
+                "ft_value": {
+                    "type": "number"
+                },
+                "is_high_value": {
+                    "type": "boolean"
                 },
                 "password": {
                     "type": "string"

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -229,7 +229,7 @@
                         "in": "body",
                         "required": true,
                         "schema": {
-                            "$ref": "#/definitions/server.CreateFTReqSwaggoInput"
+                            "$ref": "#/definitions/model.CreateFTReq"
                         }
                     }
                 ],
@@ -1721,6 +1721,32 @@
                 }
             }
         },
+        "model.CreateFTReq": {
+            "type": "object",
+            "properties": {
+                "did": {
+                    "type": "string"
+                },
+                "from_rbt": {
+                    "type": "boolean"
+                },
+                "ft_count": {
+                    "type": "integer"
+                },
+                "ft_name": {
+                    "type": "string"
+                },
+                "ft_num_start_index": {
+                    "type": "integer"
+                },
+                "ft_value": {
+                    "type": "number"
+                },
+                "is_high_value": {
+                    "type": "boolean"
+                }
+            }
+        },
         "model.DIDFromPubKeyResponse": {
             "type": "object",
             "properties": {
@@ -1740,6 +1766,9 @@
                 },
                 "ft_name": {
                     "type": "string"
+                },
+                "ft_total_value": {
+                    "type": "number"
                 },
                 "high_value_ft": {
                     "type": "boolean"
@@ -1899,26 +1928,6 @@
                 },
                 "high_value_ft": {
                     "type": "boolean"
-                }
-            }
-        },
-        "server.CreateFTReqSwaggoInput": {
-            "type": "object",
-            "properties": {
-                "did": {
-                    "type": "string"
-                },
-                "ft_count": {
-                    "type": "integer"
-                },
-                "ft_name": {
-                    "type": "string"
-                },
-                "ft_num_start_index": {
-                    "type": "integer"
-                },
-                "token_count": {
-                    "type": "integer"
                 }
             }
         },

--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -44,6 +44,40 @@
                 }
             }
         },
+        "/api/burn-ft": {
+            "post": {
+                "description": "This API endpoint will burn FTs and optionally unlock parent RBTs.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "FT"
+                ],
+                "summary": "Burn FTs",
+                "parameters": [
+                    {
+                        "description": "Burn FT",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.BurnFTReqSwaggoInput"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/check-pinned-state": {
             "delete": {
                 "description": "This API is used to check if the token state for which the token is pledged is exhausted or not.",
@@ -713,6 +747,41 @@
                 }
             }
         },
+        "/api/get-failed-ft-download-status": {
+            "post": {
+                "description": "This API returns the status of failed FT downloads",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "FT"
+                ],
+                "summary": "Get Failed FT Download Status",
+                "operationId": "get-failed-ft-download-status",
+                "parameters": [
+                    {
+                        "description": "DID",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.FailedFTDownloadStatusRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/get-ft-info-by-did": {
             "get": {
                 "description": "This API endpoint retrieves the names and count of FTs of a given DID.",
@@ -1114,6 +1183,50 @@
                 }
             }
         },
+        "/api/recover-lost-tokens": {
+            "post": {
+                "description": "Allows senders to recover tokens that were sent but not received by the receiver",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "FT"
+                ],
+                "summary": "Recover lost tokens",
+                "operationId": "recover-lost-tokens",
+                "parameters": [
+                    {
+                        "description": "DID of the sender",
+                        "name": "sender_did",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Transaction ID to recover tokens from",
+                        "name": "transaction_id",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/recover-token": {
             "post": {
                 "description": "This API will recover token and tokenchain from the Pinning node to the node which has pinned the token",
@@ -1184,6 +1297,67 @@
                 }
             }
         },
+        "/api/remote-recover-tokens": {
+            "post": {
+                "description": "Allows Node A to trigger token recovery on Node B",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "FT"
+                ],
+                "summary": "Initiate remote token recovery",
+                "operationId": "remote-recover-tokens",
+                "parameters": [
+                    {
+                        "description": "DID of the target node where recovery should happen",
+                        "name": "target_did",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Transaction ID to recover",
+                        "name": "transaction_id",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "DID of the requesting node",
+                        "name": "requester_did",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "Reason for remote recovery",
+                        "name": "reason",
+                        "in": "body",
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/request-did-for-pubkey": {
             "post": {
                 "description": "This API will returns DID for corresponding public key",
@@ -1214,6 +1388,41 @@
                         "description": "OK",
                         "schema": {
                             "$ref": "#/definitions/model.DIDFromPubKeyResponse"
+                        }
+                    }
+                }
+            }
+        },
+        "/api/retry-failed-ft-downloads": {
+            "post": {
+                "description": "This API retries downloading failed FT tokens",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "FT"
+                ],
+                "summary": "Retry Failed FT Downloads",
+                "operationId": "retry-failed-ft-downloads",
+                "parameters": [
+                    {
+                        "description": "DID",
+                        "name": "input",
+                        "in": "body",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/definitions/server.RetryFailedFTDownloadsRequest"
+                        }
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/model.BasicResponse"
                         }
                     }
                 }
@@ -1531,6 +1740,9 @@
                 },
                 "ft_name": {
                     "type": "string"
+                },
+                "high_value_ft": {
+                    "type": "boolean"
                 }
             }
         },
@@ -1670,6 +1882,26 @@
                 }
             }
         },
+        "server.BurnFTReqSwaggoInput": {
+            "type": "object",
+            "properties": {
+                "did": {
+                    "type": "string"
+                },
+                "from_rbt": {
+                    "type": "boolean"
+                },
+                "ft_count": {
+                    "type": "integer"
+                },
+                "ft_name": {
+                    "type": "string"
+                },
+                "high_value_ft": {
+                    "type": "boolean"
+                }
+            }
+        },
         "server.CreateFTReqSwaggoInput": {
             "type": "object",
             "properties": {
@@ -1804,6 +2036,14 @@
                 }
             }
         },
+        "server.FailedFTDownloadStatusRequest": {
+            "type": "object",
+            "properties": {
+                "did": {
+                    "type": "string"
+                }
+            }
+        },
         "server.GetSmartContractTokenChainDataSwaggoInput": {
             "type": "object",
             "properties": {
@@ -1910,6 +2150,14 @@
                 }
             }
         },
+        "server.RetryFailedFTDownloadsRequest": {
+            "type": "object",
+            "properties": {
+                "did": {
+                    "type": "string"
+                }
+            }
+        },
         "server.SignatureResponseSwaggoInput": {
             "type": "object",
             "properties": {
@@ -1938,6 +2186,12 @@
                 },
                 "ft_name": {
                     "type": "string"
+                },
+                "ft_value": {
+                    "type": "number"
+                },
+                "is_high_value": {
+                    "type": "boolean"
                 },
                 "password": {
                     "type": "string"

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -14,6 +14,23 @@ definitions:
       status:
         type: boolean
     type: object
+  model.CreateFTReq:
+    properties:
+      did:
+        type: string
+      from_rbt:
+        type: boolean
+      ft_count:
+        type: integer
+      ft_name:
+        type: string
+      ft_num_start_index:
+        type: integer
+      ft_value:
+        type: number
+      is_high_value:
+        type: boolean
+    type: object
   model.DIDFromPubKeyResponse:
     properties:
       did:
@@ -27,6 +44,8 @@ definitions:
         type: integer
       ft_name:
         type: string
+      ft_total_value:
+        type: number
       high_value_ft:
         type: boolean
     type: object
@@ -132,19 +151,6 @@ definitions:
         type: string
       high_value_ft:
         type: boolean
-    type: object
-  server.CreateFTReqSwaggoInput:
-    properties:
-      did:
-        type: string
-      ft_count:
-        type: integer
-      ft_name:
-        type: string
-      ft_num_start_index:
-        type: integer
-      token_count:
-        type: integer
     type: object
   server.DIDFromPubKeySwaggoRequest:
     properties:
@@ -480,7 +486,7 @@ paths:
         name: input
         required: true
         schema:
-          $ref: '#/definitions/server.CreateFTReqSwaggoInput'
+          $ref: '#/definitions/model.CreateFTReq'
       produces:
       - application/json
       responses:

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -27,6 +27,8 @@ definitions:
         type: integer
       ft_name:
         type: string
+      high_value_ft:
+        type: boolean
     type: object
   model.GetFTInfo:
     properties:
@@ -118,6 +120,19 @@ definitions:
           $ref: '#/definitions/model.TransactionCount'
         type: array
     type: object
+  server.BurnFTReqSwaggoInput:
+    properties:
+      did:
+        type: string
+      from_rbt:
+        type: boolean
+      ft_count:
+        type: integer
+      ft_name:
+        type: string
+      high_value_ft:
+        type: boolean
+    type: object
   server.CreateFTReqSwaggoInput:
     properties:
       did:
@@ -205,6 +220,11 @@ definitions:
       smartContractToken:
         type: string
     type: object
+  server.FailedFTDownloadStatusRequest:
+    properties:
+      did:
+        type: string
+    type: object
   server.GetSmartContractTokenChainDataSwaggoInput:
     properties:
       latest:
@@ -273,6 +293,11 @@ definitions:
       SmartContractToken:
         type: string
     type: object
+  server.RetryFailedFTDownloadsRequest:
+    properties:
+      did:
+        type: string
+    type: object
   server.SignatureResponseSwaggoInput:
     properties:
       id:
@@ -292,6 +317,10 @@ definitions:
         type: integer
       ft_name:
         type: string
+      ft_value:
+        type: number
+      is_high_value:
+        type: boolean
       password:
         type: string
       quorum_type:
@@ -331,6 +360,28 @@ paths:
       summary: Add Peer
       tags:
       - Account
+  /api/burn-ft:
+    post:
+      consumes:
+      - application/json
+      description: This API endpoint will burn FTs and optionally unlock parent RBTs.
+      parameters:
+      - description: Burn FT
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/server.BurnFTReqSwaggoInput'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.BasicResponse'
+      summary: Burn FTs
+      tags:
+      - FT
   /api/check-pinned-state:
     delete:
       consumes:
@@ -776,6 +827,29 @@ paths:
       summary: Get Data Token
       tags:
       - Data Tokens
+  /api/get-failed-ft-download-status:
+    post:
+      consumes:
+      - application/json
+      description: This API returns the status of failed FT downloads
+      operationId: get-failed-ft-download-status
+      parameters:
+      - description: DID
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/server.FailedFTDownloadStatusRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.BasicResponse'
+      summary: Get Failed FT Download Status
+      tags:
+      - FT
   /api/get-ft-info-by-did:
     get:
       consumes:
@@ -1042,6 +1116,36 @@ paths:
       summary: Get ALL NFTs
       tags:
       - NFT
+  /api/recover-lost-tokens:
+    post:
+      consumes:
+      - application/json
+      description: Allows senders to recover tokens that were sent but not received
+        by the receiver
+      operationId: recover-lost-tokens
+      parameters:
+      - description: DID of the sender
+        in: body
+        name: sender_did
+        required: true
+        schema:
+          type: string
+      - description: Transaction ID to recover tokens from
+        in: body
+        name: transaction_id
+        required: true
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.BasicResponse'
+      summary: Recover lost tokens
+      tags:
+      - FT
   /api/recover-token:
     post:
       consumes:
@@ -1090,6 +1194,46 @@ paths:
       summary: Get Smart Contract Token Chain Data
       tags:
       - Smart Contract
+  /api/remote-recover-tokens:
+    post:
+      consumes:
+      - application/json
+      description: Allows Node A to trigger token recovery on Node B
+      operationId: remote-recover-tokens
+      parameters:
+      - description: DID of the target node where recovery should happen
+        in: body
+        name: target_did
+        required: true
+        schema:
+          type: string
+      - description: Transaction ID to recover
+        in: body
+        name: transaction_id
+        required: true
+        schema:
+          type: string
+      - description: DID of the requesting node
+        in: body
+        name: requester_did
+        required: true
+        schema:
+          type: string
+      - description: Reason for remote recovery
+        in: body
+        name: reason
+        schema:
+          type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.BasicResponse'
+      summary: Initiate remote token recovery
+      tags:
+      - FT
   /api/request-did-for-pubkey:
     post:
       consumes:
@@ -1113,6 +1257,29 @@ paths:
       summary: Returns DID for corresponding public key
       tags:
       - Account
+  /api/retry-failed-ft-downloads:
+    post:
+      consumes:
+      - application/json
+      description: This API retries downloading failed FT tokens
+      operationId: retry-failed-ft-downloads
+      parameters:
+      - description: DID
+        in: body
+        name: input
+        required: true
+        schema:
+          $ref: '#/definitions/server.RetryFailedFTDownloadsRequest'
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/model.BasicResponse'
+      summary: Retry Failed FT Downloads
+      tags:
+      - FT
   /api/run-unpledge:
     post:
       consumes:

--- a/server/ft.go
+++ b/server/ft.go
@@ -20,14 +20,16 @@ type CreateFTReqSwaggoInput struct {
 }
 
 type TransferFTReqSwaggoInput struct {
-	Receiver   string `json:"receiver"`
-	Sender     string `json:"sender"`
-	FTName     string `json:"ft_name"`
-	FTCount    int    `json:"ft_count"`
-	Comment    string `json:"comment"`
-	QuorumType int    `json:"quorum_type"`
-	Password   string `json:"password"`
-	CreatorDID string `json:"creatorDID"`
+	Receiver        string  `json:"receiver"`
+	Sender          string  `json:"sender"`
+	FTName          string  `json:"ft_name"`
+	FTCount         int     `json:"ft_count"`
+	Comment         string  `json:"comment"`
+	QuorumType      int     `json:"quorum_type"`
+	Password        string  `json:"password"`
+	CreatorDID      string  `json:"creatorDID"`
+	IsHighValueFT   bool    `json:"is_high_value"`
+	FTTransferValue float64 `json:"ft_value"`
 }
 
 // ShowAccount godoc

--- a/server/ft.go
+++ b/server/ft.go
@@ -49,8 +49,7 @@ func (s *Server) APICreateFT(req *ensweb.Request) *ensweb.Result {
 		return s.BasicResponse(req, false, "DID does not have an access", nil)
 	}
 	s.c.AddWebReq(req)
-	rbtAmount := int(createFTReq.TokenCount)
-	go s.c.CreateFTs(req.ID, createFTReq.DID, createFTReq.FTCount, createFTReq.FTName, rbtAmount, createFTReq.FTNumStartIndex)
+	go s.c.CreateFTs(req.ID, createFTReq.DID, createFTReq.FTCount, createFTReq.FTName, createFTReq.FTValue, createFTReq.FTNumStartIndex, createFTReq.FromRBT, createFTReq.IsHighValueFT)
 	return s.didResponse(req, req.ID)
 }
 

--- a/server/ft.go
+++ b/server/ft.go
@@ -82,6 +82,38 @@ func (s *Server) APIInitiateFTTransfer(req *ensweb.Request) *ensweb.Result {
 	return s.didResponse(req, req.ID)
 }
 
+// BurnFTReqSwaggoInput represents the input for burning FTs
+type BurnFTReqSwaggoInput struct {
+	DID         string `json:"did"`
+	FTName      string `json:"ft_name"`
+	FTCount     int    `json:"ft_count"`
+	FromRBT     bool   `json:"from_rbt"`
+	HighValueFT bool   `json:"high_value_ft"`
+}
+
+// ShowAccount godoc
+// @Summary      Burn FTs
+// @Description  This API endpoint will burn FTs and optionally unlock parent RBTs.
+// @Tags         FT
+// @Accept       json
+// @Produce      json
+// @Param        input body BurnFTReqSwaggoInput true "Burn FT"
+// @Success      200  {object}  model.BasicResponse
+// @Router       /api/burn-ft [post]
+func (s *Server) APIBurnFT(req *ensweb.Request) *ensweb.Result {
+	var burnReq model.BurnFTReq
+	err := s.ParseJSON(req, &burnReq)
+	if err != nil {
+		return s.BasicResponse(req, false, "Invalid input", nil)
+	}
+	if !s.validateDIDAccess(req, burnReq.DID) {
+		return s.BasicResponse(req, false, "DID does not have an access", nil)
+	}
+	s.c.AddWebReq(req)
+	go s.c.BurnFT(req.ID, &burnReq)
+	return s.didResponse(req, req.ID)
+}
+
 // ShowAccount godoc
 // @Summary      Get FT balance information for a given DID
 // @Description  This API endpoint retrieves the names and count of FTs of a given DID.

--- a/server/ft.go
+++ b/server/ft.go
@@ -50,8 +50,16 @@ func (s *Server) APICreateFT(req *ensweb.Request) *ensweb.Result {
 	if !s.validateDIDAccess(req, createFTReq.DID) {
 		return s.BasicResponse(req, false, "DID does not have an access", nil)
 	}
+
+	// If high-value FT mode is enabled, override ftCount to 1
+	ftCount := createFTReq.FTCount
+	if createFTReq.IsHighValueFT {
+		ftCount = 1
+		s.log.Info("High-value FT mode enabled, setting ft_count to 1")
+	}
+
 	s.c.AddWebReq(req)
-	go s.c.CreateFTs(req.ID, createFTReq.DID, createFTReq.FTCount, createFTReq.FTName, createFTReq.FTValue, createFTReq.FTNumStartIndex, createFTReq.FromRBT, createFTReq.IsHighValueFT)
+	go s.c.CreateFTs(req.ID, createFTReq.DID, ftCount, createFTReq.FTName, createFTReq.FTValue, createFTReq.FTNumStartIndex, createFTReq.FromRBT, createFTReq.IsHighValueFT)
 	return s.didResponse(req, req.ID)
 }
 

--- a/server/ft.go
+++ b/server/ft.go
@@ -38,7 +38,7 @@ type TransferFTReqSwaggoInput struct {
 // @Tags         FT
 // @Accept       json
 // @Produce      json
-// @Param        input body CreateFTReqSwaggoInput true "Create FT"
+// @Param        input body model.CreateFTReq true "Create FT"
 // @Success      200  {object}  model.BasicResponse
 // @Router       /api/create-ft [post]
 func (s *Server) APICreateFT(req *ensweb.Request) *ensweb.Result {
@@ -160,14 +160,14 @@ func (s *Server) APIGetFTInfo(req *ensweb.Request) *ensweb.Result {
 
 func (s *Server) APIFixFTCreator(req *ensweb.Request) *ensweb.Result {
 	s.log.Info("Fixing FT tokens with peer ID as CreatorDID")
-	
+
 	// Run the fix utility
 	results, err := s.c.FixAllFTTokensWithPeerIDAsCreator()
 	if err != nil {
 		s.log.Error("Failed to fix FT creators", "err", err)
 		return s.BasicResponse(req, false, "Failed to fix FT creators: "+err.Error(), nil)
 	}
-	
+
 	// Convert results to a format suitable for JSON response
 	var responseResults []map[string]interface{}
 	successCount := 0
@@ -186,24 +186,24 @@ func (s *Server) APIFixFTCreator(req *ensweb.Request) *ensweb.Result {
 		}
 		responseResults = append(responseResults, r)
 	}
-	
+
 	message := fmt.Sprintf("Fixed %d of %d FT tokens", successCount, len(results))
 	if len(results) == 0 {
 		message = "No FT tokens found with peer ID as CreatorDID"
 	}
-	
+
 	return s.BasicResponse(req, true, message, responseResults)
 }
 
 func (s *Server) APIGetFTCreatorStats(req *ensweb.Request) *ensweb.Result {
 	s.log.Info("Getting FT creator statistics")
-	
+
 	// Get the statistics
 	stats, err := s.c.GetFTTokenCreatorStats()
 	if err != nil {
 		s.log.Error("Failed to get FT creator stats", "err", err)
 		return s.BasicResponse(req, false, "Failed to get FT creator statistics: "+err.Error(), nil)
 	}
-	
+
 	return s.BasicResponse(req, true, "FT creator statistics retrieved successfully", stats)
 }

--- a/server/server.go
+++ b/server/server.go
@@ -176,6 +176,7 @@ func (s *Server) RegisterRoutes() {
 	s.AddRoute(setup.APICreateFT, "POST", s.AuthHandle(s.APICreateFT, true, s.AuthError, false))
 	s.AddRoute(setup.APIDumpFTTokenChainBlock, "POST", s.AuthHandle(s.APIDumpFTTokenChainBlock, true, s.AuthError, false))
 	s.AddRoute(setup.APIInitiateFTTransfer, "POST", s.AuthHandle(s.APIInitiateFTTransfer, true, s.AuthError, true))
+	s.AddRoute(setup.APIBurnFT, "POST", s.AuthHandle(s.APIBurnFT, true, s.AuthError, false))
 	s.AddRoute(setup.APIGetFTInfo, "GET", s.AuthHandle(s.APIGetFTInfo, true, s.AuthError, false))
 	s.AddRoute(setup.APIFixFTCreator, "POST", s.AuthHandle(s.APIFixFTCreator, true, s.AuthError, false))
 	s.AddRoute(setup.APIGetFTCreatorStats, "GET", s.AuthHandle(s.APIGetFTCreatorStats, true, s.AuthError, false))

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -108,6 +108,8 @@ const (
 	APIGetFailedFTDownloadStatus        string = "/api/get-failed-ft-download-status"
 	APIRecoverLostTokens                string = "/api/recover-lost-tokens"
 	APIRemoteRecoverTokens              string = "/api/remote-recover-tokens"
+	APIBurnFT                           string = "/api/burn-ft"
+	APIGetFTValue                       string = "/api/get-ft-value"
 )
 
 // jwt.RegisteredClaims


### PR DESCRIPTION
## Summary

This PR introduces **High-Value Fungible Tokens (HVFT)** functionality across the entire FT lifecycle, including **creation**, **transfer**, and **burn** operations. The changes encompass new API request parameters, updated RBT locking logic, and corresponding database schema modifications to support this new token type.

## Key Features Added

### 1. High-Value FT Creation (`/api/create-ft`)

Added support for creating High-Value FTs via the following new request parameters:

-   `is_high_value`: A boolean flag to identify the token as a High-Value FT.
-   `from_rbt`: Indicates if RBT is used for the FT creation.
-   `ft_value`: Defines the per-token value for HVFTs.

#### RBT Lock Calculation Change

The RBT count to be locked is now dynamically calculated for HVFTs using the formula:

RBTs locked  = ft_count * ft_value`

#### New DB Enhancements:

-   Added column `is_high_value_ft` to `FTTable` to identify high-value token sets.
-   Added column `rbt_lock_status` to `FTTokenTable` to track the RBT lock state per token.
-   Added a new `FTIndexTable` to maintain the latest index at which a High-Value FT was created.

### 2. FT Transfer Enhancements (`/api/transfer-ft`)

The existing transfer API has been extended to support High-Value FTs. The request body has been updated to include:

-   `is_high_value`
-   `ft_value`
-   `from_rbt` (if applicable)

This ensures correct validation and transfer logic for HVFTs, maintaining consistency with the new database schema.

### 3. FT Burn Implementation (`/api/burn-ft`)

Introduced new burn functionality for both standard and high-value FTs. The burn logic now correctly identifies and handles high-value tokens with the new `high_value_ft` flag.

**Request Body Example:**

```json
{
  "did": "bafybmiguvjk5nqxjmrdhfna42dzpgloy47d7r3vncsax6nxe3irir4vkdy",
  "from_rbt": false,
  "ft_count": 1,
  "ft_name": "HVFT",
  "high_value_ft": true
}