### PR TITLE
information to previous quorums for unpledging happens via `rubix_txns` pubsub topic

### DIFF
--- a/core/callback.go
+++ b/core/callback.go
@@ -1,0 +1,51 @@
+package core
+
+import "github.com/rubixchain/rubixgoplatform/types/models"
+
+// Quorums listening on "rubix_txns" event will check the `Tokens` attribute
+// of incoming `TransactionInfo` (recieved via main Callback function of "rubix_txns")
+// and will go through all Tokens. Quorum check if the TokenStateHash is present
+// in their DB or not (for which they have pledged). If they have, then they can
+// remove all the records from the TokenStateHash table
+func (c *Core) CallBackQuorumUnpledge(tx models.TransactionInfo) error {
+	// Step 1: Loop through all the tokens and gather transactionID and
+	// pledge Token ID map
+	var prevTransactionsSet map[string]struct{} = make(map[string]struct{})
+
+	addToSet := func(id string) {
+		if id != "" {
+			prevTransactionsSet[id] = struct{}{}
+		}
+	}
+
+	for _, rbtToken := range tx.Tokens.RBT {
+		addToSet(rbtToken.PreviousTransactionID)
+	}
+
+	for _, ftToken := range tx.Tokens.FT {
+		addToSet(ftToken.PreviousTransactionID)
+	}
+
+	for _, nftToken := range tx.Tokens.NFT {
+		addToSet(nftToken.PreviousTransactionID)
+	}
+
+	for _, smartContractToken := range tx.Tokens.SmartContract {
+		addToSet(smartContractToken.PreviousTransactionID)
+	}
+
+	if len(prevTransactionsSet) == 0 {
+		return nil
+	}
+
+	var prevTransactionList []string = make([]string, 0, len(prevTransactionsSet))
+	for prevTransaction := range prevTransactionsSet {
+		prevTransactionList = append(prevTransactionList, prevTransaction)
+	}
+
+	if err := c.w.RemoveTokenStateHashes(prevTransactionList); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/core/fullnode.go
+++ b/core/fullnode.go
@@ -30,19 +30,40 @@ func (c *Core) SubscribeTxnSetup() {
 
 // Enhanced callback with dynamic scaling integration
 func (c *Core) TxnCallBack(peerID string, topic string, data []byte) {
-	var newEvent model.PubSubTxnInfo
+	var newEvent models.EventTransaction
 	err := json.Unmarshal(data, &newEvent)
 	if err != nil {
 		c.log.Error("Failed to parse published event", "error", err, "data", string(data))
 		return
 	}
 
+	// Ignore failed transaction IDs
+	// Valid condition for both full node and Quorum nodes
+	if !newEvent.Status {
+		return
+	}
+
+	var txInfo models.TransactionInfo
+	if err := json.Unmarshal(newEvent.Transaction.Info, &txInfo); err != nil {
+		c.log.Error(fmt.Sprintf("failed to unmarshal transaction info, err: %v", err))
+		return
+	}
+
+	// If the current node is setup as quorum, we check the records in token_state_hashes
+	// table to see if any previous transaction id from TransactionInfo is present in the
+	// current node's table. If so, then its removed 
+	if len(c.qc) > 0 {
+		if err := c.CallBackQuorumUnpledge(txInfo); err != nil {
+			c.log.Error(fmt.Sprintf("failed to check token state hashes records, err: %v", err))
+		}
+	}
+
 	// add publisher to peer did table
-	publisherDetails := &models.DID{
-		DID:    newEvent.PublisherDID,
+	publisherDetails := models.DID{
+		DID:    txInfo.Initiator,
 		PeerID: peerID,
 	}
-	err = c.AddPeerDetails(*publisherDetails)
+	err = c.AddPeerDetails(publisherDetails)
 	if err != nil {
 		c.log.Error("failed to add publisher info to DB")
 	}

--- a/core/fullnode_txn_processor.go
+++ b/core/fullnode_txn_processor.go
@@ -8,11 +8,12 @@ import (
 	"time"
 
 	"github.com/rubixchain/rubixgoplatform/core/model"
+	"github.com/rubixchain/rubixgoplatform/types/models"
 )
 
 // DynamicTxnProcessor handles adaptive concurrent transaction processing
 type DynamicTxnProcessor struct {
-	txnQueue      chan *model.PubSubTxnInfo
+	txnQueue      chan *models.EventTransaction
 	processedTxns sync.Map
 	ctx           context.Context
 	cancel        context.CancelFunc

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -19,9 +19,10 @@ import (
 	wallet "github.com/rubixchain/rubixgoplatform/core/wallet"
 	"github.com/rubixchain/rubixgoplatform/did"
 	tkn "github.com/rubixchain/rubixgoplatform/token"
-	"github.com/rubixchain/rubixgoplatform/types/models"
 	"github.com/rubixchain/rubixgoplatform/types"
+	"github.com/rubixchain/rubixgoplatform/types/models"
 	"github.com/rubixchain/rubixgoplatform/util"
+	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
 )
 
 const (
@@ -223,7 +224,6 @@ func (c *Core) QuroumSetup() {
 	c.l.AddRoute(APICreditStatus, "GET", c.creditStatus)
 	c.l.AddRoute(APIQuorumConsensus, "POST", c.quorumConensus)
 	c.l.AddRoute(APIQuorumCredit, "POST", c.quorumCredit)
-	c.l.AddRoute(APIReqPledgeToken, "POST", c.reqPledgeToken)
 	c.l.AddRoute(APIUpdatePledgeToken, "POST", c.updatePledgeToken)
 	c.l.AddRoute(APISignatureRequest, "POST", c.signatureRequest)
 	c.l.AddRoute(APISendReceiverToken, "POST", c.updateReceiverTokenHandle)
@@ -319,6 +319,9 @@ func (c *Core) SetupQuorum(didStr string, pwd string, pvtKeyPwd string) error {
 		return fmt.Errorf("failed to setup quorum")
 	}
 	c.pqc[didStr] = dc
+
+	// Subscribe to "rubix_txns" event
+	c.SubscribeTxnSetup()
 
 	return nil
 }

--- a/core/wallet/token_state_hash.go
+++ b/core/wallet/token_state_hash.go
@@ -1,0 +1,72 @@
+package wallet
+
+import (
+	"fmt"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/rubixchain/rubixgoplatform/types/models"
+)
+
+func (w *Wallet) RemoveTokenStateHashes(transactionIds []string) error {
+	if len(transactionIds) == 0 {
+		return nil
+	}
+	
+	if _, err := w.db.Pool().Exec(w.Ctx,
+		`DELETE FROM token_state_hashes WHERE transaction_id=ANY($1)`,
+		transactionIds,
+	); err != nil {
+		return fmt.Errorf("RemoveTokenStateHashes: failed to delete records from token_state_hashes table, err: %v", err)
+	}
+
+	return nil
+}
+
+func (w *Wallet) GetTokenStateHashes(transactionId string) ([]models.TokenStateHash, error) {
+	rows, err := w.db.Pool().Query(w.Ctx,
+		`SELECT did, token_state_hash, pledged_token, transaction_id FROM token_state_hashes
+		`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	tokenStateHashes, err := pgx.CollectRows(rows, pgx.RowToStructByName[models.TokenStateHash])
+	if err != nil {
+		return nil, fmt.Errorf("GetTokenStateHashes: failed to collect rows, err: %v", err)
+	}
+
+	return tokenStateHashes, nil
+}
+
+func (w *Wallet) AddTokenStateHashes(hashes []models.TokenStateHash) error {
+    if len(hashes) == 0 {
+        return nil
+    }
+
+    batch := &pgx.Batch{}
+
+    for _, h := range hashes {
+        batch.Queue(
+            `INSERT INTO token_state_hashes 
+            (did, token_state_hash, pledged_token, transaction_id)
+            VALUES ($1, $2, $3, $4)`,
+            h.DID,
+            h.TokenStateHash,
+            h.PledgedToken,
+            h.TransactionID,
+        )
+    }
+
+    br := w.db.Pool().SendBatch(w.Ctx, batch)
+    defer br.Close()
+
+    for range hashes {
+        if _, err := br.Exec(); err != nil {
+            return fmt.Errorf("AddTokenStateHashes: insert failed: %w", err)
+        }
+    }
+
+    return nil
+}


### PR DESCRIPTION
- Added `token_state_hashes` table functions
- Upon running `setupquorum`, subscription of `rubix_txns` topic occurs
- Quorums will listen on `rubix_txns` and check if the `previousTransactionID`s present in the incoming `EvenTransaction` is present in their local DB. If so, they can proceed to remove them. 