### PR TITLE
Resolve Pin Issues

### DIFF
--- a/client/token.go
+++ b/client/token.go
@@ -9,10 +9,11 @@ import (
 	"github.com/rubixchain/rubixgoplatform/setup"
 )
 
-func (c *Client) GenerateTestRBT(numTokens int, didStr string) (*model.BasicResponse, error) {
+func (c *Client) GenerateTestRBT(numTokens int, didStr string, startIndex int) (*model.BasicResponse, error) {
 	m := model.RBTGenerateRequest{
 		NumberOfTokens: numTokens,
 		DID:            didStr,
+		StartIndex:     startIndex,
 	}
 	var rm model.BasicResponse
 	err := c.sendJSONRequest("POST", setup.APIGenerateTestToken, nil, &m, &rm)

--- a/command/command.go
+++ b/command/command.go
@@ -307,6 +307,7 @@ type Command struct {
 	transComment                 string
 	quorumType                   int
 	numTokens                    int
+	startIndex                   int
 	enableAuth                   bool
 	did                          string
 	token                        string
@@ -721,6 +722,7 @@ func Run(args []string) {
 	flag.StringVar(&cmd.transComment, "transComment", "", "Transaction comment")
 	flag.IntVar(&cmd.quorumType, "quorumType", 2, "Quorum type")
 	flag.IntVar(&cmd.numTokens, "numTokens", 1, "Number of tokens")
+	flag.IntVar(&cmd.startIndex, "startIndex", -1, "startIndex to generate test rbt tokens locally")
 	flag.StringVar(&cmd.did, "did", "", "DID")
 	flag.BoolVar(&cmd.enableAuth, "enableAuth", false, "Enable authentication")
 	flag.BoolVar(&cmd.arbitaryMode, "arbitaryMode", false, "Enable arbitary mode")

--- a/command/token.go
+++ b/command/token.go
@@ -26,7 +26,7 @@ func (cmd *Command) GenerateTestRBT() {
 		return
 	}
 
-	br, err := cmd.c.GenerateTestRBT(cmd.numTokens, cmd.did)
+	br, err := cmd.c.GenerateTestRBT(cmd.numTokens, cmd.did, cmd.startIndex)
 
 	if err != nil {
 		cmd.log.Error("Failed to generate RBT", "err", err)

--- a/core/model/tokens.go
+++ b/core/model/tokens.go
@@ -8,6 +8,7 @@ const (
 type RBTGenerateRequest struct {
 	NumberOfTokens int    `json:"number_of_tokens"`
 	DID            string `json:"did"`
+	StartIndex     int    `json:"start_index"`
 }
 
 type RBTTransferRequest struct {

--- a/core/model/tokens.go
+++ b/core/model/tokens.go
@@ -87,7 +87,7 @@ type FaucetRBTGenerateRequest struct {
 }
 
 type TokenProviderMap struct {
-	TokenHash     string  `gorm:"column:token_hash;primaryKey"`
+	TokenHash     string  `gorm:"column:token;primaryKey"`
 	DID           string  `gorm:"column:did"`
 	FuncID        int     `gorm:"column:func_id"`
 	Role          int     `gorm:"column:role"`

--- a/core/model/tokens.go
+++ b/core/model/tokens.go
@@ -87,7 +87,7 @@ type FaucetRBTGenerateRequest struct {
 }
 
 type TokenProviderMap struct {
-	Token         string  `gorm:"column:token;primaryKey"`
+	TokenHash     string  `gorm:"column:token_hash;primaryKey"`
 	DID           string  `gorm:"column:did"`
 	FuncID        int     `gorm:"column:func_id"`
 	Role          int     `gorm:"column:role"`

--- a/core/provider_routing.go
+++ b/core/provider_routing.go
@@ -7,15 +7,15 @@ import (
 )
 
 type PinStatusReq struct {
-	Token string `json:"token"`
+	TokenHash string `json:"token_hash"`
 }
 
 type PinStatusRes struct {
-	Status bool   `json:"status"`
-	Token  string `json:"token"`
-	DID    string `json:"did"`
-	FuncID int    `json:"funcid"`
-	Role   int    `json:"role"`
+	Status    bool   `json:"status"`
+	TokenHash string `json:"token_hash"`
+	DID       string `json:"did"`
+	FuncID    int    `json:"funcid"`
+	Role      int    `json:"role"`
 }
 
 func (c *Core) PinService() {
@@ -32,12 +32,13 @@ func (c *Core) checkProviderStatus(req *ensweb.Request) *ensweb.Result {
 		c.log.Error("error parsing incoming request", "error", err)
 		return c.l.RenderJSON(req, &res, http.StatusOK)
 	}
-	providerMap, err := c.w.GetProviderDetails(reqObj.Token)
+	providerMap, err := c.w.GetProviderDetails(reqObj.TokenHash)
 	if err != nil {
+		c.log.Error("eror getting provider info", "error", err)
 		return c.l.RenderJSON(req, &res, http.StatusOK)
 	}
 	res.Status = true
-	res.Token = providerMap.Token
+	res.TokenHash = providerMap.TokenHash
 	res.DID = providerMap.DID
 	res.FuncID = providerMap.FuncID
 	res.Role = providerMap.Role

--- a/core/provider_routing.go
+++ b/core/provider_routing.go
@@ -34,7 +34,7 @@ func (c *Core) checkProviderStatus(req *ensweb.Request) *ensweb.Result {
 	}
 	providerMap, err := c.w.GetProviderDetails(reqObj.TokenHash)
 	if err != nil {
-		c.log.Error("eror getting provider info", "error", err)
+		c.log.Error("eror getting provider info for token hash ", reqObj.TokenHash, "error", err)
 		return c.l.RenderJSON(req, &res, http.StatusOK)
 	}
 	res.Status = true

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -955,8 +955,7 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("Unable to do IPFS Add operation on Token: %v", err)
 				}
-				c.w.UnPin(tokenHash, wallet.PrevSenderRole, sc.GetSenderDID())
-				
+				c.w.UnPin(tokenHash, wallet.PrevSenderRole, sc.GetSenderDID())				
 			}
 			//call ipfs repo gc after unpinnning
 			c.ipfsRepoGc()

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -955,7 +955,11 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("Unable to do IPFS Add operation on Token: %v", err)
 				}
-				c.w.UnPin(tokenHash, wallet.PrevSenderRole, sc.GetSenderDID())
+				unpinStatus, err := c.w.UnPin(tokenHash, wallet.PrevSenderRole, sc.GetSenderDID())
+				if err != nil || !unpinStatus {
+					c.log.Error("failed to unpin token ", t.Token, "token hash ", tokenHash, "err ", err)
+					return nil, nil, nil, fmt.Errorf("Unable to do IPFS unpin operation on Token: %v, err : %v", t.Token, err)
+				}
 			}
 			//call ipfs repo gc after unpinnning
 			c.ipfsRepoGc()

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -955,11 +955,8 @@ func (c *Core) initiateConsensus(cr *ConensusRequest, sc *contract.Contract, dc 
 				if err != nil {
 					return nil, nil, nil, fmt.Errorf("Unable to do IPFS Add operation on Token: %v", err)
 				}
-				unpinStatus, err := c.w.UnPin(tokenHash, wallet.PrevSenderRole, sc.GetSenderDID())
-				if err != nil || !unpinStatus {
-					c.log.Error("failed to unpin token ", t.Token, "token hash ", tokenHash, "err ", err)
-					return nil, nil, nil, fmt.Errorf("Unable to do IPFS unpin operation on Token: %v, err : %v", t.Token, err)
-				}
+				c.w.UnPin(tokenHash, wallet.PrevSenderRole, sc.GetSenderDID())
+				
 			}
 			//call ipfs repo gc after unpinnning
 			c.ipfsRepoGc()

--- a/core/token.go
+++ b/core/token.go
@@ -88,14 +88,6 @@ type PubSubEnvelope struct {
 	Data json.RawMessage `json:"data"`
 }
 
-//	type SendTokenDetailsInfo struct {
-//		TokenChainLength uint64 `json:"tc_length"`
-//		TokenType        int    `json:"token_type"`
-//		Token            string `json:"token"`
-//	}
-// type AllTokenChainDetails struct {
-// 	TokenTCLengthDetails map[string]model.SendTokenDetailsInfo `json:"token_tc_details"`
-// }
 
 func (c *Core) SetupToken() {
 	c.l.AddRoute(APISyncTokenChain, "POST", c.syncTokenChain)
@@ -174,8 +166,8 @@ func (c *Core) GetAccountInfo(did string) (model.DIDAccountInfo, error) {
 	return info, nil
 }
 
-func (c *Core) GenerateTestTokens(reqID string, num int, did string) {
-	err := c.generateTestTokens(reqID, num, did)
+func (c *Core) GenerateTestTokens(reqID string, num int, did string, startIndex int ) {
+	err := c.generateTestTokens(reqID, num, did, startIndex)
 	br := model.BasicResponse{
 		Status:  true,
 		Message: "Test tokens generated successfully",
@@ -199,7 +191,7 @@ func (c *Core) getTokenIDForLocalTestTokens(tokenLevel int, tokenNumber int, did
 	return idValue, nil
 }
 
-func (c *Core) generateTestTokens(reqID string, num int, did string) error {
+func (c *Core) generateTestTokens(reqID string, num int, did string, startIndex int) error {
 	if !c.testNet {
 		return fmt.Errorf("generate test token is available in test net")
 	}
@@ -207,10 +199,16 @@ func (c *Core) generateTestTokens(reqID string, num int, did string) error {
 	if err != nil {
 		return fmt.Errorf("DID is not exist")
 	}
+	var currentTokenNumber int
 
-	currentTokenNumber, err := c.w.GetLocalTokenNumber()
-	if err != nil {
-		return fmt.Errorf("failed to get local test token info, err: %v", err)
+	if startIndex >= 0 {
+		currentTokenNumber = startIndex
+	} else {
+		currentTokenNumber, err = c.w.GetLocalTokenNumber()
+		if err != nil {
+			return fmt.Errorf("failed to get local test token info, err: %v", err)
+		}
+
 	}
 
 	localTokenLevel := c.w.GetLocalTokenLevel()

--- a/core/token.go
+++ b/core/token.go
@@ -283,6 +283,17 @@ func (c *Core) generateTestTokens(reqID string, num int, did string) error {
 			c.log.Error("Failed to add token chain", "err", err)
 			return err
 		}
+
+		tokenIDBuffer := bytes.NewBufferString(id)
+		tokenHash, err := c.w.Add(tokenIDBuffer, did, wallet.AddFunc, true)
+		if err != nil {
+			return fmt.Errorf("createTokensAtLevel: failed to add token to ipfs: %v, err: %v", id, err)
+		}
+
+		if _, err := c.w.Pin(tokenHash, wallet.OwnerRole, did, "NA", did, "NA", t.TokenValue); err != nil {
+			return fmt.Errorf("createChildTokensAtLevel: failed to pin child token: %v, err: %v", id, err)
+		}
+
 		err = c.w.CreateToken(t)
 		if err != nil {
 			c.log.Error("Failed to create token", "err", err)

--- a/core/token_pin_check.go
+++ b/core/token_pin_check.go
@@ -73,8 +73,8 @@ func (c *Core) pinCheck(tokenID string, index int, senderPeerId string, receiver
 		results[index] = result
 		return
 	}
-	
-	provList, err := c.GetDHTddrs(tokenID)
+
+	provList, err := c.GetDHTddrs(tokenHash)
 	if err != nil {
 		c.log.Error("Error triggered while fetching providers ", "error", err)
 		result.Status = false

--- a/core/token_pin_check.go
+++ b/core/token_pin_check.go
@@ -81,6 +81,7 @@ func (c *Core) pinCheck(tokenID string, index int, senderPeerId string, receiver
 		result.Owners = nil
 		result.Error = err
 		results[index] = result
+		return
 	}
 
 	if len(provList) == 0 {
@@ -88,23 +89,24 @@ func (c *Core) pinCheck(tokenID string, index int, senderPeerId string, receiver
 		result.Owners = provList
 		result.Error = nil
 		results[index] = result
+		return
 	}
 
 	if len(provList) == 1 {
-		for _, peerId := range provList {
-			if peerId != senderPeerId {
-				c.log.Error("Sender peer not exist in provider list", "peerID", peerId)
-				result.Status = true
-				result.Owners = provList
-				result.Error = nil
-				results[index] = result
-			} else {
-				result.Status = false
-				result.Owners = nil
-				result.Error = nil
-				results[index] = result
-			}
+		peerId := provList[0]
+		if peerId != senderPeerId {
+			c.log.Error("Sender peer not exist in provider list", "peerID", peerId)
+			result.Status = true
+			result.Owners = provList
+			result.Error = nil
+			results[index] = result
+		} else {
+			result.Status = false
+			result.Owners = nil
+			result.Error = nil
+			results[index] = result
 		}
+		return
 	}
 
 	var knownPeer []string
@@ -122,6 +124,7 @@ func (c *Core) pinCheck(tokenID string, index int, senderPeerId string, receiver
 			result.Owners = nil
 			result.Error = nil
 			results[index] = result
+			return
 		} else {
 			peerIdRolemap := make(map[string]int)
 			for _, peerId := range t {
@@ -132,10 +135,10 @@ func (c *Core) pinCheck(tokenID string, index int, senderPeerId string, receiver
 					result.Owners = nil
 					result.Error = err
 					results[index] = result
-					continue
+					return
 				}
 				req := PinStatusReq{
-					Token: tokenID,
+					TokenHash: tokenHash,
 				}
 				var psr PinStatusRes
 				err = p.SendJSONRequest("POST", APIDhtProviderCheck, nil, &req, &psr, true)
@@ -145,19 +148,21 @@ func (c *Core) pinCheck(tokenID string, index int, senderPeerId string, receiver
 					result.Owners = nil
 					result.Error = err
 					results[index] = result
+					return
 				}
 				if psr.Status {
 					peerIdRolemap[peerId] = psr.Role
 				}
 			}
 
-			for peerId, _ := range peerIdRolemap {
+			for peerId := range peerIdRolemap {
 				if peerIdRolemap[peerId] == wallet.OwnerRole {
 					// c.log.Error("Token has multiple Pins")
 					result.Status = true
 					result.Owners = provList
 					result.Error = nil
 					results[index] = result
+					return
 				}
 			}
 		}

--- a/core/wallet/ipfs_get_optimized.go
+++ b/core/wallet/ipfs_get_optimized.go
@@ -48,10 +48,10 @@ func (w *Wallet) GetWithProviderMap(hash string, did string, role int, path stri
 		if err == nil {
 			// Success - create provider map and return
 			tpm := model.TokenProviderMap{
-				Token:  hash,
-				Role:   role,
-				DID:    did,
-				FuncID: GetFunc,
+				TokenHash: hash,
+				Role:      role,
+				DID:       did,
+				FuncID:    GetFunc,
 			}
 			
 			w.log.Info("IPFS Get successful", 

--- a/core/wallet/ipfs_service.go
+++ b/core/wallet/ipfs_service.go
@@ -42,7 +42,7 @@ func (w *Wallet) Pin(hash string, role int, did string, transactionId string, se
 	if len(skipProviderDetails) > 0 && skipProviderDetails[0] {
 		return true, nil
 	}
-	err = w.AddProviderDetails(model.TokenProviderMap{Token: hash, Role: role, DID: did, FuncID: PinFunc, TransactionID: transactionId, Sender: sender, Receiver: receiver, TokenValue: tokenValue})
+	err = w.AddProviderDetails(model.TokenProviderMap{TokenHash: hash, Role: role, DID: did, FuncID: PinFunc, TransactionID: transactionId, Sender: sender, Receiver: receiver, TokenValue: tokenValue})
 	if err != nil {
 		w.log.Info("Error addding provider details to DB", "error", err)
 		return false, err
@@ -78,7 +78,7 @@ func (w *Wallet) Cat(hash string, role int, did string) (string, error) {
 		w.log.Error("Error formatting ipfs content", "error", err)
 		return "", err
 	}
-	err1 := w.AddProviderDetails(model.TokenProviderMap{Token: hash, Role: role, DID: did, FuncID: CatFunc})
+	err1 := w.AddProviderDetails(model.TokenProviderMap{TokenHash: hash, Role: role, DID: did, FuncID: CatFunc})
 	if err1 != nil {
 		w.log.Info("Error addding provider details to DB", "error", err)
 		return "", err
@@ -94,7 +94,7 @@ func (w *Wallet) Get(hash string, did string, role int, path string) error {
 		w.log.Error("Error while getting file from ipfs", "error", err)
 		return err
 	}
-	err = w.AddProviderDetails(model.TokenProviderMap{Token: hash, Role: role, DID: did, FuncID: GetFunc})
+	err = w.AddProviderDetails(model.TokenProviderMap{TokenHash: hash, Role: role, DID: did, FuncID: GetFunc})
 	if err != nil {
 		w.log.Info("Error addding provider details to DB", "error", err)
 		//return err
@@ -112,7 +112,7 @@ func (w *Wallet) Add(r io.Reader, did string, role int, skipProvider ...bool) (s
 	}
 
 	if len(skipProvider) == 0 || !skipProvider[0] {
-		err = w.AddProviderDetails(model.TokenProviderMap{Token: result, Role: role, DID: did, FuncID: AddFunc})
+		err = w.AddProviderDetails(model.TokenProviderMap{TokenHash: result, Role: role, DID: did, FuncID: AddFunc})
 		if err != nil {
 			w.log.Error("Error adding provider details", "error", err)
 			return "", err
@@ -131,10 +131,10 @@ func (w *Wallet) AddWithProviderMap(r io.Reader, did string, role int) (string, 
 		return "", model.TokenProviderMap{}, err
 	}
 	tpm := model.TokenProviderMap{
-		Token:  result,
-		Role:   role,
-		DID:    did,
-		FuncID: AddFunc,
+		TokenHash: result,
+		Role:      role,
+		DID:       did,
+		FuncID:    AddFunc,
 	}
 	return result, tpm, nil
 }

--- a/core/wallet/provider_details.go
+++ b/core/wallet/provider_details.go
@@ -13,7 +13,7 @@ import (
 func (w *Wallet) GetProviderDetails(tokenHash string) (*model.TokenProviderMap, error) {
 	var tokenMap model.TokenProviderMap
 
-	err := w.s.Read(TokenProvider, &tokenMap, "token_hash=?", tokenHash)
+	err := w.s.Read(TokenProvider, &tokenMap, "token=?", tokenHash)
 	if err != nil {
 		if err.Error() == "no records found" {
 			//w.log.Debug("Data Not avilable in DB")
@@ -31,18 +31,18 @@ func (w *Wallet) GetProviderDetails(tokenHash string) (*model.TokenProviderMap, 
 
 func (w *Wallet) AddProviderDetails(tokenProviderMap model.TokenProviderMap) error {
 	var tpm model.TokenProviderMap
-	err := w.s.Read(TokenProvider, &tpm, "token_hash=?", tokenProviderMap.TokenHash)
+	err := w.s.Read(TokenProvider, &tpm, "token=?", tokenProviderMap.TokenHash)
 	if err != nil || tpm.TokenHash == "" {
 		w.log.Debug("Token Details not found: Creating new Record")
 		// create new entry, but handle unique constraint error
 		writeErr := w.s.Write(TokenProvider, tokenProviderMap)
 		if writeErr != nil && strings.Contains(writeErr.Error(), "UNIQUE constraint failed") {
 			// Someone else inserted, so update instead
-			return w.s.Update(TokenProvider, tokenProviderMap, "token_hash=?", tokenProviderMap.TokenHash)
+			return w.s.Update(TokenProvider, tokenProviderMap, "token=?", tokenProviderMap.TokenHash)
 		}
 		return writeErr
 	}
-	return w.s.Update(TokenProvider, tokenProviderMap, "token_hash=?", tokenProviderMap.TokenHash)
+	return w.s.Update(TokenProvider, tokenProviderMap, "token=?", tokenProviderMap.TokenHash)
 }
 
 // Method to add provider details to DB in batch during ipfs ops

--- a/core/wallet/provider_details.go
+++ b/core/wallet/provider_details.go
@@ -10,9 +10,10 @@ import (
 // struct definition for Mapping token and reason the did is a provider
 
 // Method takes token hash as input and returns the Provider details
-func (w *Wallet) GetProviderDetails(token string) (*model.TokenProviderMap, error) {
+func (w *Wallet) GetProviderDetails(tokenHash string) (*model.TokenProviderMap, error) {
 	var tokenMap model.TokenProviderMap
-	err := w.s.Read(TokenProvider, &tokenMap, "token=?", token)
+
+	err := w.s.Read(TokenProvider, &tokenMap, "token_hash=?", tokenHash)
 	if err != nil {
 		if err.Error() == "no records found" {
 			//w.log.Debug("Data Not avilable in DB")
@@ -30,18 +31,18 @@ func (w *Wallet) GetProviderDetails(token string) (*model.TokenProviderMap, erro
 
 func (w *Wallet) AddProviderDetails(tokenProviderMap model.TokenProviderMap) error {
 	var tpm model.TokenProviderMap
-	err := w.s.Read(TokenProvider, &tpm, "token=?", tokenProviderMap.Token)
-	if err != nil || tpm.Token == "" {
+	err := w.s.Read(TokenProvider, &tpm, "token_hash=?", tokenProviderMap.TokenHash)
+	if err != nil || tpm.TokenHash == "" {
 		w.log.Debug("Token Details not found: Creating new Record")
 		// create new entry, but handle unique constraint error
 		writeErr := w.s.Write(TokenProvider, tokenProviderMap)
 		if writeErr != nil && strings.Contains(writeErr.Error(), "UNIQUE constraint failed") {
 			// Someone else inserted, so update instead
-			return w.s.Update(TokenProvider, tokenProviderMap, "token=?", tokenProviderMap.Token)
+			return w.s.Update(TokenProvider, tokenProviderMap, "token_hash=?", tokenProviderMap.TokenHash)
 		}
 		return writeErr
 	}
-	return w.s.Update(TokenProvider, tokenProviderMap, "token=?", tokenProviderMap.Token)
+	return w.s.Update(TokenProvider, tokenProviderMap, "token_hash=?", tokenProviderMap.TokenHash)
 }
 
 // Method to add provider details to DB in batch during ipfs ops
@@ -60,7 +61,7 @@ func (w *Wallet) AddProviderDetailsBatch(tokenProviderMaps []model.TokenProvider
 		err := w.AddProviderDetails(tpm)
 		if err != nil {
 			// Log the error but continue processing other entries
-			w.log.Warn("Failed to add provider details in batch", "token", tpm.Token, "did", tpm.DID, "err", err)
+			w.log.Warn("Failed to add provider details in batch", "token hash", tpm.TokenHash, "did", tpm.DID, "err", err)
 			lastErr = err
 			// If it's not a UNIQUE constraint error, it might be more serious
 			if !strings.Contains(err.Error(), "UNIQUE constraint failed") {

--- a/core/wallet/provider_details_optimized.go
+++ b/core/wallet/provider_details_optimized.go
@@ -62,7 +62,7 @@ func (w *Wallet) processProviderDetailsChunk(chunk []model.TokenProviderMap) err
 		if err != nil {
 			if strings.Contains(err.Error(), "UNIQUE constraint failed") {
 				// Already exists, update instead
-				err = w.s.Update(TokenProvider, tpm, "token_hash=?", tpm.TokenHash)
+				err = w.s.Update(TokenProvider, tpm, "token=?", tpm.TokenHash)
 				if err != nil {
 					w.log.Warn("Failed to update provider details", "token hash", tpm.TokenHash, "err", err)
 					continue

--- a/core/wallet/provider_details_optimized.go
+++ b/core/wallet/provider_details_optimized.go
@@ -62,13 +62,13 @@ func (w *Wallet) processProviderDetailsChunk(chunk []model.TokenProviderMap) err
 		if err != nil {
 			if strings.Contains(err.Error(), "UNIQUE constraint failed") {
 				// Already exists, update instead
-				err = w.s.Update(TokenProvider, tpm, "token=?", tpm.Token)
+				err = w.s.Update(TokenProvider, tpm, "token_hash=?", tpm.TokenHash)
 				if err != nil {
-					w.log.Warn("Failed to update provider details", "token", tpm.Token, "err", err)
+					w.log.Warn("Failed to update provider details", "token hash", tpm.TokenHash, "err", err)
 					continue
 				}
 			} else {
-				w.log.Warn("Failed to add provider details", "token", tpm.Token, "err", err)
+				w.log.Warn("Failed to add provider details", "token hash", tpm.TokenHash, "err", err)
 				continue
 			}
 		}

--- a/core/wallet/smart_contract.go
+++ b/core/wallet/smart_contract.go
@@ -107,7 +107,7 @@ func (w *Wallet) UpdateSmartContractStatus(smartContractToken string, tokenStatu
 // retrive state pin info if it exists
 func (w *Wallet) GetStatePinnedInfo(token string) (*model.TokenProviderMap, error) {
 	var tokenMap model.TokenProviderMap
-	err := w.s.Read(TokenProvider, &tokenMap, "token_hash=?", token)
+	err := w.s.Read(TokenProvider, &tokenMap, "token=?", token)
 	if err != nil {
 		if err.Error() == "no records found" {
 			//w.log.Debug("Data Not avilable in DB")

--- a/core/wallet/smart_contract.go
+++ b/core/wallet/smart_contract.go
@@ -107,7 +107,7 @@ func (w *Wallet) UpdateSmartContractStatus(smartContractToken string, tokenStatu
 // retrive state pin info if it exists
 func (w *Wallet) GetStatePinnedInfo(token string) (*model.TokenProviderMap, error) {
 	var tokenMap model.TokenProviderMap
-	err := w.s.Read(TokenProvider, &tokenMap, "token=?", token)
+	err := w.s.Read(TokenProvider, &tokenMap, "token_hash=?", token)
 	if err != nil {
 		if err.Error() == "no records found" {
 			//w.log.Debug("Data Not avilable in DB")

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -955,9 +955,8 @@ func (w *Wallet) TokensReceived(did string, ti []contract.TokenInfo, b *block.Bl
 	for _, info := range ti {
 		t := info.Token
 		b := w.GetLatestTokenBlock(info.Token, info.TokenType)
-		blockId, _ := b.GetBlockID(t)
-		tokenIDTokenStateData := t + blockId
-		tokenIDTokenStateBuffer := bytes.NewBuffer([]byte(tokenIDTokenStateData))
+		// add token hash to token provider map
+		tokenIDTokenStateBuffer := bytes.NewBuffer([]byte(t))
 		tokenIDTokenStateHash, tpm, _ := w.AddWithProviderMap(tokenIDTokenStateBuffer, did, OwnerRole)
 		updatedtokenhashes = append(updatedtokenhashes, tokenIDTokenStateHash)
 		tokenHashMap[t] = tokenIDTokenStateHash

--- a/core/wallet/token_receiver_optimized.go
+++ b/core/wallet/token_receiver_optimized.go
@@ -156,7 +156,13 @@ func (w *Wallet) OptimizedTokensReceived(did string, ti []contract.TokenInfo, b 
 			// Pin the token with new transaction details
 			senderAddress := senderPeerId + "." + b.GetSenderDID()
 			receiverAddress := receiverPeerId + "." + b.GetOwner()
-			_, err = w.Pin(tokenInfo.Token, role, did, b.GetTid(), senderAddress, receiverAddress, tokenInfo.TokenValue, true)
+			tokenHash, err := w.ipfsOps.Add(
+				bytes.NewBufferString(tokenInfo.Token),
+			)
+			if err != nil {
+				w.log.Error("Failed to add ft tokens to ipfs", "err", err)
+			}
+			_, err = w.Pin(tokenHash, role, did, b.GetTid(), senderAddress, receiverAddress, tokenInfo.TokenValue, true)
 			if err != nil {
 				w.log.Error("Failed to pin existing token",
 					"token", tokenInfo.Token,
@@ -276,7 +282,13 @@ func (w *Wallet) OptimizedTokensReceived(did string, ti []contract.TokenInfo, b 
 		receiverAddress := receiverPeerId + "." + b.GetOwner()
 
 		// Pin the token
-		_, err = w.Pin(tokenInfo.Token, role, did, b.GetTid(), senderAddress, receiverAddress, tokenInfo.TokenValue, true)
+		tokenHash, err := w.ipfsOps.Add(
+			bytes.NewBufferString(tokenInfo.Token),
+		)
+		if err != nil {
+			w.log.Error("Failed to get rbt token hash", "err", err)
+		}
+		_, err = w.Pin(tokenHash, role, did, b.GetTid(), senderAddress, receiverAddress, tokenInfo.TokenValue, true)
 		if err != nil {
 			w.log.Error("Failed to pin token", 
 				"token", tokenInfo.Token,

--- a/grpcserver/token.go
+++ b/grpcserver/token.go
@@ -7,13 +7,14 @@ import (
 	"github.com/rubixchain/rubixgoplatform/core/model"
 	"github.com/rubixchain/rubixgoplatform/protos"
 )
+const defaultStartIndex = -1
 
 func (rn *RubixNative) GenerateRBT(ctx context.Context, in *protos.GenerateReq) (*protos.BasicReponse, error) {
 	c, tkn, err := rn.getClient(ctx, true)
 	if err != nil {
 		return nil, err
 	}
-	br, err := c.GenerateTestRBT(int(in.TokenCount), rn.c.GetTokenDID(tkn))
+	br, err := c.GenerateTestRBT(int(in.TokenCount), rn.c.GetTokenDID(tkn), defaultStartIndex)
 	if err != nil {
 		return nil, err
 	}

--- a/server/tokens.go
+++ b/server/tokens.go
@@ -48,7 +48,7 @@ func (s *Server) APIGenerateTestToken(req *ensweb.Request) *ensweb.Result {
 		return s.BasicResponse(req, false, "DID does not have an access", nil)
 	}
 	s.c.AddWebReq(req)
-	go s.c.GenerateTestTokens(req.ID, tr.NumberOfTokens, tr.DID)
+	go s.c.GenerateTestTokens(req.ID, tr.NumberOfTokens, tr.DID, tr.StartIndex)
 	return s.didResponse(req, req.ID)
 }
 


### PR DESCRIPTION
## Issue
This PR is addressing the following issues :

1. **No pins on newly generated local test tokens** : there was no pin while first transferring a newly generated token, leading to unpin error logs on sender node 
2. **Adding token-state-hash inplace of token-hash to TokenProviderTable of receiver** : Receiver was adding token state hash instead of token hash in Provider table. So, when the receiver transfers, it never finds the tokens in Provider table and hence never removes the token details from the table.
3. **Multi-pin check failure** : Quorum was fetching the providers list of the token-hash. But while inquiring about the pin role, quorum was passing token-id instead of token-hash. So, when the providers checks its' Provider table it does not get any info, returning false to quorum. Quorum passes multi-pin check due to absence of correct info.

## Solution

1. Token owner is pinning the test tokens while generating them
2. Receiver is adding token hash to TokenProviderTable. Hence, it is successfully getting removed whenever the token is transferred further. 
3. During multi-pin check, Quorum is inquiring about the token-hash pin role instead of token-id pin role.