### PR TITLE
Updates for Xell Migration

### DIFF
--- a/block/block.go
+++ b/block/block.go
@@ -60,7 +60,7 @@ const (
 	TokenContractCommited    string = "11"
 	TokenPinnedAsService     string = "12"
 	TokenIsBurntForFT        string = "13"
-	TokenSelfTransferredType string = "14" // xell migration
+	TokenSelfTransferredType string = "20" // xell migration
 )
 
 const (

--- a/block/block.go
+++ b/block/block.go
@@ -47,19 +47,20 @@ const (
 )
 
 const (
-	TokenMintedType       string = "01"
-	TokenTransferredType  string = "02"
-	TokenMigratedType     string = "03"
-	TokenPledgedType      string = "04"
-	TokenGeneratedType    string = "05"
-	TokenUnpledgedType    string = "06"
-	TokenCommittedType    string = "07"
-	TokenBurntType        string = "08"
-	TokenDeployedType     string = "09"
-	TokenExecutedType     string = "10"
-	TokenContractCommited string = "11"
-	TokenPinnedAsService  string = "12"
-	TokenIsBurntForFT     string = "13"
+	TokenMintedType          string = "01"
+	TokenTransferredType     string = "02"
+	TokenMigratedType        string = "03"
+	TokenPledgedType         string = "04"
+	TokenGeneratedType       string = "05"
+	TokenUnpledgedType       string = "06"
+	TokenCommittedType       string = "07"
+	TokenBurntType           string = "08"
+	TokenDeployedType        string = "09"
+	TokenExecutedType        string = "10"
+	TokenContractCommited    string = "11"
+	TokenPinnedAsService     string = "12"
+	TokenIsBurntForFT        string = "13"
+	TokenSelfTransferredType string = "14" // xell migration
 )
 
 const (

--- a/client/did.go
+++ b/client/did.go
@@ -315,3 +315,14 @@ func (c *Client) SignVerification(signerDID, signedMsg, signature string) (strin
 	result := fmt.Sprintf("sign verification Status : %v, Message : %v", resp.Status, resp.Message)
 	return result, nil
 }
+
+func (c *Client) RemoveStaleDID(didStr string) (*model.BasicResponse, error) {
+	m := make(map[string]interface{})
+	m["did"] = didStr
+	var rm model.BasicResponse
+	err := c.sendJSONRequest("POST", setup.APIRemoveStaleDID, nil, &m, &rm)
+	if err != nil {
+		return nil, err
+	}
+	return &rm, nil
+}

--- a/command/command.go
+++ b/command/command.go
@@ -305,7 +305,7 @@ type Command struct {
 	receiverAddr                 string
 	rbtAmount                    float64
 	transComment                 string
-	transType                    int
+	quorumType                   int
 	numTokens                    int
 	enableAuth                   bool
 	did                          string
@@ -366,7 +366,7 @@ type Command struct {
 	pgsqlDBName                  string
 	pgsqlDBUserName              string
 	pgsqlDBPassword              string
-	xellMigration                bool
+	operationType                int
 }
 
 func showVersion() {
@@ -716,7 +716,7 @@ func Run(args []string) {
 	flag.StringVar(&cmd.receiverAddr, "receiverAddr", "", "Receiver address")
 	flag.Float64Var(&cmd.rbtAmount, "rbtAmount", 0.0, "RBT amount")
 	flag.StringVar(&cmd.transComment, "transComment", "", "Transaction comment")
-	flag.IntVar(&cmd.transType, "transType", 2, "Transaction type")
+	flag.IntVar(&cmd.quorumType, "quorumType", 2, "Quorum type")
 	flag.IntVar(&cmd.numTokens, "numTokens", 1, "Number of tokens")
 	flag.StringVar(&cmd.did, "did", "", "DID")
 	flag.BoolVar(&cmd.enableAuth, "enableAuth", false, "Enable authentication")
@@ -774,7 +774,7 @@ func Run(args []string) {
 	flag.StringVar(&cmd.pgsqlDBName, "pgsqlDBName", "", "Postgress Tokens database name")
 	flag.StringVar(&cmd.pgsqlDBUserName, "pgsqlDBUserName", "myuser", "Postgress Tokens Database username")
 	flag.StringVar(&cmd.pgsqlDBPassword, "pgsqlDBPassword", "mypassword", "Postgress Tokens Database password")
-	flag.BoolVar(&cmd.xellMigration, "xellmigration", false, "dump tokenchain from fullnode storage")
+	flag.IntVar(&cmd.operationType, "operationType", 0, "this defines the underlying transaction type")
 
 	if len(os.Args) < 2 {
 		fmt.Println("Invalid Command")

--- a/command/command.go
+++ b/command/command.go
@@ -364,6 +364,7 @@ type Command struct {
 	pgsqlDBName                  string
 	pgsqlDBUserName              string
 	pgsqlDBPassword              string
+	xellMigration                bool
 }
 
 func showVersion() {
@@ -771,6 +772,7 @@ func Run(args []string) {
 	flag.StringVar(&cmd.pgsqlDBName, "pgsqlDBName", "", "Postgress Tokens database name")
 	flag.StringVar(&cmd.pgsqlDBUserName, "pgsqlDBUserName", "myuser", "Postgress Tokens Database username")
 	flag.StringVar(&cmd.pgsqlDBPassword, "pgsqlDBPassword", "mypassword", "Postgress Tokens Database password")
+	flag.BoolVar(&cmd.xellMigration, "xellmigration", false, "dump tokenchain from fullnode storage")
 
 	if len(os.Args) < 2 {
 		fmt.Println("Invalid Command")

--- a/command/command.go
+++ b/command/command.go
@@ -115,6 +115,7 @@ const (
 	SetAsyncFTStatusCmd            string = "setasyncftstatus"
 	FixFTCreatorCmd                string = "fix-ft-creator"
 	GetFTCreatorStatsCmd           string = "get-ft-creator-stats"
+	RemoveStaleDIDCmd              string = "removedid"
 )
 
 var commands = []string{VersionCmd,
@@ -188,6 +189,7 @@ var commands = []string{VersionCmd,
 	SetAsyncFTStatusCmd,
 	FixFTCreatorCmd,
 	GetFTCreatorStatsCmd,
+	RemoveStaleDIDCmd,
 }
 
 var commandsHelp = []string{"To get tool version",
@@ -1001,6 +1003,8 @@ func Run(args []string) {
 		cmd.fixFTCreator()
 	case GetFTCreatorStatsCmd:
 		cmd.getFTCreatorStats()
+	case RemoveStaleDIDCmd:
+		cmd.RemoveStaleDID()
 	default:
 		cmd.log.Error("Invalid command")
 	}

--- a/command/did.go
+++ b/command/did.go
@@ -455,3 +455,38 @@ func (cmd *Command) SignVerification() {
 	}
 	cmd.log.Info("signature verification result", result)
 }
+
+func (cmd *Command) RemoveStaleDID() {
+	if cmd.did == "" {
+		cmd.log.Info("DID cannot be empty")
+		fmt.Print("Enter DID : ")
+		_, err := fmt.Scan(&cmd.did)
+		if err != nil {
+			cmd.log.Error("Failed to get DID")
+			return
+		}
+	}
+	isAlphanumeric := regexp.MustCompile(`^[a-zA-Z0-9]*$`).MatchString(cmd.did)
+	if !strings.HasPrefix(cmd.did, "bafybmi") || len(cmd.did) != 59 || !isAlphanumeric {
+		cmd.log.Error("Invalid DID")
+		return
+	}
+	br, err := cmd.c.RemoveStaleDID(cmd.did)
+	if err != nil {
+		cmd.log.Error("Failed to remove DID from network", "err", err)
+		return
+	}
+
+	if !br.Status {
+		cmd.log.Error("Failed to remove DID from network", "msg", br.Message)
+		return
+	}
+
+	msg, status := cmd.SignatureResponse(br)
+
+	if !status {
+		cmd.log.Error("Failed to remove DID from network, " + msg)
+		return
+	}
+	cmd.log.Info("DID removed from network successfully")
+}

--- a/command/ft.go
+++ b/command/ft.go
@@ -100,18 +100,19 @@ func (cmd *Command) transferFT() {
 	if cmd.ftName == "" {
 		cmd.log.Error("FT name cannot be empty")
 	}
-	if cmd.transType != 0 && cmd.transType != 1 && cmd.transType != 2 {
+	if cmd.quorumType != 0 && cmd.quorumType != 1 && cmd.quorumType != 2 {
 		cmd.log.Error("Quorum type should be either 1 or 2")
 		return
 	}
 	transferFtReq := model.TransferFTReq{
-		Receiver:   cmd.receiverAddr,
-		Sender:     cmd.senderAddr,
-		FTName:     cmd.ftName,
-		FTCount:    cmd.ftCount,
-		QuorumType: cmd.transType,
-		Comment:    cmd.transComment,
-		CreatorDID: cmd.creatorDID,
+		Receiver:      cmd.receiverAddr,
+		Sender:        cmd.senderAddr,
+		FTName:        cmd.ftName,
+		FTCount:       cmd.ftCount,
+		QuorumType:    cmd.quorumType,
+		Comment:       cmd.transComment,
+		CreatorDID:    cmd.creatorDID,
+		OperationType: cmd.operationType,
 	}
 
 	br, err := cmd.c.TransferFT(&transferFtReq)
@@ -166,21 +167,21 @@ func (cmd *Command) getFTinfo() {
 
 func (cmd *Command) fixFTCreator() {
 	cmd.log.Info("Starting FT Creator fix utility...")
-	
+
 	// Call the fix FT creator API
 	br, err := cmd.c.FixFTCreator()
 	if err != nil {
 		cmd.log.Error("Failed to fix FT creators", "err", err)
 		return
 	}
-	
+
 	if !br.Status {
 		cmd.log.Error("Failed to fix FT creators", "message", br.Message)
 		return
 	}
-	
+
 	cmd.log.Info("FT Creator fix completed successfully", "message", br.Message)
-	
+
 	// Display results if any
 	if br.Result != nil {
 		if results, ok := br.Result.([]interface{}); ok && len(results) > 0 {
@@ -210,29 +211,29 @@ func (cmd *Command) fixFTCreator() {
 
 func (cmd *Command) getFTCreatorStats() {
 	cmd.log.Info("Getting FT Creator statistics...")
-	
+
 	// Call the get FT creator stats API
 	br, err := cmd.c.GetFTCreatorStats()
 	if err != nil {
 		cmd.log.Error("Failed to get FT creator stats", "err", err)
 		return
 	}
-	
+
 	if !br.Status {
 		cmd.log.Error("Failed to get FT creator stats", "message", br.Message)
 		return
 	}
-	
+
 	// Display statistics
 	if stats, ok := br.Result.(map[string]interface{}); ok {
 		fmt.Println("\n=== FT Creator Statistics ===")
 		fmt.Printf("Total FT Tokens: %v\n", stats["total_tokens"])
-		fmt.Printf("Tokens with Peer ID as Creator: %v (%v)\n", 
+		fmt.Printf("Tokens with Peer ID as Creator: %v (%v)\n",
 			stats["peer_id_creators"], stats["peer_id_percentage"])
 		fmt.Printf("Tokens with DID as Creator: %v\n", stats["did_creators"])
 		fmt.Printf("Tokens with Empty Creator: %v\n", stats["empty_creators"])
 		fmt.Printf("Unique Creators: %v\n", stats["unique_creators"])
-		
+
 		// Display top creators
 		if topCreators, ok := stats["top_creators"].([]interface{}); ok && len(topCreators) > 0 {
 			fmt.Println("\n=== Top Creators ===")
@@ -241,23 +242,23 @@ func (cmd *Command) getFTCreatorStats() {
 					creatorID := c["creator"].(string)
 					count := c["count"]
 					isPeerID := c["is_peer_id"].(bool)
-					
+
 					// Truncate long IDs for display
 					displayID := creatorID
 					if len(displayID) > 50 {
 						displayID = displayID[:47] + "..."
 					}
-					
+
 					typeStr := "DID"
 					if isPeerID {
 						typeStr = "PeerID"
 					}
-					
+
 					fmt.Printf("%d. %s (%s): %v tokens\n", i+1, displayID, typeStr, count)
 				}
 			}
 		}
-		
+
 		// Recommendation
 		if peerIDCount, ok := stats["peer_id_creators"].(float64); ok && peerIDCount > 0 {
 			fmt.Println("\n⚠️  Warning: Found", int(peerIDCount), "tokens with peer ID as creator.")

--- a/command/nft.go
+++ b/command/nft.go
@@ -71,14 +71,14 @@ func (cmd *Command) deployNFT() {
 		cmd.log.Error("Invalid deployer DID")
 		return
 	}
-	if cmd.transType < 1 || cmd.transType > 2 {
+	if cmd.quorumType < 1 || cmd.quorumType > 2 {
 		cmd.log.Error("Invalid trans type")
 		return
 	}
 	deployRequest := model.DeployNFTRequest{
 		NFT:        cmd.nft,
 		DID:        cmd.deployerAddr,
-		QuorumType: cmd.transType,
+		QuorumType: cmd.quorumType,
 		NFTValue:   cmd.nftValue,
 		NFTData:    cmd.nftData,
 	}
@@ -118,7 +118,7 @@ func (cmd *Command) executeNFT() {
 		cmd.log.Error("Invalid executer DID")
 		return
 	}
-	if cmd.transType < 1 || cmd.transType > 2 {
+	if cmd.quorumType < 1 || cmd.quorumType > 2 {
 		cmd.log.Error("Invalid trans type")
 		return
 	}
@@ -127,7 +127,7 @@ func (cmd *Command) executeNFT() {
 		NFT:        cmd.nft,
 		Executor:   cmd.executorAddr,
 		Receiver:   cmd.receiverAddr,
-		QuorumType: cmd.transType,
+		QuorumType: cmd.quorumType,
 		Comment:    cmd.transComment,
 		NFTValue:   cmd.rbtAmount,
 	}

--- a/command/smartContract.go
+++ b/command/smartContract.go
@@ -205,7 +205,7 @@ func (cmd *Command) deploySmartcontract() {
 		cmd.log.Error("Invalid RBT amount. Minimum RBT amount should be 0.001")
 		return
 	}
-	if cmd.transType < 1 || cmd.transType > 2 {
+	if cmd.quorumType < 1 || cmd.quorumType > 2 {
 		cmd.log.Error("Invalid trans type")
 		return
 	}
@@ -213,7 +213,7 @@ func (cmd *Command) deploySmartcontract() {
 		SmartContractToken: cmd.smartContractToken,
 		DeployerAddress:    cmd.deployerAddr,
 		RBTAmount:          cmd.rbtAmount,
-		QuorumType:         cmd.transType,
+		QuorumType:         cmd.quorumType,
 		Comment:            cmd.transComment,
 	}
 	response, err := cmd.c.DeploySmartContract(&deployRequest)
@@ -252,7 +252,7 @@ func (cmd *Command) executeSmartcontract() {
 		cmd.log.Error("Invalid executer DID")
 		return
 	}
-	if cmd.transType < 1 || cmd.transType > 2 {
+	if cmd.quorumType < 1 || cmd.quorumType > 2 {
 		cmd.log.Error("Invalid trans type")
 		return
 	}
@@ -267,7 +267,7 @@ func (cmd *Command) executeSmartcontract() {
 	executorRequest := model.ExecuteSmartContractRequest{
 		SmartContractToken: cmd.smartContractToken,
 		ExecutorAddress:    cmd.executorAddr,
-		QuorumType:         cmd.transType,
+		QuorumType:         cmd.quorumType,
 		Comment:            cmd.transComment,
 		SmartContractData:  cmd.smartContractData,
 	}

--- a/command/transfer.go
+++ b/command/transfer.go
@@ -55,17 +55,17 @@ func (cmd *Command) TransferRBT() {
 		cmd.log.Error("Invalid RBT amount. RBT amount should be atlease 0.001")
 		return
 	}
-	if cmd.transType < 1 || cmd.transType > 2 {
+	if cmd.quorumType < 1 || cmd.quorumType > 2 {
 		cmd.log.Error("Invalid trans type. TransType should be 1 or 2")
 		return
 	}
 	rt := model.RBTTransferRequest{
-		Receiver:   cmd.receiverAddr,
-		Sender:     cmd.senderAddr,
-		TokenCount: cmd.rbtAmount,
-		Type:       cmd.transType,
-		Comment:    cmd.transComment,
-		XellMigration: cmd.xellMigration,
+		Receiver:      cmd.receiverAddr,
+		Sender:        cmd.senderAddr,
+		TokenCount:    cmd.rbtAmount,
+		Type:          cmd.quorumType,
+		Comment:       cmd.transComment,
+		OperationType: cmd.operationType,
 	}
 
 	br, err := cmd.c.TransferRBT(&rt)
@@ -87,7 +87,7 @@ func (cmd *Command) PinRBT() {
 		PinningNode: cmd.pinningAddress,
 		Sender:      cmd.senderAddr,
 		TokenCount:  cmd.rbtAmount,
-		Type:        cmd.transType,
+		Type:        cmd.quorumType,
 		Comment:     cmd.transComment,
 	}
 
@@ -109,7 +109,7 @@ func (cmd *Command) SelfTransferRBT() {
 	rt := model.RBTTransferRequest{
 		Sender:   cmd.senderAddr,
 		Receiver: cmd.senderAddr,
-		Type:     cmd.transType,
+		Type:     cmd.quorumType,
 	}
 
 	br, err := cmd.c.SelfTransferRBT(&rt)

--- a/command/transfer.go
+++ b/command/transfer.go
@@ -65,6 +65,7 @@ func (cmd *Command) TransferRBT() {
 		TokenCount: cmd.rbtAmount,
 		Type:       cmd.transType,
 		Comment:    cmd.transComment,
+		XellMigration: cmd.xellMigration,
 	}
 
 	br, err := cmd.c.TransferRBT(&rt)

--- a/core/core.go
+++ b/core/core.go
@@ -66,7 +66,6 @@ const (
 	APISyncGenesisAndLatestBlock    string = "/api/sync-gennesis-n-lastest-block"
 	APIUpdateStatus                 string = "/api/update-status"
 	APIGetTokenStatus               string = "/api/get-token-status"
-	// APISendTokenChainDetails        string = "api/send-token-chain-details"
 )
 
 const (
@@ -506,6 +505,7 @@ func (c *Core) SetupCore() error {
 	c.CheckQuorumStatusSetup()
 	c.GetPeerdidTypeSetup()
 	c.peerSetup()
+	c.removePeerSetup()
 	c.w.AddDIDLastChar()
 	c.SetupToken()
 	c.QuroumSetup()

--- a/core/did.go
+++ b/core/did.go
@@ -600,3 +600,92 @@ func (c *Core) ArbitrarySignVerification(reqID string, verificationReq *model.Si
 	verificationResp.Status = verificationResult
 	return verificationResp, nil
 }
+
+func (c *Core) RemoveStaleDIDFromNetwork(reqID string, staleDID string) {
+	br, err := c.removeStaleDIDFromNetwork(reqID, staleDID)
+	if err != nil {
+		br.Status = false
+		br.Message = err.Error()
+	}
+
+	dc := c.GetWebReq(reqID)
+	if dc == nil {
+		c.log.Error("Failed to get did channels")
+		return
+	}
+	dc.OutChan <- &br
+}
+
+// remove stale DIDs from DIDTable and from peers' PeerDIDTable
+func (c *Core) removeStaleDIDFromNetwork(reqID, staleDID string) (model.BasicResponse, error) {
+	response := model.BasicResponse{
+		Status: false,
+	}
+
+	// // check if DID still holds tokens, prevent deletion if it does
+	// accInfo, err := c.GetAccountInfo(staleDID)
+	// if err != nil {
+	// 	c.log.Error("Failed to get account info for DID %v", staleDID)
+	// 	return response, err
+	// }
+	// if accInfo !=  {
+	// 	errMsg := fmt.Sprintf("cannot remove DID : %v, holds RBT amount : %v", staleDID, accInfo.RBTAmount)
+	// 	c.log.Error(errMsg)
+	// 	return response, fmt.Errorf(errMsg)
+	// }
+	// ftInfo, err := c.GetFTInfoByDID(staleDID)
+	// if err != nil {
+	// 	c.log.Error("Failed to get ft info for DID %v", staleDID)
+	// 	return response, err
+	// }
+	// if ftInfo != nil {
+	// 	errMsg := fmt.Sprintf("cannot remove DID : %v, holds RBT amount : %v", staleDID, accInfo.RBTAmount)
+	// 	c.log.Error(errMsg)
+	// 	return response, fmt.Errorf(errMsg)
+	// }
+
+	// remove old-did from peers' DB :
+	// 1. sign on the information to be published
+	dc, err := c.SetupDID(reqID, staleDID)
+	if err != nil {
+		return response, fmt.Errorf("DID is not exist")
+	}
+	t := time.Now().String()
+	h := util.CalculateHashString(c.peerID+staleDID+t, "SHA3-256")
+	sig, err := dc.PvtSign([]byte(h))
+	if err != nil {
+		return response, fmt.Errorf("remove stale did, failed to do signature")
+	}
+
+	didInfo, err := c.w.GetDID(staleDID)
+	if err != nil {
+		return response, fmt.Errorf("DID does not exist")
+	}
+
+	// 2. publish the stale did and the signature
+	pm := &PeerMap{
+		PeerID:    c.peerID,
+		DID:       staleDID,
+		DIDType:   didInfo.Type,
+		Signature: sig,
+		Time:      t,
+	}
+
+	err = c.publishStalePeer(pm)
+	if err != nil {
+		c.log.Error("Remove DID from network, failed to publish peer did map", "err", err)
+		return response, err
+	}
+
+	// remove old-did from DIDTable
+	err = c.w.RemoveDID(staleDID)
+	if err != nil {
+		response.Message = err.Error()
+		return response, err
+	}
+
+	response.Status = true
+	response.Message = "successfully erased staled did"
+	c.log.Info(response.Message)
+	return response, nil
+}

--- a/core/did.go
+++ b/core/did.go
@@ -684,6 +684,9 @@ func (c *Core) removeStaleDIDFromNetwork(reqID, staleDID string) (model.BasicRes
 		return response, err
 	}
 
+	// remove old-did folder
+	os.RemoveAll(c.didDir + staleDID)
+
 	response.Status = true
 	response.Message = "successfully erased staled did"
 	c.log.Info(response.Message)

--- a/core/did.go
+++ b/core/did.go
@@ -622,27 +622,42 @@ func (c *Core) removeStaleDIDFromNetwork(reqID, staleDID string) (model.BasicRes
 		Status: false,
 	}
 
-	// // check if DID still holds tokens, prevent deletion if it does
-	// accInfo, err := c.GetAccountInfo(staleDID)
-	// if err != nil {
-	// 	c.log.Error("Failed to get account info for DID %v", staleDID)
-	// 	return response, err
-	// }
-	// if accInfo !=  {
-	// 	errMsg := fmt.Sprintf("cannot remove DID : %v, holds RBT amount : %v", staleDID, accInfo.RBTAmount)
-	// 	c.log.Error(errMsg)
-	// 	return response, fmt.Errorf(errMsg)
-	// }
-	// ftInfo, err := c.GetFTInfoByDID(staleDID)
-	// if err != nil {
-	// 	c.log.Error("Failed to get ft info for DID %v", staleDID)
-	// 	return response, err
-	// }
-	// if ftInfo != nil {
-	// 	errMsg := fmt.Sprintf("cannot remove DID : %v, holds RBT amount : %v", staleDID, accInfo.RBTAmount)
-	// 	c.log.Error(errMsg)
-	// 	return response, fmt.Errorf(errMsg)
-	// }
+	// check if DID still holds tokens, prevent deletion if it does
+	accInfo, err := c.GetAccountInfo(staleDID)
+	if err != nil {
+		c.log.Error("Failed to get account info for DID %v", staleDID)
+		return response, err
+	}
+	if accInfo.RBTAmount == 0 &&
+		accInfo.LockedRBT == 0 &&
+		accInfo.PledgedRBT == 0 &&
+		accInfo.PinnedRBT == 0 {
+
+		// DID has no tokens, safe to delete
+		c.log.Debug("*******did has no balance, safe to delete")
+	} else {
+		errMsg := fmt.Sprintf(
+			"cannot remove DID: %v, holds RBT [%f free, %f locked, %f pledged, %f pinned]",
+			staleDID,
+			accInfo.RBTAmount,
+			accInfo.LockedRBT,
+			accInfo.PledgedRBT,
+			accInfo.PinnedRBT,
+		)
+		c.log.Error(errMsg)
+		return response, fmt.Errorf(errMsg)
+	}
+
+	ftInfo, err := c.GetFTInfoByDID(staleDID)
+	if err != nil {
+		c.log.Error("Failed to get ft info for DID %v", staleDID)
+		return response, err
+	}
+	if len(ftInfo) != 0 {
+		errMsg := fmt.Sprintf("cannot remove DID : %v, holds FTs : %v", staleDID, ftInfo)
+		c.log.Error(errMsg)
+		return response, fmt.Errorf(errMsg)
+	}
 
 	// remove old-did from peers' DB :
 	// 1. sign on the information to be published

--- a/core/ft.go
+++ b/core/ft.go
@@ -431,7 +431,7 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, numWholeTokens
 	}
 
 	c.log.Debug("updating ft table with new fts")
-	
+
 	updateFTTableErr := c.updateFTTable()
 	if updateFTTableErr != nil {
 		c.log.Error("Failed to update FT table after FT creation", "err", updateFTTableErr)
@@ -715,6 +715,9 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 		FTinfo:           FTData,
 		TransactionEpoch: txEpoch,
 	}
+
+	// xell migration
+	cr.XellMigrationMode = req.XellMigration
 
 	resultChan := make(chan *model.BasicResponse, 1)
 

--- a/core/ft.go
+++ b/core/ft.go
@@ -714,10 +714,8 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 		ContractBlock:    sc.GetBlock(),
 		FTinfo:           FTData,
 		TransactionEpoch: txEpoch,
+		OperationType:    req.OperationType,
 	}
-
-	// xell migration
-	cr.XellMigrationMode = req.XellMigration
 
 	resultChan := make(chan *model.BasicResponse, 1)
 

--- a/core/model/ft.go
+++ b/core/model/ft.go
@@ -17,7 +17,7 @@ type TransferFTReq struct {
 	QuorumType    int    `json:"quorum_type"`
 	Password      string `json:"password"`
 	CreatorDID    string `json:"creatorDID"`
-	XellMigration bool   `json:"xell_migration"`
+	OperationType int    `json:"operation_type"`
 }
 
 type GetFTInfo struct {

--- a/core/model/ft.go
+++ b/core/model/ft.go
@@ -9,14 +9,15 @@ type CreateFTReq struct {
 }
 
 type TransferFTReq struct {
-	Receiver   string `json:"receiver"`
-	Sender     string `json:"sender"`
-	FTName     string `json:"ft_name"`
-	FTCount    int    `json:"ft_count"`
-	Comment    string `json:"comment"`
-	QuorumType int    `json:"quorum_type"`
-	Password   string `json:"password"`
-	CreatorDID string `json:"creatorDID"`
+	Receiver      string `json:"receiver"`
+	Sender        string `json:"sender"`
+	FTName        string `json:"ft_name"`
+	FTCount       int    `json:"ft_count"`
+	Comment       string `json:"comment"`
+	QuorumType    int    `json:"quorum_type"`
+	Password      string `json:"password"`
+	CreatorDID    string `json:"creatorDID"`
+	XellMigration bool   `json:"xell_migration"`
 }
 
 type GetFTInfo struct {

--- a/core/model/tokens.go
+++ b/core/model/tokens.go
@@ -11,13 +11,13 @@ type RBTGenerateRequest struct {
 }
 
 type RBTTransferRequest struct {
-	Receiver   string  `json:"receiver"`
-	Sender     string  `json:"sender"`
-	TokenCount float64 `json:"tokenCOunt"`
-	Comment    string  `json:"comment"`
-	Type       int     `json:"type"`
-	Password   string  `json:"password"`
-	XellMigration bool `json:"xell_migration"`
+	Receiver      string  `json:"receiver"`
+	Sender        string  `json:"sender"`
+	TokenCount    float64 `json:"tokenCOunt"`
+	Comment       string  `json:"comment"`
+	Type          int     `json:"type"`
+	Password      string  `json:"password"`
+	OperationType int     `json:"operation_type"`
 }
 
 type RBTPinRequest struct {
@@ -103,12 +103,12 @@ type PinCheckReply struct {
 }
 
 type SendTokenDetailsInfo struct {
-	TokenChainLength uint64 `json:"tc_length"`
-	TokenType        int    `json:"token_type"`
-	Token            string `json:"token"`
-	Did              string `json:"did"`
-	AssetType        int    `json:"asset_type"`
-	TokenValue      float64  `json:"token_value"`  //For some mainnet tokens, token value is not there in the genesis block so we need to pass it through the pubsub
+	TokenChainLength uint64  `json:"tc_length"`
+	TokenType        int     `json:"token_type"`
+	Token            string  `json:"token"`
+	Did              string  `json:"did"`
+	AssetType        int     `json:"asset_type"`
+	TokenValue       float64 `json:"token_value"` //For some mainnet tokens, token value is not there in the genesis block so we need to pass it through the pubsub
 }
 type FailedToSyncTokenDetailsInfo struct {
 	TokenID   string `gorm:"column:token_id;primaryKey"` // `gorm:"column:token;primaryKey"`

--- a/core/model/tokens.go
+++ b/core/model/tokens.go
@@ -17,6 +17,7 @@ type RBTTransferRequest struct {
 	Comment    string  `json:"comment"`
 	Type       int     `json:"type"`
 	Password   string  `json:"password"`
+	XellMigration bool `json:"xell_migration"`
 }
 
 type RBTPinRequest struct {

--- a/core/peer.go
+++ b/core/peer.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"os"
 	"strings"
 
 	"github.com/rubixchain/rubixgoplatform/core/ipfsport"
@@ -259,4 +260,7 @@ func (c *Core) removeStalePeerCallback(peerID string, topic string, data []byte)
 		c.log.Debug("failed to remove peer", stalePeer.DID, "err", err)
 		return
 	}
+
+	// remove peer-did folder
+	os.RemoveAll(c.didDir + stalePeer.DID)
 }

--- a/core/peer.go
+++ b/core/peer.go
@@ -16,6 +16,7 @@ import (
 
 const (
 	PeerService string = "peer_service"
+	RemovePeer  string = "remove_peer"
 )
 
 type PeerMap struct {
@@ -30,6 +31,11 @@ type PeerMap struct {
 func (c *Core) peerSetup() error {
 	c.l.AddRoute(APIPeerStatus, "GET", c.peerStatus)
 	return c.ps.SubscribeTopic(PeerService, c.peerCallback)
+}
+
+// removePeerSetup will setup the ping route
+func (c *Core) removePeerSetup() error {
+	return c.ps.SubscribeTopic(RemovePeer, c.removeStalePeerCallback)
 }
 
 func (c *Core) publishPeerMap(pm *PeerMap) error {
@@ -210,4 +216,47 @@ func (c *Core) isDIDInArbitaryAddr(peerDID string) (bool, *wallet.DIDPeerMap, er
 		}
 	}
 	return false, nil, nil
+}
+
+func (c *Core) publishStalePeer(pm *PeerMap) error {
+	if c.ps != nil {
+		err := c.ps.Publish(RemovePeer, pm)
+		if err != nil {
+			c.log.Error("Failed to publish peer map message", "err", err)
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Core) removeStalePeerCallback(peerID string, topic string, data []byte) {
+	var stalePeer PeerMap
+	err := json.Unmarshal(data, &stalePeer)
+	c.log.Debug("Peer DID Removal")
+	if err != nil {
+		c.log.Error("failed to parse explorer data", "err", err)
+		return
+	}
+
+	// verify the signature
+	h := util.CalculateHashString(stalePeer.PeerID+stalePeer.DID+stalePeer.Time, "SHA3-256")
+	dc, err := c.InitialiseDID(stalePeer.DID, stalePeer.DIDType)
+	if err != nil {
+		c.log.Error("failed to initialise stale peer")
+		return
+	}
+	st, err := dc.PvtVerify([]byte(h), stalePeer.Signature)
+	if err != nil || !st {
+		c.log.Error("failed to remove stale peer, signature verification failed, err ", err)
+		return
+	}
+
+	c.log.Debug("removing peer ", stalePeer.DID, stalePeer.PeerID)
+
+	// remove provided peer did and peer-id from PeerDIDTable
+	err = c.w.RemoveStalePeerDID(stalePeer.DID, stalePeer.PeerID)
+	if err != nil {
+		c.log.Debug("failed to remove peer", stalePeer.DID, "err", err)
+		return
+	}
 }

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -87,7 +87,8 @@ type ConensusRequest struct {
 	NFT                string       `json:"nft"`
 	FTinfo             model.FTInfo `json:"ft_info"`
 	// TransTokenSyncInfo map[string]GenesisAndLatestBlocks `json:"tokens_sync_info"`
-	ExplorerDone chan struct{} `json:"-"` // Channel to signal explorer submission completion
+	ExplorerDone      chan struct{} `json:"-"` // Channel to signal explorer submission completion
+	XellMigrationMode bool          `json:"xell_migration"`
 }
 
 type ConensusReply struct {
@@ -948,6 +949,11 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 			Epoch:           int64(cr.TransactionEpoch),
 		}
 
+		// to filter out migration transactions in xell wallet
+		if cr.XellMigrationMode {
+			td.Mode = wallet.SelfTransferMode
+		}
+
 		go func() {
 			err = c.initiateUnpledgingProcess(cr, td.TransactionID, td.Epoch)
 			if err != nil {
@@ -1389,6 +1395,11 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 			DateTime:        time.Now(),
 			Status:          true,
 			Epoch:           int64(cr.TransactionEpoch),
+		}
+
+		// xell migration
+		if cr.XellMigrationMode {
+			td.Mode = wallet.SelfTransferMode
 		}
 		// publish txn
 		publishingTxn.AssetType = FTTokenType
@@ -2844,6 +2855,12 @@ func (c *Core) pledgeQuorumToken(cr *ConensusRequest, sc *contract.Contract, tid
 	if cr.Mode == DTCommitMode {
 		tcb.TransactionType = block.TokenCommittedType
 	}
+
+	// token being transferred from old DID to new DID of user
+	if cr.XellMigrationMode {
+		tcb.TransactionType = block.TokenSelfTransferredType
+	}
+
 	nb := block.CreateNewBlock(ctcb, &tcb)
 	if nb == nil {
 		c.log.Error("Failed to create new token chain block - qrm init")

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -70,6 +70,11 @@ const (
 	MinTokenTimeout         = 30 * time.Second       // Minimum timeout for token processing
 )
 
+// operation type in integer to define transaction type in string, to disstinguish between transactions
+const (
+	TokenSelfTransferredType int = 20
+)
+
 type ConensusRequest struct {
 	ReqID              string       `json:"req_id"`
 	Type               int          `json:"type"`
@@ -87,8 +92,8 @@ type ConensusRequest struct {
 	NFT                string       `json:"nft"`
 	FTinfo             model.FTInfo `json:"ft_info"`
 	// TransTokenSyncInfo map[string]GenesisAndLatestBlocks `json:"tokens_sync_info"`
-	ExplorerDone      chan struct{} `json:"-"` // Channel to signal explorer submission completion
-	XellMigrationMode bool          `json:"xell_migration"`
+	ExplorerDone  chan struct{} `json:"-"` // Channel to signal explorer submission completion
+	OperationType int           `json:"operation_type"`
 }
 
 type ConensusReply struct {
@@ -155,6 +160,7 @@ type SendTokenRequest struct {
 	TransactionEpoch   int                  `json:"transaction_epoch"`
 	PinningServiceMode bool                 `json:"pinning_service_mode"`
 	FTInfo             model.FTInfo         `json:"ft_info"`
+	OperationType      int                  `json:"operation_type"`
 	// TransTokenSyncInfo map[string]GenesisAndLatestBlocks `json:"token_chain_sync_info"`
 }
 
@@ -723,6 +729,7 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 			QuorumList:         cr.QuorumList,
 			TransactionEpoch:   cr.TransactionEpoch,
 			PinningServiceMode: false,
+			OperationType:      cr.OperationType,
 			// TransTokenSyncInfo: cr.TransTokenSyncInfo,
 		}
 
@@ -950,8 +957,8 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 		}
 
 		// to filter out migration transactions in xell wallet
-		if cr.XellMigrationMode {
-			td.Mode = wallet.SelfTransferMode
+		if cr.OperationType == TokenSelfTransferredType {
+			td.Mode = wallet.RBTSelfTransferMode
 		}
 
 		go func() {
@@ -1398,8 +1405,8 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 		}
 
 		// xell migration
-		if cr.XellMigrationMode {
-			td.Mode = wallet.SelfTransferMode
+		if cr.OperationType == TokenSelfTransferredType {
+			td.Mode = wallet.FTSelfTransferMode
 		}
 		// publish txn
 		publishingTxn.AssetType = FTTokenType
@@ -1428,6 +1435,7 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 			TokenChainBlock:    nb.GetBlock(),
 			QuorumList:         cr.QuorumList,
 			PinningServiceMode: true,
+			OperationType: cr.OperationType,
 		}
 		// fetching quorums' info from PeerDIDTable to share with the receiver
 		for _, qrm := range sr.QuorumList {
@@ -2857,7 +2865,7 @@ func (c *Core) pledgeQuorumToken(cr *ConensusRequest, sc *contract.Contract, tid
 	}
 
 	// token being transferred from old DID to new DID of user
-	if cr.XellMigrationMode {
+	if cr.OperationType == TokenSelfTransferredType {
 		tcb.TransactionType = block.TokenSelfTransferredType
 	}
 

--- a/core/quorum_recv.go
+++ b/core/quorum_recv.go
@@ -1441,6 +1441,10 @@ func (c *Core) updateReceiverToken(
 		if td.Epoch == 0 {
 			td.Epoch = time.Now().Unix()
 		}
+		// maintain transaction mode as per transaction type
+		if td.TransactionType == block.TokenSelfTransferredType {
+			td.Mode = wallet.RBTSelfTransferMode
+		}
 		err = c.w.AddTransactionHistory(td)
 		if err != nil {
 			c.log.Error("failed to add transaction history on the receiver", "err", err)
@@ -1671,6 +1675,10 @@ func (c *Core) updateFTToken(senderAddress string, receiverAddress string, token
 		}
 		if td.Epoch == 0 {
 			td.Epoch = time.Now().Unix()
+		}
+		// maintain transaction mode as per transaction type
+		if td.TransactionType == block.TokenSelfTransferredType {
+			td.Mode = wallet.FTSelfTransferMode
 		}
 		err = c.w.AddTransactionHistory(td)
 		if err != nil {
@@ -1938,7 +1946,7 @@ func (c *Core) updatePledgeToken(req *ensweb.Request) *ensweb.Result {
 			PublisherDID: dc.GetDID(),
 			TxnBlock:     nb.GetBlock(),
 		}
-	
+
 		c.log.Debug("quorum publishing pledge block : ", publishingTxn.BlockHash)
 		err = c.publishTxn(publishingTxn)
 		if err != nil {
@@ -1947,7 +1955,6 @@ func (c *Core) updatePledgeToken(req *ensweb.Request) *ensweb.Result {
 			return
 		}
 	}()
-
 
 	// return
 	crep.Status = true

--- a/core/transfer.go
+++ b/core/transfer.go
@@ -187,15 +187,15 @@ func getConsensusRequest(consensusRequestType int, senderPeerID string, receiver
 func (c *Core) initiateRBTTransfer(reqID string, req *model.RBTTransferRequest) *model.BasicResponse {
 	st := time.Now()
 	txEpoch := int(st.Unix())
-	
+
 	// Track overall transaction performance
 	var txErr error
 	defer func() {
 		c.TrackOperation("tx.rbt_transfer.total", map[string]interface{}{
-			"sender": req.Sender,
+			"sender":   req.Sender,
 			"receiver": req.Receiver,
-			"amount": req.TokenCount,
-			"type": req.Type,
+			"amount":   req.TokenCount,
+			"type":     req.Type,
 		})(txErr)
 	}()
 
@@ -413,6 +413,9 @@ func (c *Core) initiateRBTTransfer(reqID string, req *model.RBTTransferRequest) 
 
 	cr := getConsensusRequest(req.Type, c.peerID, rpeerid, sc.GetBlock(), txEpoch, isSelfRBTTransfer)
 	resultChan := make(chan *model.BasicResponse, 1)
+
+	// xell migration
+	cr.XellMigrationMode = req.XellMigration
 
 	// Start the transaction in a goroutine
 	go func() {

--- a/core/transfer.go
+++ b/core/transfer.go
@@ -414,8 +414,8 @@ func (c *Core) initiateRBTTransfer(reqID string, req *model.RBTTransferRequest) 
 	cr := getConsensusRequest(req.Type, c.peerID, rpeerid, sc.GetBlock(), txEpoch, isSelfRBTTransfer)
 	resultChan := make(chan *model.BasicResponse, 1)
 
-	// xell migration
-	cr.XellMigrationMode = req.XellMigration
+	// to distinguish between transaction types
+	cr.OperationType = req.OperationType
 
 	// Start the transaction in a goroutine
 	go func() {

--- a/core/wallet/did.go
+++ b/core/wallet/did.go
@@ -100,6 +100,18 @@ func (w *Wallet) IsDIDExist(did string) bool {
 	return true
 }
 
+func (w *Wallet) RemoveDID(did string) error {
+	w.l.Lock()
+	defer w.l.Unlock()
+	err := w.s.Delete(DIDStorage, &DIDType{}, "did=?", did)
+	if err != nil {
+		errMsg := fmt.Sprintf("DID could not be removed from DIDTable, did : %v, err : %v", did, err)
+		w.log.Error(errMsg)
+		return fmt.Errorf("%v", errMsg)
+	}
+	return nil
+}
+
 func (w *Wallet) AddDIDPeerMap(did string, peerID string, didType int) error {
 	lastChar, err := w.GetLastChar(did)
 	if err != nil {
@@ -143,6 +155,20 @@ func (w *Wallet) AddDIDPeerMap(did string, peerID string, didType int) error {
 	existing.DIDLastChar = lastChar
 
 	return w.s.Update(DIDPeerStorage, &existing, "did=?", did)
+}
+
+// remove stale peer
+func (w *Wallet) RemoveStalePeerDID(peerDID, peerId string) error {
+	w.l.Lock()
+	defer w.l.Unlock()
+
+	err := w.s.Delete(DIDPeerStorage, &DIDPeerMap{}, "did=? AND peer_id=?", peerDID, peerId)
+	if err != nil {
+		errMsg := fmt.Sprintf("peer-DID could not be removed from DIDPeerTable, peer-did : %v, err : %v", peerDID, err)
+		w.log.Error(errMsg)
+		return fmt.Errorf("%v", errMsg)
+	}
+	return nil
 }
 
 func (w *Wallet) AddDIDLastChar() error {

--- a/core/wallet/transaction_history.go
+++ b/core/wallet/transaction_history.go
@@ -15,7 +15,8 @@ const (
 	ExecuteMode
 	PinningServiceMode
 	FTTransferMode
-	SelfTransferMode // xell migration
+	RBTSelfTransferMode // xell DID migration
+	FTSelfTransferMode  // xell DID migration
 )
 
 func (w *Wallet) AddTransactionHistory(td *model.TransactionDetails) error {

--- a/core/wallet/transaction_history.go
+++ b/core/wallet/transaction_history.go
@@ -15,6 +15,7 @@ const (
 	ExecuteMode
 	PinningServiceMode
 	FTTransferMode
+	SelfTransferMode // xell migration
 )
 
 func (w *Wallet) AddTransactionHistory(td *model.TransactionDetails) error {

--- a/server/did.go
+++ b/server/did.go
@@ -350,3 +350,28 @@ func (s *Server) APISignVerification(req *ensweb.Request) *ensweb.Result {
 	}
 	return s.RenderJSON(req, verificationResp, http.StatusOK)
 }
+
+func (s *Server) APIRemoveStaleDID(req *ensweb.Request) *ensweb.Result {
+	var m map[string]interface{}
+	err := s.ParseJSON(req, &m)
+	if err != nil {
+		return s.BasicResponse(req, false, "Failed to parse input", nil)
+	}
+	di, ok := m["did"]
+	if !ok {
+		return s.BasicResponse(req, false, "Failed to parse input", nil)
+	}
+	didStr, ok := di.(string)
+	if !ok {
+		return s.BasicResponse(req, false, "Failed to parse input", nil)
+	}
+	is_alphanumeric := regexp.MustCompile(`^[a-zA-Z0-9]*$`).MatchString(didStr)
+	if !strings.HasPrefix(didStr, "bafybmi") || len(didStr) != 59 || !is_alphanumeric {
+		s.log.Error("Invalid DID")
+		return s.BasicResponse(req, false, "Invalid DID", nil)
+	}
+	s.c.AddWebReq(req)
+
+	go s.c.RemoveStaleDIDFromNetwork(req.ID, didStr)
+	return s.didResponse(req, req.ID)
+}

--- a/server/server.go
+++ b/server/server.go
@@ -213,18 +213,7 @@ func (s *Server) RegisterRoutes() {
 	s.AddRoute(setup.APIGetTxnAmount, "GET", s.AuthHandle(s.APIGetTxnAmountFromFullNode, false, s.AuthError, false))
 
 	s.AddRoute(setup.APIGetTokenChain, "GET", s.AuthHandle(s.APIGetFullTokenChain, false, s.AuthError, false))
-
-	// s.AddRoute(setup.APIGetRBTFullTokenChain, "GET", s.AuthHandle(s.APIGetRBTFullTokenChain, false, s.AuthError, false))
-	// s.AddRoute(setup.APIGetFTFullTokenChain, "GET", s.AuthHandle(s.APIGetFTFullTokenChain, false, s.AuthError, false))
-
-	// s.AddRoute(setup.APIGetRBTGenesisBlock, "GET", s.AuthHandle(s.APIGetRBTGenesisBlock, false, s.AuthError, false))
-	// s.AddRoute(setup.APIGetFTGenesisBlock, "GET", s.AuthHandle(s.APIGetFTGenesisBlock, false, s.AuthError, false))
-
-	// s.AddRoute(setup.APIGetRBTLatestBlock, "GET", s.AuthHandle(s.APIGetRBTLatestBlock, false, s.AuthError, false))
-	// s.AddRoute(setup.APIGetFTLatestBlock, "GET", s.AuthHandle(s.APIGetFTLatestBlock, false, s.AuthError, false))
-
-	// s.AddRoute(setup.APIGetRBTLatestValidators, "GET", s.AuthHandle(s.APIGetRBTLatestValidators, false, s.AuthError, false))
-	// s.AddRoute(setup.APIGetFTLatestValidators, "GET", s.AuthHandle(s.APIGetFTLatestValidators, false, s.AuthError, false))
+	s.AddRoute(setup.APIRemoveStaleDID, "POST", s.AuthHandle(s.APIRemoveStaleDID, true, s.AuthError, false))
 }
 
 func (s *Server) ExitFunc() error {

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -121,19 +121,8 @@ const (
 	APIGetSmartContractbyDID string = "/api/de-exp/get-smart-contract-list-by-did"
 	APIGetTxnAmount          string = "/api/de-exp/get-txn-amount-by-txnID"
 
-	APIGetTokenChain string = "/api/de-exp/get-token-chain"
-
-	// APIGetRBTFullTokenChain string = "/api/de-exp/get-rbt-token-chain"
-	// APIGetFTFullTokenChain  string = "/api/de-exp/get-ft-token-chain"
-
-	// APIGetRBTGenesisBlock string = "/api/de-exp/get-rbt-token-chain-genesis-block"
-	// APIGetFTGenesisBlock  string = "/api/de-exp/get-ft-token-chain-genesis-block"
-
-	// APIGetRBTLatestBlock string = "/api/de-exp/get-rbt-token-chain-latest-block"
-	// APIGetFTLatestBlock  string = "/api/de-exp/get-ft-token-chain-latest-block"
-
-	// APIGetRBTLatestValidators string = "/api/de-exp/get-rbt-token-chain-latest-block-validators"
-	// APIGetFTLatestValidators  string = "/api/de-exp/get-ft-token-chain-latest-block-validators"
+	APIGetTokenChain  string = "/api/de-exp/get-token-chain"
+	APIRemoveStaleDID string = "/api/remove-stale-did"
 )
 
 // jwt.RegisteredClaims


### PR DESCRIPTION
This PR is created to support Xell migration by adding : 

### 1. Self-transfer mode to transfer all tokens from Old DID to new, migrated DID 
This is achieved by providing a integer field `operation_type` with value `20` (TokensSelfTransferredType) to the below mentioned token transfer APIs. This flag updates the  **block type** (aka trans_type) of the transaction to **self-tranfer** and **transaction mode** to **6**(RBT) or **7**(FT).
#### `/api/initiate-rbt-transfer`
Input format : 
```
{
    "sender": "bafybmigmsl74mitvslxvp7vrqabemi2apnevwj3ly47yow7gkxtyi5di2y",
    "receiver": "bafybmifdyvhqcmctgtcu7t4zt477myp46fymbsvep2a4rchd4uzyu7unay",
    "tokenCOunt": 0.010,
    "comment": "testing xell-migration mode",
    "type":2,
    "operation_type": 20
}
```

#### `/api/initiate-ft-transfer`
 Input format : 
```
{
    "sender":"bafybmiasokq4vc7biuionvuapvtqjcyugbkwg7u66eyflhfzn4wmowwury",
    "receiver":"bafybmifdyvhqcmctgtcu7t4zt477myp46fymbsvep2a4rchd4uzyu7unay",
    "ft_count":1,
    "ft_name":"testFt-1",
    "comment":"testing xell-migration ft transfer",
    "quorum_type":2,
    "password":"mypassword",
    "creatorDID":"bafybmiasokq4vc7biuionvuapvtqjcyugbkwg7u66eyflhfzn4wmowwury",
    "operation_type": 20
}
```
### 2. API to remove Old DID from the network by 
            i. removing the Old DID from the node's DIDTable and 
            ii. removing from the peers' PeerDIDTable in the network

#### API Info 
CLI command : 
`./rubixgoplatform removedid -did bafybmietmhdfj23c72353fwcsps2r5wf4vqi772aetv67w2jcluf4ex4z4 -port 20008`

Endpoint : `/api/remove-stale-did`
Method : POST
Input : 
```
{
	"did": "string"
}
```
Output : 
{
    "status": true,
    "message": "successfully erased old did",
    "result": null
}

**_Note :_**  Signature Response API is required to get the above output

### Test Cases Covered
All of the below test cases are tested with two scenarios : 

1. Private key stored with the node in DID folder
2. Private key stored outside the node

#### DID Removal API 

- Create new DID, D1 
- Register new DID, D1
- Run DID removal API or command and pass the new DID, D1
- Check DID Table and D1 folder in root directory of the node, D1 should not be there
- Check PeerDIDTable and D1 folder in root directory of the peers, D1 should not be there

**Result :** D1 was removed from the node's DIDTable and peers' PeerDIDTable


#### Try Sending RBT/FT to an Old DID

- Create new DID, D2
- Register new DID, D2
- Remove DID D2 only from DIDTable, but not from peers' PeerDIDTable
- Try sending some RBTs / FTs from a valid sender to D2

**Result :** Transfer failed with error message : `Failed to trasnfer RBT: msg="Failed to get receiver peer, did not exist with the peer"`

#### RBT and FT Transfer with the integer flag `operationType`

- Transfer RBT / FT with the integer flag `operationType` with value `20`
- Note the transaction ID
- Fetch all transactions of the sender / reciver with the API `/api/get-ft-txn-by-did` (in case of FT transfer) or `/api/get-by-did` (in case of RBT transfer)

**Result :** In case of RBT transfer, the above transaction cannot be found in the transactions list, because they do not pick transactions with mode `6` (RBT self transfer mode). 
In case of FT transfer, the above transaction can be found in the transaction list with **mode** `7` (FT self transfer mode) and transaction type `20`. 

- Check the mode of the transaction ID in the Transaction History Table of the sender or the receiver

**Result :** Transaction mode is `6`(for RBT) or `7` (for FT) for transactions with integer input `operation_type` with value `20`
