### PR TITLE
Fix Remove Stale DID API 

### DIFF
--- a/core/did.go
+++ b/core/did.go
@@ -648,16 +648,16 @@ func (c *Core) removeStaleDIDFromNetwork(reqID, staleDID string) (model.BasicRes
 		return response, fmt.Errorf(errMsg)
 	}
 
-	ftInfo, err := c.GetFTInfoByDID(staleDID)
-	if err != nil {
-		c.log.Error("Failed to get ft info for DID %v", staleDID)
-		return response, err
-	}
-	if len(ftInfo) != 0 {
-		errMsg := fmt.Sprintf("cannot remove DID : %v, holds FTs : %v", staleDID, ftInfo)
-		c.log.Error(errMsg)
-		return response, fmt.Errorf(errMsg)
-	}
+	// ftInfo, err := c.GetFTInfoByDID(staleDID)
+	// if err != nil {
+	// 	c.log.Error("Failed to get ft info for DID %v", staleDID)
+	// 	return response, err
+	// }
+	// if len(ftInfo) != 0 {
+	// 	errMsg := fmt.Sprintf("cannot remove DID : %v, holds FTs : %v", staleDID, ftInfo)
+	// 	c.log.Error(errMsg)
+	// 	return response, fmt.Errorf(errMsg)
+	// }
 
 	// remove old-did from peers' DB :
 	// 1. sign on the information to be published


### PR DESCRIPTION
### Problem 
The API `/api/remove-stale-did` checks RBT balance and FT balance before removing the DID from the network. But this is creating issue in Xell migration transfers, as we are not planning to transfer existing FTs in OLD DIDs to the new DID within the Xell migration.

### Solution 
Do not check for FT balance while removing stale DID. RBT balance check is sufficient.