### PR TITLE
Update TokenInfo struct 

### DIFF
--- a/types/models/transaction_info.go
+++ b/types/models/transaction_info.go
@@ -9,7 +9,6 @@ type TransactionInfo struct {
 	CommittedTokens []*TokenInfo            `json:"committedTokens"`
 	Quorums         map[string][]*TokenInfo `json:"quorums"`
 	Memo            string                 `json:"memo"`
-	Data            string                 `json:"data"`
 }
 
 type TransactionTokens struct {
@@ -22,6 +21,7 @@ type TransactionTokens struct {
 type TokenInfo struct {
 	TokenID               string `json:"tokenId"`
 	PreviousTransactionID string `json:"previousTransactionID"`
+	Data string `json:"data"`
 }
 
 type QuorumSignature struct {


### PR DESCRIPTION
Update TokenInfo struct to include data field, so that multiple execution of NFTs and SCs is possible. So the corresponding data field in TransactionInfo struct has been removed