### PR TITLE
Fix Higher RBT Fetch Issue; Async Consensus & Unpledge Issue

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -34,7 +34,7 @@ const (
 )
 
 const (
-	version string = "0.1_G"
+	version string = "0.1_mig"
 )
 const (
 	VersionCmd                     string = "-v"

--- a/command/did.go
+++ b/command/did.go
@@ -260,7 +260,7 @@ func (cmd *Command) SignatureResponse(br *model.BasicResponse, timeout ...time.D
 		if br.Result == nil {
 			return br.Message, true
 		}
-		
+
 		// signature response for arbitrary signature
 		if strings.Contains(br.Message, "arbitrary sign") {
 			jsonbytes, err := json.Marshal(br.Result)
@@ -277,7 +277,7 @@ func (cmd *Command) SignatureResponse(br *model.BasicResponse, timeout ...time.D
 			}
 			return signMap.Signature, true
 		}
-		
+
 		cmd.log.Info("Got the request for the signature")
 
 		switch res := br.Result.(type) {
@@ -376,7 +376,7 @@ func (cmd *Command) SignatureResponse(br *model.BasicResponse, timeout ...time.D
 
 		case string:
 			// fallback: result is just transaction ID string
-			return "Transaction is still processing, Transaction ID: " + res, true
+			return "Transaction completed, Transaction ID: " + res, true
 
 		default:
 			return "Invalid response: unexpected format", false
@@ -443,7 +443,7 @@ func (cmd *Command) ArbitrarySign() {
 	} else {
 		result = fmt.Sprintf("Status : %v, message : %v", status, msg)
 	}
-	
+
 	cmd.log.Info(result)
 }
 

--- a/command/did.go
+++ b/command/did.go
@@ -376,7 +376,7 @@ func (cmd *Command) SignatureResponse(br *model.BasicResponse, timeout ...time.D
 
 		case string:
 			// fallback: result is just transaction ID string
-			return "Transaction completed, Transaction ID: " + res, true
+			return br.Message, true
 
 		default:
 			return "Invalid response: unexpected format", false

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -858,68 +858,81 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 
 		// Checking prev block details (i.e. the latest block before transferring) by sender. Sender will connect with old quorums, and update about the exhausted token state hashes to quorums for them to unpledge their tokens.
 		// Optimization: Local cache for previousQuorumDID -> PeerInfo
-		peerInfoCache := make(map[string]*wallet.DIDPeerMap)
-		for _, tokeninfo := range ti {
-			b := c.w.GetLatestTokenBlock(tokeninfo.Token, tokeninfo.TokenType)
+		go func() {
+			peerInfoCache := make(map[string]*wallet.DIDPeerMap)
+			for _, tokeninfo := range ti {
+				b := c.w.GetLatestTokenBlock(tokeninfo.Token, tokeninfo.TokenType)
 
-			blockHeight, err := b.GetBlockNumber(tokeninfo.Token)
-			if err != nil {
-				c.log.Error("failed to get latest block height of token ", tokeninfo.Token)
-			}
+				blockHeight, err := b.GetBlockNumber(tokeninfo.Token)
+				if err != nil {
+					c.log.Error("failed to get latest block height of token ", tokeninfo.Token)
+					return
+				}
 
-			// if latest block is genesis block of a whole token, then the signer(s) is(are) advisory node(s), not quorum(s)
-			// this is the case of all migrated RBTs
-			if blockHeight == 0 && tokeninfo.TokenValue == 1.0 {
-				continue
-			}
-			previousQuorumDIDs, err := b.GetSigner()
-			if err != nil {
-				return nil, nil, nil, fmt.Errorf("unable to fetch previous quorum's DIDs for token: %v, err: %v", tokeninfo.Token, err)
-			}
+				// if latest block is genesis block of a whole token, then the signer(s) is(are) advisory node(s), not quorum(s)
+				// this is the case of all migrated RBTs
+				if blockHeight == 0 && tokeninfo.TokenValue == 1.0 {
+					continue
+				}
+				previousQuorumDIDs, err := b.GetSigner()
+				if err != nil {
+					c.log.Error("unable to fetch previous quorum's DIDs for token: %v, err: %v", tokeninfo.Token, err)
+					return
+					// return nil, nil, nil, fmt.Errorf("unable to fetch previous quorum's DIDs for token: %v, err: %v", tokeninfo.Token, err)
+				}
 
-			// if signer is similar to sender did skip this token, as the block is the genesis block
-			if previousQuorumDIDs[0] == sc.GetSenderDID() {
-				continue
-			}
+				// if signer is similar to sender did skip this token, as the block is the genesis block
+				if previousQuorumDIDs[0] == sc.GetSenderDID() {
+					continue
+				}
 
-			// concat tokenId and BlockID
-			bid, errBlockID := b.GetBlockID(tokeninfo.Token)
-			if errBlockID != nil {
-				return nil, nil, nil, fmt.Errorf("unable to fetch current block id for Token %v, err: %v", tokeninfo.Token, err)
-			}
-			prevtokenIDTokenStateData := tokeninfo.Token + bid
-			prevtokenIDTokenStateBuffer := bytes.NewBuffer([]byte(prevtokenIDTokenStateData))
+				// concat tokenId and BlockID
+				bid, errBlockID := b.GetBlockID(tokeninfo.Token)
+				if errBlockID != nil {
+					c.log.Error("unable to fetch current block id for Token %v, err: %v", tokeninfo.Token, err)
+					return
+					// return nil, nil, nil, fmt.Errorf("unable to fetch current block id for Token %v, err: %v", tokeninfo.Token, err)
+				}
+				prevtokenIDTokenStateData := tokeninfo.Token + bid
+				prevtokenIDTokenStateBuffer := bytes.NewBuffer([]byte(prevtokenIDTokenStateData))
 
-			// add to ipfs get only the hash of the token+tokenstate. This is the hash just before transferring i.e. the exhausted token state hash, and updating in Sender side
-			prevtokenIDTokenStateHash, errIpfsAdd := IpfsAddWithBackoff(c.ipfs, prevtokenIDTokenStateBuffer, ipfsnode.Pin(false), ipfsnode.OnlyHash(true))
-			if errIpfsAdd != nil {
-				return nil, nil, nil, fmt.Errorf("unable to get previous token state hash for token: %v, err: %v", tokeninfo.Token, errIpfsAdd)
-			}
-			// send this exhausted hash to old quorums to unpledge
-			for _, previousQuorumDID := range previousQuorumDIDs {
-				// fetch previous quorum's peer Id with local cache
-				var previousQuorumInfo *wallet.DIDPeerMap
-				var ok bool
-				if previousQuorumInfo, ok = peerInfoCache[previousQuorumDID]; !ok {
-					previousQuorumInfo, err = c.GetPeerDIDInfo(previousQuorumDID)
-					if previousQuorumInfo.PeerID == "" || err != nil {
-						return nil, nil, nil, fmt.Errorf("unable to get peerID for signer DID: %v. It is likely that either the DID is not created anywhere or ", previousQuorumDID)
+				// add to ipfs get only the hash of the token+tokenstate. This is the hash just before transferring i.e. the exhausted token state hash, and updating in Sender side
+				prevtokenIDTokenStateHash, errIpfsAdd := IpfsAddWithBackoff(c.ipfs, prevtokenIDTokenStateBuffer, ipfsnode.Pin(false), ipfsnode.OnlyHash(true))
+				if errIpfsAdd != nil {
+					c.log.Error("unable to get previous token state hash for token: %v, err: %v", tokeninfo.Token, errIpfsAdd)
+					return
+					// return nil, nil, nil, fmt.Errorf("unable to get previous token state hash for token: %v, err: %v", tokeninfo.Token, errIpfsAdd)
+				}
+				// send this exhausted hash to old quorums to unpledge
+				for _, previousQuorumDID := range previousQuorumDIDs {
+					// fetch previous quorum's peer Id with local cache
+					var previousQuorumInfo *wallet.DIDPeerMap
+					var ok bool
+					if previousQuorumInfo, ok = peerInfoCache[previousQuorumDID]; !ok {
+						previousQuorumInfo, err = c.GetPeerDIDInfo(previousQuorumDID)
+						if previousQuorumInfo.PeerID == "" || err != nil {
+							c.log.Error("unable to get peerID for signer DID: %v. It is likely that either the DID is not created anywhere or ", previousQuorumDID)
+							return
+							// return nil, nil, nil, fmt.Errorf("unable to get peerID for signer DID: %v. It is likely that either the DID is not created anywhere or ", previousQuorumDID)
+						}
+						peerInfoCache[previousQuorumDID] = previousQuorumInfo
 					}
-					peerInfoCache[previousQuorumDID] = previousQuorumInfo
-				}
 
-				previousQuorumAddress := previousQuorumInfo.PeerID + "." + previousQuorumDID
-				previousQuorumPeer, errGetPeer := c.getPeer(previousQuorumAddress)
-				if errGetPeer != nil {
-					return nil, nil, nil, fmt.Errorf("unable to retrieve peer information for %v, err: %v", previousQuorumInfo.PeerID, errGetPeer)
-				}
+					previousQuorumAddress := previousQuorumInfo.PeerID + "." + previousQuorumDID
+					previousQuorumPeer, errGetPeer := c.getPeer(previousQuorumAddress)
+					if errGetPeer != nil {
+						c.log.Error("unable to retrieve peer information for %v, err: %v", previousQuorumInfo.PeerID, errGetPeer)
+						return
+						// return nil, nil, nil, fmt.Errorf("unable to retrieve peer information for %v, err: %v", previousQuorumInfo.PeerID, errGetPeer)
+					}
 
-				updateTokenHashDetailsQuery := make(map[string]string)
-				updateTokenHashDetailsQuery["tokenIDTokenStateHash"] = prevtokenIDTokenStateHash
-				previousQuorumPeer.SendJSONRequest("POST", APIUpdateTokenHashDetails, updateTokenHashDetailsQuery, nil, nil, true)
-				previousQuorumPeer.Close()
+					updateTokenHashDetailsQuery := make(map[string]string)
+					updateTokenHashDetailsQuery["tokenIDTokenStateHash"] = prevtokenIDTokenStateHash
+					previousQuorumPeer.SendJSONRequest("POST", APIUpdateTokenHashDetails, updateTokenHashDetailsQuery, nil, nil, true)
+					previousQuorumPeer.Close()
+				}
 			}
-		}
+		}()
 
 		err = c.w.TokensTransferred(sc.GetSenderDID(), ti, nb, rp.IsLocal(), sr.PinningServiceMode)
 		if err != nil {
@@ -1435,7 +1448,7 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 			TokenChainBlock:    nb.GetBlock(),
 			QuorumList:         cr.QuorumList,
 			PinningServiceMode: true,
-			OperationType: cr.OperationType,
+			OperationType:      cr.OperationType,
 		}
 		// fetching quorums' info from PeerDIDTable to share with the receiver
 		for _, qrm := range sr.QuorumList {

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -856,6 +856,7 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 		// 	return nil, nil, nil, pledgeFinalityError
 		// }
 
+		// concurrent unpledge request to avoid double spent issue due to failures
 		// Checking prev block details (i.e. the latest block before transferring) by sender. Sender will connect with old quorums, and update about the exhausted token state hashes to quorums for them to unpledge their tokens.
 		// Optimization: Local cache for previousQuorumDID -> PeerInfo
 		go func() {

--- a/core/token.go
+++ b/core/token.go
@@ -1595,7 +1595,8 @@ func (c *Core) GetRequiredTokens(did string, txnAmount float64, txnMode int) ([]
 			totalValue += t.TokenValue
 		}
 		totalValue = floatPrecision(totalValue, MaxDecimalPlaces)
-		remainingAmount := floatPrecision(totalValue-txnAmount, MaxDecimalPlaces)
+		remainingAmount := floatPrecision(txnAmount-totalValue, MaxDecimalPlaces)
+		c.log.Debug("remaining amt ", remainingAmount)
 		return tokens, remainingAmount, nil
 	}
 

--- a/core/token.go
+++ b/core/token.go
@@ -1596,7 +1596,6 @@ func (c *Core) GetRequiredTokens(did string, txnAmount float64, txnMode int) ([]
 		}
 		totalValue = floatPrecision(totalValue, MaxDecimalPlaces)
 		remainingAmount := floatPrecision(txnAmount-totalValue, MaxDecimalPlaces)
-		c.log.Debug("remaining amt ", remainingAmount)
 		return tokens, remainingAmount, nil
 	}
 

--- a/core/transfer.go
+++ b/core/transfer.go
@@ -505,15 +505,15 @@ func (c *Core) initiateRBTTransfer(reqID string, req *model.RBTTransferRequest) 
 	// 	return resp
 	// }
 
-	c.log.Debug("transaction completed with txn id ", cr.TransactionID)
+	// c.log.Debug("transaction completed with txn id ", cr.TransactionID)
 
-	msg = fmt.Sprintf("Transaction completed with transaction id %v ", cr.TransactionID)
-	resp.Message = msg
-	if strings.Contains(resp.Message, "with transaction id") {
-		if txID := extractTransactionIDFromMessage(resp.Message); txID != "" {
-			resp.Result = txID
-		}
-	}
+	// msg = fmt.Sprintf("Transaction completed with transaction id %v ", cr.TransactionID)
+	// resp.Message = msg
+	// if strings.Contains(resp.Message, "with transaction id") {
+	// 	if txID := extractTransactionIDFromMessage(resp.Message); txID != "" {
+	// 		resp.Result = txID
+	// 	}
+	// }
 	resp.Status = true
 	return resp
 }

--- a/core/transfer.go
+++ b/core/transfer.go
@@ -412,98 +412,110 @@ func (c *Core) initiateRBTTransfer(reqID string, req *model.RBTTransferRequest) 
 	}
 
 	cr := getConsensusRequest(req.Type, c.peerID, rpeerid, sc.GetBlock(), txEpoch, isSelfRBTTransfer)
-	resultChan := make(chan *model.BasicResponse, 1)
+	// resultChan := make(chan *model.BasicResponse, 1)
 
 	// to distinguish between transaction types
 	cr.OperationType = req.OperationType
 
 	// Start the transaction in a goroutine
-	go func() {
-		td, _, pds, consError := c.initiateConsensus(cr, sc, dc)
-		if consError != nil {
-			resp.Message = fmt.Sprintf("Consensus failed " + consError.Error())
-			resp.Status = false
-			resultChan <- resp
-			return
-		}
-		et := time.Now()
-		dif := et.Sub(st)
-		if isSelfRBTTransfer {
-			var amt float64 = 0
-			for _, tknInfo := range tis {
-				amt += tknInfo.TokenValue
-			}
-			td.Amount = amt
-		} else {
-			td.Amount = req.TokenCount
-		}
-		td.TotalTime = float64(dif.Milliseconds())
-
-		if td.TotalTime < 0.00 {
-			td.TotalTime = 0.00
-		}
-
-		if err := c.w.AddTransactionHistory(td); err != nil {
-			errMsg := fmt.Sprintf("Error occured while adding transaction details: %v", err)
-			c.log.Error(errMsg)
-			resp.Message = errMsg
-			return
-		}
-		etrans := &ExplorerRBTTrans{
-			TokenHashes:    wta,
-			TransactionID:  td.TransactionID,
-			BlockHash:      strings.Split(td.BlockID, "-")[1],
-			Network:        req.Type,
-			SenderDID:      senderDID,
-			ReceiverDID:    receiverdid,
-			Amount:         req.TokenCount,
-			QuorumList:     extractQuorumDID(cr.QuorumList),
-			PledgeInfo:     PledgeInfo{PledgeDetails: pds.PledgedTokens, PledgedTokenList: pds.TokenList},
-			TransTokenList: tokenListForExplorer,
-			Comments:       req.Comment,
-		}
-
-		c.log.Info("Transfer finished successfully", "duration", dif, " trnxid", td.TransactionID)
-		resp.Status = true
-		msg := fmt.Sprintf("Transfer finished successfully in %v with trnxid %v", dif, td.TransactionID)
-		resp.Message = msg
-		if strings.Contains(resp.Message, "with transaction id") {
-			if txID := extractTransactionIDFromMessage(resp.Message); txID != "" {
-				resp.Result = txID
-			}
-		}
-		c.ec.ExplorerRBTTransaction(etrans)
-
-		// Send final transaction completion response if not already timed out
-		select {
-		case resultChan <- resp:
-			// Successfully sent to resultChan
-		default:
-			// If no one is listening (already timed out), just log and exit
-			c.log.Debug("Transaction completed but resultChan is not being read anymore")
-		}
-	}()
-
-	select {
-	case result := <-resultChan:
-		// Transaction completed within 40s or failed
-		c.log.Debug("transaction completed before 20 secs")
-		return result
-
-	case <-time.After(20 * time.Second):
-		// Timeout occurred, return Transaction ID only
-		c.log.Debug("transaction still processing with txn id ", cr.TransactionID)
-
-		msg := fmt.Sprintf("Transaction is still processing, with transaction id %v ", cr.TransactionID)
-		resp.Message = msg
-		if strings.Contains(resp.Message, "with transaction id") {
-			if txID := extractTransactionIDFromMessage(resp.Message); txID != "" {
-				resp.Result = txID
-			}
-		}
-		resp.Status = true
+	// go func() {
+	td, _, pds, consError := c.initiateConsensus(cr, sc, dc)
+	if consError != nil {
+		resp.Message = fmt.Sprintf("Consensus failed " + consError.Error())
+		resp.Status = false
+		// resultChan <- resp
 		return resp
 	}
+	et := time.Now()
+	dif := et.Sub(st)
+	if isSelfRBTTransfer {
+		var amt float64 = 0
+		for _, tknInfo := range tis {
+			amt += tknInfo.TokenValue
+		}
+		td.Amount = amt
+	} else {
+		td.Amount = req.TokenCount
+	}
+	td.TotalTime = float64(dif.Milliseconds())
+
+	if td.TotalTime < 0.00 {
+		td.TotalTime = 0.00
+	}
+
+	if err := c.w.AddTransactionHistory(td); err != nil {
+		errMsg := fmt.Sprintf("Error occured while adding transaction details: %v", err)
+		c.log.Error(errMsg)
+		resp.Message = errMsg
+		return resp
+	}
+	etrans := &ExplorerRBTTrans{
+		TokenHashes:    wta,
+		TransactionID:  td.TransactionID,
+		BlockHash:      strings.Split(td.BlockID, "-")[1],
+		Network:        req.Type,
+		SenderDID:      senderDID,
+		ReceiverDID:    receiverdid,
+		Amount:         req.TokenCount,
+		QuorumList:     extractQuorumDID(cr.QuorumList),
+		PledgeInfo:     PledgeInfo{PledgeDetails: pds.PledgedTokens, PledgedTokenList: pds.TokenList},
+		TransTokenList: tokenListForExplorer,
+		Comments:       req.Comment,
+	}
+
+	c.log.Info("Transfer finished successfully", "duration", dif, " trnxid", td.TransactionID)
+	resp.Status = true
+	msg := fmt.Sprintf("Transfer finished successfully in %v with trnxid %v", dif, td.TransactionID)
+	resp.Message = msg
+	if strings.Contains(resp.Message, "with transaction id") {
+		if txID := extractTransactionIDFromMessage(resp.Message); txID != "" {
+			resp.Result = txID
+		}
+	}
+	c.ec.ExplorerRBTTransaction(etrans)
+
+	// Send final transaction completion response if not already timed out
+	// select {
+	// case resultChan <- resp:
+	// 	// Successfully sent to resultChan
+	// default:
+	// 	// If no one is listening (already timed out), just log and exit
+	// 	c.log.Debug("Transaction completed but resultChan is not being read anymore")
+	// }
+	// }()
+
+	// select {
+	// case result := <-resultChan:
+	// 	// Transaction completed within 40s or failed
+	// 	c.log.Debug("transaction completed before 20 secs")
+	// 	return result
+
+	// case <-time.After(20 * time.Second):
+	// 	// Timeout occurred, return Transaction ID only
+	// 	c.log.Debug("transaction still processing with txn id ", cr.TransactionID)
+
+	// 	msg := fmt.Sprintf("Transaction is still processing, with transaction id %v ", cr.TransactionID)
+	// 	resp.Message = msg
+	// 	if strings.Contains(resp.Message, "with transaction id") {
+	// 		if txID := extractTransactionIDFromMessage(resp.Message); txID != "" {
+	// 			resp.Result = txID
+	// 		}
+	// 	}
+	// 	resp.Status = true
+	// 	return resp
+	// }
+
+	c.log.Debug("transaction completed with txn id ", cr.TransactionID)
+
+	msg = fmt.Sprintf("Transaction completed with transaction id %v ", cr.TransactionID)
+	resp.Message = msg
+	if strings.Contains(resp.Message, "with transaction id") {
+		if txID := extractTransactionIDFromMessage(resp.Message); txID != "" {
+			resp.Result = txID
+		}
+	}
+	resp.Status = true
+	return resp
 }
 
 //Functions to initiate PinRBT

--- a/core/wallet/token_fetch_optimized.go
+++ b/core/wallet/token_fetch_optimized.go
@@ -215,12 +215,10 @@ func calculateTokensNeeded(availableTokens []Token, requiredAmount float64) []To
 		totalValue += token.TokenValue
 		if totalValue == requiredAmount {
 			selectedTokens = append(selectedTokens, token)
-			fmt.Println("token sum ", totalValue)
 			break
 		} else if totalValue > requiredAmount {
 			// do not add this token to the list
 			totalValue -= token.TokenValue
-			fmt.Println("total sum ", totalValue)
 			break
 		}
 		selectedTokens = append(selectedTokens, token)

--- a/core/wallet/token_fetch_optimized.go
+++ b/core/wallet/token_fetch_optimized.go
@@ -9,44 +9,44 @@ import (
 // OptimizedGetFreeTokens fetches and processes free tokens efficiently for any large amount
 func (w *Wallet) OptimizedGetFreeTokens(did string, requiredCount float64) ([]Token, error) {
 	startTime := time.Now()
-	
+
 	// Step 1: Batch fetch all free tokens
 	var allFreeTokens []Token
 	err := w.s.Read(TokenStorage, &allFreeTokens, "token_status=? AND did=?", TokenIsFree, did)
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch free tokens: %v", err)
 	}
-	
-	w.log.Info("Fetched free tokens", 
-		"count", len(allFreeTokens), 
+
+	w.log.Info("Fetched free tokens",
+		"count", len(allFreeTokens),
 		"fetch_time", time.Since(startTime))
-	
+
 	if len(allFreeTokens) == 0 {
 		return []Token{}, nil
 	}
-	
+
 	// Step 2: Calculate how many tokens we need
 	tokensNeeded := calculateTokensNeeded(allFreeTokens, requiredCount)
 	if len(tokensNeeded) == 0 {
-		return nil, fmt.Errorf("insufficient free tokens: have %d, need %.2f", 
+		return nil, fmt.Errorf("insufficient free tokens: have %d, need %.2f",
 			len(allFreeTokens), requiredCount)
 	}
-	
-	w.log.Info("Tokens needed for transaction", 
+
+	w.log.Info("Tokens needed for transaction",
 		"required_value", requiredCount,
 		"token_count", len(tokensNeeded))
-	
+
 	// Step 3: Batch lock tokens (single UPDATE query)
 	lockStart := time.Now()
 	err = w.batchLockTokens(tokensNeeded, did)
 	if err != nil {
 		return nil, fmt.Errorf("failed to lock tokens: %v", err)
 	}
-	
-	w.log.Info("Locked tokens", 
+
+	w.log.Info("Locked tokens",
 		"count", len(tokensNeeded),
 		"lock_time", time.Since(lockStart))
-	
+
 	// Step 4: Parallel validation (if needed)
 	if len(tokensNeeded) > 1000 {
 		validationStart := time.Now()
@@ -56,15 +56,15 @@ func (w *Wallet) OptimizedGetFreeTokens(did string, requiredCount float64) ([]To
 			w.batchUnlockTokens(tokensNeeded, did)
 			return nil, fmt.Errorf("token validation failed: %v", err)
 		}
-		w.log.Info("Validated tokens", 
+		w.log.Info("Validated tokens",
 			"count", len(tokensNeeded),
 			"validation_time", time.Since(validationStart))
 	}
-	
-	w.log.Info("Total token fetch operation", 
+
+	w.log.Info("Total token fetch operation",
 		"token_count", len(tokensNeeded),
 		"total_time", time.Since(startTime))
-	
+
 	return tokensNeeded, nil
 }
 
@@ -73,7 +73,7 @@ func (w *Wallet) batchLockTokens(tokens []Token, did string) error {
 	if len(tokens) == 0 {
 		return nil
 	}
-	
+
 	// Process in chunks to avoid too many individual updates
 	chunkSize := 100
 	for i := 0; i < len(tokens); i += chunkSize {
@@ -81,12 +81,12 @@ func (w *Wallet) batchLockTokens(tokens []Token, did string) error {
 		if end > len(tokens) {
 			end = len(tokens)
 		}
-		
+
 		chunk := tokens[i:end]
 		// Lock tokens in parallel within chunk
 		var wg sync.WaitGroup
 		errChan := make(chan error, len(chunk))
-		
+
 		for j := range chunk {
 			wg.Add(1)
 			go func(idx int) {
@@ -99,10 +99,10 @@ func (w *Wallet) batchLockTokens(tokens []Token, did string) error {
 				}
 			}(j)
 		}
-		
+
 		wg.Wait()
 		close(errChan)
-		
+
 		// Check for errors
 		for err := range errChan {
 			if err != nil {
@@ -110,17 +110,16 @@ func (w *Wallet) batchLockTokens(tokens []Token, did string) error {
 			}
 		}
 	}
-	
+
 	return nil
 }
-
 
 // batchUnlockTokens unlocks multiple tokens (for rollback)
 func (w *Wallet) batchUnlockTokens(tokens []Token, did string) error {
 	// Process in parallel for efficiency
 	var wg sync.WaitGroup
 	errChan := make(chan error, len(tokens))
-	
+
 	for i := range tokens {
 		wg.Add(1)
 		go func(idx int) {
@@ -133,17 +132,17 @@ func (w *Wallet) batchUnlockTokens(tokens []Token, did string) error {
 			}
 		}(i)
 	}
-	
+
 	wg.Wait()
 	close(errChan)
-	
+
 	// Check for errors
 	for err := range errChan {
 		if err != nil {
 			return err
 		}
 	}
-	
+
 	return nil
 }
 
@@ -153,17 +152,17 @@ func (w *Wallet) parallelValidateTokens(tokens []Token) error {
 		// For smaller sets, sequential is fine
 		return nil
 	}
-	
+
 	numWorkers := 10
 	if len(tokens) > 10000 {
 		numWorkers = 20
 	}
-	
+
 	jobs := make(chan Token, len(tokens))
 	errors := make(chan error, numWorkers)
-	
+
 	var wg sync.WaitGroup
-	
+
 	// Start workers
 	for i := 0; i < numWorkers; i++ {
 		wg.Add(1)
@@ -178,24 +177,24 @@ func (w *Wallet) parallelValidateTokens(tokens []Token) error {
 			}
 		}()
 	}
-	
+
 	// Submit jobs
 	for _, token := range tokens {
 		jobs <- token
 	}
 	close(jobs)
-	
+
 	// Wait for completion
 	wg.Wait()
 	close(errors)
-	
+
 	// Check for errors
 	for err := range errors {
 		if err != nil {
 			return err
 		}
 	}
-	
+
 	return nil
 }
 
@@ -210,20 +209,27 @@ func (w *Wallet) validateToken(token Token) error {
 func calculateTokensNeeded(availableTokens []Token, requiredAmount float64) []Token {
 	var totalValue float64
 	var selectedTokens []Token
-	
+
 	// Simple greedy algorithm - select tokens until we have enough
 	for _, token := range availableTokens {
-		if totalValue >= requiredAmount {
+		totalValue += token.TokenValue
+		if totalValue == requiredAmount {
+			selectedTokens = append(selectedTokens, token)
+			fmt.Println("token sum ", totalValue)
+			break
+		} else if totalValue > requiredAmount {
+			// do not add this token to the list
+			totalValue -= token.TokenValue
+			fmt.Println("total sum ", totalValue)
 			break
 		}
 		selectedTokens = append(selectedTokens, token)
-		totalValue += token.TokenValue
 	}
-	
-	if totalValue < requiredAmount {
-		return nil // Insufficient tokens
-	}
-	
+
+	// if totalValue < requiredAmount {
+	// 	return nil // Insufficient tokens
+	// }
+
 	return selectedTokens
 }
 
@@ -231,42 +237,42 @@ func calculateTokensNeeded(availableTokens []Token, requiredAmount float64) []To
 func (w *Wallet) GetTokensForOptimizedTransfer(did string, amount float64, txnMode int) ([]Token, error) {
 	w.l.Lock()
 	defer w.l.Unlock()
-	
+
 	startTime := time.Now()
-	
+
 	// Step 1: Batch fetch all free tokens
 	var allFreeTokens []Token
 	var err error
-	
+
 	if txnMode == 0 { // RBT Transfer mode
 		err = w.s.Read(TokenStorage, &allFreeTokens, "did=? AND (token_status=? OR token_status=?)", did, TokenIsFree, TokenIsPinnedAsService)
 	} else { // Pinning service mode
 		err = w.s.Read(TokenStorage, &allFreeTokens, "did=? AND token_status=?", did, TokenIsFree)
 	}
-	
+
 	if err != nil {
 		return nil, fmt.Errorf("failed to fetch free tokens: %v", err)
 	}
-	
-	w.log.Info("Fetched free tokens for optimization", 
-		"count", len(allFreeTokens), 
+
+	w.log.Info("Fetched free tokens for optimization",
+		"count", len(allFreeTokens),
 		"fetch_time", time.Since(startTime))
-	
+
 	if len(allFreeTokens) == 0 {
 		return []Token{}, nil
 	}
-	
+
 	// Step 2: Calculate how many tokens we need
 	tokensNeeded := calculateTokensNeeded(allFreeTokens, amount)
 	if len(tokensNeeded) == 0 {
-		return nil, fmt.Errorf("insufficient free tokens: have %d tokens, need %.2f value", 
+		return nil, fmt.Errorf("insufficient free tokens: have %d tokens, need %.2f value",
 			len(allFreeTokens), amount)
 	}
-	
-	w.log.Info("Tokens needed for transaction", 
+
+	w.log.Info("Tokens needed for transaction",
 		"required_value", amount,
 		"token_count", len(tokensNeeded))
-	
+
 	// Step 3: Lock tokens sequentially (since we're already under wallet lock)
 	lockStart := time.Now()
 	for i := range tokensNeeded {
@@ -281,14 +287,14 @@ func (w *Wallet) GetTokensForOptimizedTransfer(did string, amount float64, txnMo
 			return nil, fmt.Errorf("failed to lock token %s: %v", tokensNeeded[i].TokenID, err)
 		}
 	}
-	
-	w.log.Info("Locked tokens", 
+
+	w.log.Info("Locked tokens",
 		"count", len(tokensNeeded),
 		"lock_time", time.Since(lockStart))
-	
-	w.log.Info("Total optimized token fetch operation", 
+
+	w.log.Info("Total optimized token fetch operation",
 		"token_count", len(tokensNeeded),
 		"total_time", time.Since(startTime))
-	
+
 	return tokensNeeded, nil
 }


### PR DESCRIPTION
## Problems

1. **Higher RBT Fetch for Transfer** : The Optimized RBT fetching algorithm was sometimes fetching more RBT than requested, leading to transaction failure.
2. **Asynchronous Conensus for RBT transfer** : When RBTs are transferred in a loop, it can lead to transaction failure if next transfer is initiated before completion of the current transfer. 
3. **Asynchronous Unpledge Request** : Previous quorums are requested to initiate unpledge process after the sender sends the trans-tokens to receiver. If the unpledge request fails, then the transaction fails at sender end, and the sender updates the token status to be free. But the receiver has already received the tokens and have updated the tokens metadata in DB. This leads to double spend.


## Solutions 

1. **Higher RBT Fetch for Transfer** : Select `1` token less than requested amount, and fetch the remaining amount using the un-optimized RBT fetch algorithm.
2. **Asynchronous Consensus for RBT transfer** : Remove asynchronous consensus and return transaction completion status only after transaction is complete (with success/ failure status).
3. **Asynchronous Unpledge Request** : Send the unpledge request to previous quorums asynchronously, so that the transaction does not fail even when the unpledge request fails.