### PR TITLE
fixes associated with FT transfer

### DIFF
--- a/core/ft.go
+++ b/core/ft.go
@@ -1,9 +1,9 @@
 package core
 
 import (
+	"bytes"
 	"errors"
 	"fmt"
-	"bytes"
 	"log"
 	"math"
 	"regexp"
@@ -24,8 +24,8 @@ import (
 	"github.com/rubixchain/rubixgoplatform/util"
 	"github.com/rubixchain/rubixgoplatform/wrapper/uuid"
 
-	rubixmath "github.com/rubixchain/rubixgoplatform/math"
 	ipfsnode "github.com/ipfs/go-ipfs-api"
+	rubixmath "github.com/rubixchain/rubixgoplatform/math"
 )
 
 func (c *Core) CreateFTs(reqID string, did string, ftcount int, ftname string, wholeToken int, ftNumStartIndex int) {
@@ -660,10 +660,8 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 
 	// Extract token IDs for later use
 	FTTokenIDs := make([]string, 0)
-	fTTokenValue := rubixmath.ZeroFloat()
 
 	for i := range TokenInfo {
-		fTTokenValue = TokenInfo[i].TokenValue
 		FTTokenIDs = append(FTTokenIDs, TokenInfo[i].Token)
 	}
 	sct := &contract.ContractType{
@@ -675,7 +673,6 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 			Comment:     req.Comment,
 			TransTokens: TokenInfo,
 		},
-		TotalRBTs: fTTokenValue,
 		ReqID: reqID,
 	}
 	FTData := model.FTInfo{

--- a/core/ft.go
+++ b/core/ft.go
@@ -3,6 +3,7 @@ package core
 import (
 	"errors"
 	"fmt"
+	"bytes"
 	"log"
 	"math"
 	"regexp"
@@ -24,6 +25,7 @@ import (
 	"github.com/rubixchain/rubixgoplatform/wrapper/uuid"
 
 	rubixmath "github.com/rubixchain/rubixgoplatform/math"
+	ipfsnode "github.com/ipfs/go-ipfs-api"
 )
 
 func (c *Core) CreateFTs(reqID string, did string, ftcount int, ftname string, wholeToken int, ftNumStartIndex int) {
@@ -220,8 +222,14 @@ func (c *Core) createFTs(reqID string, FTName string, numFTs int, numWholeTokens
 				results <- ftResult{Err: err}
 				continue
 			}
-		}
 
+			_, err = c.ipfs.Add(bytes.NewBufferString(ftID), ipfsnode.OnlyHash(false), ipfsnode.Pin(true))
+			if err != nil {
+				c.log.Error(fmt.Sprintf("createFts: failed to get IPFS token hash for token: %v, err: %v", ftID, err))
+				results <- ftResult{Err: err}
+				continue
+			}
+		}
 	}
 
 	// Start workers
@@ -652,7 +660,10 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 
 	// Extract token IDs for later use
 	FTTokenIDs := make([]string, 0)
+	fTTokenValue := rubixmath.ZeroFloat()
+
 	for i := range TokenInfo {
+		fTTokenValue = TokenInfo[i].TokenValue
 		FTTokenIDs = append(FTTokenIDs, TokenInfo[i].Token)
 	}
 	sct := &contract.ContractType{
@@ -664,6 +675,7 @@ func (c *Core) initiateFTTransfer(reqID string, req *model.TransferFTReq) *model
 			Comment:     req.Comment,
 			TransTokens: TokenInfo,
 		},
+		TotalRBTs: fTTokenValue,
 		ReqID: reqID,
 	}
 	FTData := model.FTInfo{

--- a/core/ipfs_operations.go
+++ b/core/ipfs_operations.go
@@ -1,8 +1,10 @@
 package core
 
 import (
+	"bytes"
 	"context"
 	"io"
+	"strings"
 	"time"
 
 	ipfsnode "github.com/ipfs/go-ipfs-api"
@@ -21,23 +23,23 @@ func NewIPFSOperations(core *Core) *IPFSOperations {
 // executeWithMetrics executes an operation with health checks and performance metrics
 func (ops *IPFSOperations) executeWithMetrics(ctx context.Context, operationName string, metadata map[string]interface{}, operation func() error) error {
 	start := time.Now()
-	
+
 	err := ops.core.ipfsHealth.ExecuteWithHealthCheck(ctx, operation)
-	
+
 	// Update metrics if scalability manager exists
 	if ops.core.ipfsScalability != nil {
 		responseTime := time.Since(start)
 		success := err == nil
 		ops.core.ipfsScalability.UpdateMetrics(responseTime, success)
 	}
-	
+
 	// Track operation performance
 	if metadata == nil {
 		metadata = make(map[string]interface{})
 	}
 	metadata["duration_ms"] = time.Since(start).Milliseconds()
 	ops.core.TrackOperation(operationName, metadata)(err)
-	
+
 	return err
 }
 
@@ -45,7 +47,7 @@ func (ops *IPFSOperations) executeWithMetrics(ctx context.Context, operationName
 func (ops *IPFSOperations) Add(data io.Reader, opts ...ipfsnode.AddOpts) (string, error) {
 	var result string
 	var operationErr error
-	
+
 	// Check if pinning is enabled
 	// Note: This is a simplified check - actual pinning detection would need
 	// to inspect the options differently
@@ -83,7 +85,7 @@ func (ops *IPFSOperations) AddDir(path string) (string, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
 	defer cancel()
-	
+
 	metadata := map[string]interface{}{
 		"path": path,
 	}
@@ -113,13 +115,22 @@ func (ops *IPFSOperations) Cat(hash string) (io.ReadCloser, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	
+
+	inputHash := hash
+	if !(strings.HasPrefix(hash, "Qm") || strings.HasPrefix(hash, "bafy")) {
+		var err error
+		inputHash, err = ops.Add(bytes.NewBufferString(hash), ipfsnode.OnlyHash(true), ipfsnode.Pin(false))
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	metadata := map[string]interface{}{
-		"hash": hash,
+		"hash": inputHash,
 	}
 
 	err := ops.executeWithMetrics(ctx, "ipfs.cat", metadata, func() error {
-		reader, err := ops.core.ipfs.Cat(hash)
+		reader, err := ops.core.ipfs.Cat(inputHash)
 		if err != nil {
 			operationErr = err
 			return err
@@ -139,14 +150,23 @@ func (ops *IPFSOperations) Cat(hash string) (io.ReadCloser, error) {
 func (ops *IPFSOperations) Get(hash, path string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
 	defer cancel()
-	
+
+	inputHash := hash
+	if !(strings.HasPrefix(hash, "Qm") || strings.HasPrefix(hash, "bafy")) {
+		var err error
+		inputHash, err = ops.Add(bytes.NewBufferString(hash), ipfsnode.OnlyHash(true), ipfsnode.Pin(false))
+		if err != nil {
+			return err
+		}
+	}
+
 	metadata := map[string]interface{}{
-		"hash": hash,
+		"hash": inputHash,
 		"path": path,
 	}
 
 	return ops.executeWithMetrics(ctx, "ipfs.get", metadata, func() error {
-		return ops.core.ipfs.Get(hash, path)
+		return ops.core.ipfs.Get(inputHash, path)
 	})
 }
 
@@ -154,13 +174,22 @@ func (ops *IPFSOperations) Get(hash, path string) error {
 func (ops *IPFSOperations) Pin(hash string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	
+
+	inputHash := hash
+	if !(strings.HasPrefix(hash, "Qm") || strings.HasPrefix(hash, "bafy")) {
+		var err error
+		inputHash, err = ops.Add(bytes.NewBufferString(hash), ipfsnode.OnlyHash(true), ipfsnode.Pin(false))
+		if err != nil {
+			return err
+		}
+	}
+
 	metadata := map[string]interface{}{
-		"hash": hash,
+		"hash": inputHash,
 	}
 
 	return ops.executeWithMetrics(ctx, "ipfs.pin", metadata, func() error {
-		return ops.core.ipfs.Pin(hash)
+		return ops.core.ipfs.Pin(inputHash)
 	})
 }
 
@@ -168,13 +197,22 @@ func (ops *IPFSOperations) Pin(hash string) error {
 func (ops *IPFSOperations) Unpin(hash string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
 	defer cancel()
-	
+
+	inputHash := hash
+	if !(strings.HasPrefix(hash, "Qm") || strings.HasPrefix(hash, "bafy")) {
+		var err error
+		inputHash, err = ops.Add(bytes.NewBufferString(hash), ipfsnode.OnlyHash(true), ipfsnode.Pin(false))
+		if err != nil {
+			return err
+		}
+	}
+
 	metadata := map[string]interface{}{
-		"hash": hash,
+		"hash": inputHash,
 	}
 
 	return ops.executeWithMetrics(ctx, "ipfs.unpin", metadata, func() error {
-		return ops.core.ipfs.Unpin(hash)
+		return ops.core.ipfs.Unpin(inputHash)
 	})
 }
 

--- a/core/wallet/ipfs_interface.go
+++ b/core/wallet/ipfs_interface.go
@@ -1,7 +1,9 @@
 package wallet
 
 import (
+	"bytes"
 	"io"
+	"strings"
 
 	ipfsnode "github.com/ipfs/go-ipfs-api"
 )
@@ -31,17 +33,57 @@ func (d *DirectIPFSOperations) Add(data io.Reader, opts ...ipfsnode.AddOpts) (st
 }
 
 func (d *DirectIPFSOperations) Cat(hash string) (io.ReadCloser, error) {
+	if !(strings.HasPrefix(hash, "Qm") || strings.HasPrefix(hash, "bafy")) {
+		var err error
+		hash, err = d.Add(bytes.NewBufferString(hash), ipfsnode.OnlyHash(true), ipfsnode.Pin(false))
+		if err != nil {
+			return nil, err
+		}
+
+		return d.ipfs.Cat(hash)
+	}
+
 	return d.ipfs.Cat(hash)
 }
 
 func (d *DirectIPFSOperations) Get(hash, path string) error {
+	if !(strings.HasPrefix(hash, "Qm") || strings.HasPrefix(hash, "bafy")) {
+		var err error
+		hash, err = d.Add(bytes.NewBufferString(hash), ipfsnode.OnlyHash(true), ipfsnode.Pin(false))
+		if err != nil {
+			return err
+		}
+
+		return d.ipfs.Get(hash, path)
+	}
+
 	return d.ipfs.Get(hash, path)
 }
 
 func (d *DirectIPFSOperations) Pin(hash string) error {
+	if !(strings.HasPrefix(hash, "Qm") || strings.HasPrefix(hash, "bafy")) {
+		var err error
+		hash, err = d.Add(bytes.NewBufferString(hash), ipfsnode.OnlyHash(true), ipfsnode.Pin(false))
+		if err != nil {
+			return err
+		}
+
+		return d.ipfs.Pin(hash)
+	}
+
 	return d.ipfs.Pin(hash)
 }
 
 func (d *DirectIPFSOperations) Unpin(hash string) error {
+	if !(strings.HasPrefix(hash, "Qm") || strings.HasPrefix(hash, "bafy")) {
+		var err error
+		hash, err = d.Add(bytes.NewBufferString(hash), ipfsnode.OnlyHash(true), ipfsnode.Pin(false))
+		if err != nil {
+			return err
+		}
+
+		return d.ipfs.Unpin(hash)
+	}
+
 	return d.ipfs.Unpin(hash)
 }

--- a/core/wallet_ipfs_adapter.go
+++ b/core/wallet_ipfs_adapter.go
@@ -1,7 +1,9 @@
 package core
 
 import (
+	"bytes"
 	"io"
+	"strings"
 
 	ipfsnode "github.com/ipfs/go-ipfs-api"
 	"github.com/rubixchain/rubixgoplatform/core/wallet"
@@ -22,17 +24,57 @@ func (w *WalletIPFSAdapter) Add(data io.Reader, opts ...ipfsnode.AddOpts) (strin
 }
 
 func (w *WalletIPFSAdapter) Cat(hash string) (io.ReadCloser, error) {
+	if !(strings.HasPrefix(hash, "Qm") || strings.HasPrefix(hash, "bafy")) {
+		var err error
+		hash, err = w.Add(bytes.NewBufferString(hash), ipfsnode.OnlyHash(true), ipfsnode.Pin(false))
+		if err != nil {
+			return nil, err
+		}
+
+		return w.ops.Cat(hash)
+	}
+
 	return w.ops.Cat(hash)
 }
 
 func (w *WalletIPFSAdapter) Get(hash, path string) error {
+	if !(strings.HasPrefix(hash, "Qm") || strings.HasPrefix(hash, "bafy")) {
+		var err error
+		hash, err = w.Add(bytes.NewBufferString(hash), ipfsnode.OnlyHash(true), ipfsnode.Pin(false))
+		if err != nil {
+			return err
+		}
+
+		return w.ops.Get(hash, path)
+	}
+
 	return w.ops.Get(hash, path)
 }
 
 func (w *WalletIPFSAdapter) Pin(hash string) error {
+	if !(strings.HasPrefix(hash, "Qm") || strings.HasPrefix(hash, "bafy")) {
+		var err error
+		hash, err = w.Add(bytes.NewBufferString(hash), ipfsnode.OnlyHash(true), ipfsnode.Pin(false))
+		if err != nil {
+			return err
+		}
+
+		return w.ops.Pin(hash)
+	}
+
 	return w.ops.Pin(hash)
 }
 
 func (w *WalletIPFSAdapter) Unpin(hash string) error {
+	if !(strings.HasPrefix(hash, "Qm") || strings.HasPrefix(hash, "bafy")) {
+		var err error
+		hash, err = w.Add(bytes.NewBufferString(hash), ipfsnode.OnlyHash(true), ipfsnode.Pin(false))
+		if err != nil {
+			return err
+		}
+
+		return w.ops.Unpin(hash)
+	}
+
 	return w.ops.Unpin(hash)
 }


### PR DESCRIPTION
This PR intends to fix the issues that occurs during the transfer of FT tokens between DIDs present on different nodes.

In the earlier case, the FT tokens while being created were not being added to IPFS because of the new token structure. This caused the issue on the receiver's end, when it attempted to unpin the tokenHash, which in reality never existed in the swarm network in the first place. Hence, a IPFS Add call was inserted under `(*Core).createFTs` function to address this issue,

In addition to this, a validation has been added under all the IPFS related methods (except for `Add(...)`), to check if the input is a IPFS CID (v0 or v1). If it isn't, then the input is added to IPFS. This has been done to avoid the need for looking at places where IPFS related function calls are being made, and adding an `Add` operation before it.