### PR TITLE
In generate test RBT, making token_level and token_number exactly similar to Faucet tokens or Mainnet tokens. 

### DIFF
--- a/core/token.go
+++ b/core/token.go
@@ -211,8 +211,6 @@ func (c *Core) generateTestTokens(reqID string, num int, did string, startIndex 
 
 	}
 
-	localTokenLevel := c.w.GetLocalTokenLevel()
-
 	var startTokenNumber int
 	var finalTokenNumber int
 
@@ -225,8 +223,14 @@ func (c *Core) generateTestTokens(reqID string, num int, did string, startIndex 
 	finalTokenNumber = startTokenNumber + num
 	currentTime := time.Now()
 
-	for tokenNumber := startTokenNumber; tokenNumber < finalTokenNumber; tokenNumber++ {
-		id, err := c.getTokenIDForLocalTestTokens(localTokenLevel, tokenNumber, did)
+	// Each global index maps to (tokenLevel, numInLevel) per TokenMap: level 10000 = TokenMap 0 (56 tokens), 10001 = TokenMap 1 (4300000), etc.
+	for globalIndex := startTokenNumber; globalIndex < finalTokenNumber; globalIndex++ {
+		tokenLevel, numInLevel, err := token.GetTokenLevelAndNumberForGlobalIndex(globalIndex)
+		if err != nil {
+			c.log.Error("Failed to get token level and number for global index", "globalIndex", globalIndex, "err", err)
+			return err
+		}
+		id, err := c.getTokenIDForLocalTestTokens(tokenLevel, numInLevel, did)
 		if err != nil {
 			c.log.Error("Failed to add token to network", "err", err)
 			return err

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -2220,10 +2220,6 @@ const LocalTestTokenInfo_TokenLevel_Attr = "token_level"
 const LocalTestTokenInfo_TokenNumber_Attr = "token_number"
 const LocalTestTokenInfo_TokenLevel_Value int = 10000
 
-func (w *Wallet) GetLocalTokenLevel() int {
-	return LocalTestTokenInfo_TokenLevel_Value
-}
-
 func (w *Wallet) GetLocalTokenNumber() (int, error) {
 	var localTestTokenInfo *model.LocalTestTokenInfo
 

--- a/token/token_mapping.go
+++ b/token/token_mapping.go
@@ -1,12 +1,20 @@
 package token
 
+import "fmt"
+
 const FaucetName = "faucettestrbt"
 
+// LocalTestTokenLevelBase is the starting level for local test tokens. Level 10000
+// corresponds to TokenMap level 0 (56 tokens), 10001 to level 1 (4300000 tokens), etc.
+const LocalTestTokenLevelBase = 10000
+
+// TokenMap maps RBT token level to Tokens Awarded per the official RBT Tokenomics sheet.
+// Ref: https://learn.rubix.net/docs/tools-downloads/tokenomics
 var TokenMap = map[int]int{
-	0:  0,
-	1:  5000000,
+	0:  56,
+	1:  4300000,
 	2:  2425000,
-	3:  2188563,
+	3:  2303750,
 	4:  2188563,
 	5:  2079134,
 	6:  1975178,
@@ -82,6 +90,28 @@ var TokenMap = map[int]int{
 	76: 21731,
 	77: 19558,
 	78: 17602,
+}
+
+// GetTokenLevelAndNumberForGlobalIndex maps a global token index to the
+// token level (10000 + TokenMap level) and the token number within that level.
+// E.g. global index 1-56 → level 10000, numbers 1-56; 57-4300056 → level 10001, numbers 1-4300000.
+func GetTokenLevelAndNumberForGlobalIndex(globalIndex int) (tokenLevel int, numInLevel int, err error) {
+	if globalIndex < 1 {
+		return 0, 0, fmt.Errorf("global index must be >= 1, got %d", globalIndex)
+	}
+	cumulative := 0
+	for mapLevel := 0; ; mapLevel++ {
+		maxCount, ok := TokenMap[mapLevel]
+		if !ok {
+			return 0, 0, fmt.Errorf("global index %d exceeds max token levels", globalIndex)
+		}
+		if globalIndex <= cumulative+maxCount {
+			tokenLevel = LocalTestTokenLevelBase + mapLevel
+			numInLevel = globalIndex - cumulative
+			return tokenLevel, numInLevel, nil
+		}
+		cumulative += maxCount
+	}
 }
 
 type FaucetToken struct {


### PR DESCRIPTION
While generating test net tokens, lets say If user generates more tokens than in the current existing level(according to the token Map). It will go to next level. Example: In level-0, user can create 56 tokens, after 56 tokens, token_level will be 1, token number will start from 0. 