### PR TITLE
move transaction-chain sync flow to sync package 

### DIFF
--- a/core/api/setup_api.go
+++ b/core/api/setup_api.go
@@ -1,0 +1,15 @@
+package api
+
+import (
+	"github.com/rubixchain/rubixgoplatform/core/ipfsport"
+	rubixsync "github.com/rubixchain/rubixgoplatform/core/sync"
+	"github.com/rubixchain/rubixgoplatform/core/wallet"
+	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
+	"github.com/rubixchain/rubixgoplatform/wrapper/logger"
+)
+
+func SetupAPI(listener *ipfsport.Listener, w *wallet.Wallet, log logger.Logger) {
+	listener.AddRoute(rubixsync.APISyncTransactionChain, "POST", func(req *ensweb.Request) *ensweb.Result {
+		return rubixsync.SyncTransactionChain(req, listener, w, log)
+	})
+}

--- a/core/consensus/checks.go
+++ b/core/consensus/checks.go
@@ -110,7 +110,7 @@ func SignatureVerificationCheck(
 	return nil
 }
 
-func ValidateTokenOwnershipByPrevTxn(txnInfo *models.TransactionInfo, w *wallet.Wallet) error {
+func ValidateTokenOwnershipByPrevTxn(txnInfo *models.TransactionInfo, isFullnode bool, w *wallet.Wallet) error {
 	if txnInfo.Tokens == nil {
 		return nil
 	}
@@ -153,6 +153,22 @@ func ValidateTokenOwnershipByPrevTxn(txnInfo *models.TransactionInfo, w *wallet.
 				"ownership mismatch: initiator %s does not match owner %s of previous transaction %s (affected tokens: %v)",
 				txnInfo.Initiator, prevTxnInfo.Owner, prevTxnID, tokenIDs,
 			)
+		}
+	}
+
+	//if isFullnode, Fullnode checks that owner of the previous transaction is same as the quorum which has pledged this token
+	if isFullnode {
+		for _, quorum := range txnInfo.Quorums {
+			for _, t := range quorum.Tokens {
+				tokenDetails, err := w.GetFullNodeRBTToken(t.TokenID)
+				if err != nil {
+					return fmt.Errorf("failed to get fullnode RBT token %s: %w", t.TokenID, err)
+				} //TODO: Handle the case where there is no RBT token in the fullnode rbt tokens table
+				previousTransactionOwner := tokenDetails.DID
+				if previousTransactionOwner != quorum.Did {
+					return fmt.Errorf("ownership mismatch: quorum %s does not match owner %s of previous transaction %s (affected tokens: %v)", quorum.Did, tokenDetails.DID, t.TokenID)
+				}
+			}
 		}
 	}
 
@@ -358,12 +374,17 @@ func ValidateTokenIDRelatedChecks(tokenID string, isFullNode bool, w *wallet.Wal
 	if err != nil {
 		return fmt.Errorf("failed to validate token content: %w", err)
 	}
-	err, isParentBurnt := IsParentTokenBurnt(isFullNode, tokenID, w)
-	if err != nil {
-		return fmt.Errorf("failed to validate parent token burnt: %w", err)
-	}
-	if !isParentBurnt {
-		return fmt.Errorf("parent token is not burnt")
+	//call IsParentTokenBurnt
+	//First check whether the token is a part token or not. If it is a part token, then check whether the parent token is burnt.
+	devidedParts := strings.Split(tokenID, "_")
+	if len(devidedParts) == 3 {
+		err, isParentTokenBurnt := IsParentTokenBurnt(isFullNode, tokenID, w)
+		if err != nil {
+			return fmt.Errorf("failed to validate parent token burnt: %w", err)
+		}
+		if !isParentTokenBurnt {
+			return fmt.Errorf("parent token is not burnt")
+		}
 	}
 	err = ValidateGenuineTokenCreator(tokenID, isFullNode, w)
 	if err != nil {
@@ -403,7 +424,7 @@ func FindTokenRoleInTxn(tokenID string, txInfo *models.TransactionInfo) int16 {
 	return int16(models.GetTokenRoleID(constants.TokenRole_Transfer))
 }
 
-func SyncTransactionChainFrom(p *ipfsport.Peer, previousTransactionID string, tokenID string, w *wallet.Wallet, log logger.Logger) (error, *models.TransactionChainSyncReply) {
+func SyncTransactionChainFrom(p *ipfsport.Peer, tokenID string, w *wallet.Wallet, log logger.Logger) (error, *models.TransactionChainSyncReply) {
 	var err error
 
 	latestTransactionID := w.GetLatestTransactionID(tokenID)
@@ -411,13 +432,10 @@ func SyncTransactionChainFrom(p *ipfsport.Peer, previousTransactionID string, to
 		log.Error("failed to get latest transaction id")
 		return err, nil
 	}
-	if latestTransactionID == previousTransactionID {
-		return nil, nil
-	}
 
 	syncReq := models.TransactionChainSyncRequest{
 		TokenID:       tokenID,
-		TransactionID: previousTransactionID,
+		TransactionID: latestTransactionID,
 	}
 
 	for {
@@ -502,7 +520,7 @@ func SyncTransactionChainFrom(p *ipfsport.Peer, previousTransactionID string, to
 
 // TokenChainIntigrityCheck verifies each token's chain integrity.
 // peer is the pre-resolved peer for the initiator (caller obtains via getPeer).
-func TokenChainIntigrityCheck(txnInfo *models.TransactionInfo, peer *ipfsport.Peer, w *wallet.Wallet, log logger.Logger) (error, bool) {
+func TokenChainIntigrityCheck(txnInfo *models.TransactionInfo, peer *ipfsport.Peer, isFullnode bool, w *wallet.Wallet, log logger.Logger) (error, bool) {
 	if txnInfo.Tokens == nil {
 		return nil, false
 	}
@@ -519,7 +537,7 @@ func TokenChainIntigrityCheck(txnInfo *models.TransactionInfo, peer *ipfsport.Pe
 			tokenDetails, err := w.GetTokenByTokenID(t.TokenID)
 			if err != nil {
 				log.Debug("token not found locally, syncing full chain", "tokenID", t.TokenID)
-				if syncErr, _ := SyncTransactionChainFrom(peer, t.PreviousTransactionID, t.TokenID, w, log); syncErr != nil {
+				if syncErr, _ := SyncTransactionChainFrom(peer, t.TokenID, w, log); syncErr != nil {
 					return fmt.Errorf("failed to sync token chain for %s: %w", t.TokenID, syncErr), false
 				}
 				continue
@@ -539,9 +557,10 @@ func TokenChainIntigrityCheck(txnInfo *models.TransactionInfo, peer *ipfsport.Pe
 			if err != nil {
 				return fmt.Errorf("failed to get previous transaction for token %s: %w", t.TokenID, err), false
 			}
-			if previousTransaction == nil {
-				return fmt.Errorf("previous transaction not found for token %s", t.TokenID), false
+			if tokenDetails.TransactionID != t.PreviousTransactionID {
+				return fmt.Errorf("transaction ID mismatch for token %s: %s != %s", t.TokenID, tokenDetails.TransactionID, t.PreviousTransactionID), false
 			}
+
 			var previousTransactionInfo models.TransactionInfo
 			if err := json.Unmarshal(previousTransaction.Info, &previousTransactionInfo); err != nil {
 				return fmt.Errorf("failed to unmarshal previous transaction info for token %s: %w", t.TokenID, err), false
@@ -551,6 +570,31 @@ func TokenChainIntigrityCheck(txnInfo *models.TransactionInfo, peer *ipfsport.Pe
 				role == int16(models.GetTokenRoleID(constants.TokenRole_Burn)) ||
 				role == int16(models.GetTokenRoleID(constants.TokenRole_Commit)) {
 				return nil, false
+			}
+		}
+
+		//add the same check for pledged tokens also, For pledge tokens fullnode will sync it from the quorum
+		if isFullnode {
+			for _, quorum := range txnInfo.Quorums {
+				for _, t := range quorum.Tokens {
+					tokenDetails, err := w.GetFullNodeRBTToken(t.TokenID)
+					if err != nil {
+						log.Debug("token not found locally, syncing full chain", "tokenID", t.TokenID)
+
+						if syncErr, _ := SyncTransactionChainFrom(peer, t.TokenID, w, log); syncErr != nil {
+							return fmt.Errorf("failed to sync token chain for %s: %w", t.TokenID, syncErr), false
+						}
+
+					}
+					tokenDetails, err = w.GetFullNodeRBTToken(t.TokenID)
+					if err != nil {
+						return fmt.Errorf("failed to get token details for %s: %w", t.TokenID, err), false
+					}
+					if tokenDetails.TransactionID != t.PreviousTransactionID {
+						return fmt.Errorf("transaction ID mismatch for token %s: %s != %s", t.TokenID, tokenDetails.TransactionID, t.PreviousTransactionID), false
+					}
+
+				}
 			}
 		}
 	}
@@ -644,25 +688,21 @@ func ValidateTransaction(
 		return false, fmt.Errorf("ValidateTransaction: %w", err)
 	}
 
-	if err := ValidateTokenOwnershipByPrevTxn(&txnInfo, w); err != nil {
+	if err := ValidateTokenOwnershipByPrevTxn(&txnInfo, isFullnode, w); err != nil {
 		return false, fmt.Errorf("ValidateTransaction: %w", err)
 	}
 
-	if syncErr, ok := TokenChainIntigrityCheck(&txnInfo, peer, w, log); syncErr != nil {
+	if syncErr, ok := TokenChainIntigrityCheck(&txnInfo, peer, isFullnode, w, log); syncErr != nil {
 		return false, fmt.Errorf("ValidateTransaction: %w", syncErr)
 	} else if !ok {
 		return false, fmt.Errorf("ValidateTransaction: token chain sync failed")
 	}
+	// 7. ValidateTokenIDRelatedChecks for each RBT token in Tokens and CommittedTokens and pledged tokens
+	if txnInfo.Tokens.RBT != nil {
+		for _, token := range txnInfo.Tokens.RBT {
+			if err := ValidateTokenIDRelatedChecks(token.TokenID, isFullnode, w, testnet, mainnet, localnet, log); err != nil {
+				return false, fmt.Errorf("ValidateTransaction: token %s: %w", token.TokenID, err)
 
-	if txnInfo.Tokens != nil {
-		for _, tokenList := range [][]*models.TokenInfo{
-			txnInfo.Tokens.RBT, txnInfo.Tokens.FT,
-			txnInfo.Tokens.NFT, txnInfo.Tokens.SmartContract,
-		} {
-			for _, t := range tokenList {
-				if err := ValidateTokenIDRelatedChecks(t.TokenID, isFullnode, w, testnet, mainnet, localnet, log); err != nil {
-					return false, fmt.Errorf("ValidateTransaction: token %s: %w", t.TokenID, err)
-				}
 			}
 		}
 	}
@@ -673,12 +713,13 @@ func ValidateTransaction(
 		}
 	}
 
-	if isFullnode {
-		for _, quorum := range txnInfo.Quorums {
-			for _, t := range quorum.Tokens {
-				if err := ValidateTokenIDRelatedChecks(t.TokenID, isFullnode, w, testnet, mainnet, localnet, log); err != nil {
-					return false, fmt.Errorf("ValidateTransaction: quorum %s token %s: %w", quorum.Did, t.TokenID, err)
-				}
+	//Both Fullnode as well as quorum will do the ValidateTokenIDRelatedChecks checks for pledged tokens
+
+	for _, quorum := range txnInfo.Quorums {
+		for _, t := range quorum.Tokens {
+			if err := ValidateTokenIDRelatedChecks(t.TokenID, isFullnode, w, testnet, mainnet, localnet, log); err != nil {
+				return false, fmt.Errorf("ValidateTransaction: quorum %s token %s: %w", quorum.Did, t.TokenID, err)
+
 			}
 		}
 	}

--- a/core/consensus/checks.go
+++ b/core/consensus/checks.go
@@ -11,6 +11,7 @@ import (
 	"github.com/rubixchain/rubixgoplatform/constants"
 	"github.com/rubixchain/rubixgoplatform/core/ipfsport"
 	"github.com/rubixchain/rubixgoplatform/core/parts"
+	rubixsync "github.com/rubixchain/rubixgoplatform/core/sync"
 	"github.com/rubixchain/rubixgoplatform/core/wallet"
 	rubixmath "github.com/rubixchain/rubixgoplatform/math"
 	"github.com/rubixchain/rubixgoplatform/token"
@@ -23,8 +24,6 @@ import (
 const (
 	RBTString  string = "rbt"
 	PartString string = "part"
-
-	APISyncTransactionChain string = "/api/sync-transaction-chain"
 )
 
 var validNetworks = map[string]struct{}{
@@ -424,99 +423,99 @@ func FindTokenRoleInTxn(tokenID string, txInfo *models.TransactionInfo) int16 {
 	return int16(models.GetTokenRoleID(constants.TokenRole_Transfer))
 }
 
-func SyncTransactionChainFrom(p *ipfsport.Peer, tokenID string, w *wallet.Wallet, log logger.Logger) (error, *models.TransactionChainSyncReply) {
-	var err error
+// func SyncTransactionChainFrom(p *ipfsport.Peer, tokenID string, w *wallet.Wallet, log logger.Logger) (error, *models.TransactionChainSyncReply) {
+// 	var err error
 
-	latestTransactionID := w.GetLatestTransactionID(tokenID)
-	if latestTransactionID == "" {
-		log.Error("failed to get latest transaction id")
-		return err, nil
-	}
+// 	latestTransactionID := w.GetLatestTransactionID(tokenID)
+// 	if latestTransactionID == "" {
+// 		log.Error("failed to get latest transaction id")
+// 		return err, nil
+// 	}
 
-	syncReq := models.TransactionChainSyncRequest{
-		TokenID:       tokenID,
-		TransactionID: latestTransactionID,
-	}
+// 	syncReq := models.TransactionChainSyncRequest{
+// 		TokenID:       tokenID,
+// 		TransactionID: latestTransactionID,
+// 	}
 
-	for {
-		var trep models.TransactionChainSyncReply
-		err = p.SendJSONRequest("POST", APISyncTransactionChain, nil, &syncReq, &trep, false)
-		if err != nil {
-			log.Error("failed to sync transaction chain")
-			return err, nil
-		}
-		if !trep.Status {
-			log.Error("failed to sync transaction chain")
-			return fmt.Errorf(trep.Message), nil
-		}
-		if len(trep.Transactions) > 0 {
-			for _, txn := range trep.Transactions {
-				tx, err := util.TransactionFromBytes(txn)
-				if tx == nil {
-					log.Error("failed to convert transaction bytes to transaction")
-					return fmt.Errorf("failed to convert transaction bytes to transaction"), nil
-				}
-				var txInfo models.TransactionInfo
-				if err = json.Unmarshal(tx.Info, &txInfo); err != nil {
-					log.Error("failed to unmarshal transaction info", "err", err)
-					return fmt.Errorf("failed to unmarshal transaction info: %w", err), nil
-				}
+// 	for {
+// 		var trep models.TransactionChainSyncReply
+// 		err = p.SendJSONRequest("POST", APISyncTransactionChain, nil, &syncReq, &trep, false)
+// 		if err != nil {
+// 			log.Error("failed to sync transaction chain")
+// 			return err, nil
+// 		}
+// 		if !trep.Status {
+// 			log.Error("failed to sync transaction chain")
+// 			return fmt.Errorf(trep.Message), nil
+// 		}
+// 		if len(trep.Transactions) > 0 {
+// 			for _, txn := range trep.Transactions {
+// 				tx, err := util.TransactionFromBytes(txn)
+// 				if tx == nil {
+// 					log.Error("failed to convert transaction bytes to transaction")
+// 					return fmt.Errorf("failed to convert transaction bytes to transaction"), nil
+// 				}
+// 				var txInfo models.TransactionInfo
+// 				if err = json.Unmarshal(tx.Info, &txInfo); err != nil {
+// 					log.Error("failed to unmarshal transaction info", "err", err)
+// 					return fmt.Errorf("failed to unmarshal transaction info: %w", err), nil
+// 				}
 
-				role := FindTokenRoleInTxn(tokenID, &txInfo)
+// 				role := FindTokenRoleInTxn(tokenID, &txInfo)
 
-				if err = w.CreateTransaction(tx); err != nil {
-					log.Error("failed to add transaction to transactions table", "err", err)
-					return fmt.Errorf("failed to add transaction: %w", err), nil
-				}
+// 				if err = w.CreateTransaction(tx); err != nil {
+// 					log.Error("failed to add transaction to transactions table", "err", err)
+// 					return fmt.Errorf("failed to add transaction: %w", err), nil
+// 				}
 
-				tokenDetails, err := w.GetTokenByTokenID(tokenID)
-				if err != nil {
-					newToken := models.Token{
-						TokenID:        tokenID,
-						TokenStatus:    constants.TokenStatus_Free,
-						DID:            txInfo.Owner,
-						TransactionID:  tx.ID,
-						TokenType:      int16(models.GetTokenTypeID(constants.TokenType_RBT)),
-						LatestPosition: 0,
-						LatestRole:     role,
-						CreatedAt:      time.Now(),
-						UpdatedAt:      time.Now(),
-					}
-					if createErr := w.CreateRBTToken(newToken); createErr != nil {
-						log.Error("failed to create token", "err", createErr)
-						return fmt.Errorf("failed to create token: %w", createErr), nil
-					}
-					tokenDetails = newToken
-				} else {
-					tokenDetails.DID = txInfo.Owner
-					tokenDetails.TransactionID = tx.ID
-					tokenDetails.LatestPosition++
-					tokenDetails.LatestRole = role
-					if updateErr := w.UpdateToken(tokenDetails); updateErr != nil {
-						log.Error("failed to update token", "err", updateErr)
-						return fmt.Errorf("failed to update token: %w", updateErr), nil
-					}
-				}
+// 				tokenDetails, err := w.GetTokenByTokenID(tokenID)
+// 				if err != nil {
+// 					newToken := models.Token{
+// 						TokenID:        tokenID,
+// 						TokenStatus:    constants.TokenStatus_Free,
+// 						DID:            txInfo.Owner,
+// 						TransactionID:  tx.ID,
+// 						TokenType:      int16(models.GetTokenTypeID(constants.TokenType_RBT)),
+// 						LatestPosition: 0,
+// 						LatestRole:     role,
+// 						CreatedAt:      time.Now(),
+// 						UpdatedAt:      time.Now(),
+// 					}
+// 					if createErr := w.CreateRBTToken(newToken); createErr != nil {
+// 						log.Error("failed to create token", "err", createErr)
+// 						return fmt.Errorf("failed to create token: %w", createErr), nil
+// 					}
+// 					tokenDetails = newToken
+// 				} else {
+// 					tokenDetails.DID = txInfo.Owner
+// 					tokenDetails.TransactionID = tx.ID
+// 					tokenDetails.LatestPosition++
+// 					tokenDetails.LatestRole = role
+// 					if updateErr := w.UpdateToken(tokenDetails); updateErr != nil {
+// 						log.Error("failed to update token", "err", updateErr)
+// 						return fmt.Errorf("failed to update token: %w", updateErr), nil
+// 					}
+// 				}
 
-				entry := &models.TokenChain{
-					TokenID:       tokenID,
-					TransactionID: tx.ID,
-					Role:          role,
-					Position:      tokenDetails.LatestPosition,
-				}
-				if err = w.AddTokenChainEntry(entry); err != nil {
-					log.Error("failed to add token chain entry", "err", err)
-					return fmt.Errorf("failed to add token chain entry: %w", err), nil
-				}
-			}
-		}
-		if trep.NextTransactionID == "" {
-			break
-		}
-		syncReq.TransactionID = trep.NextTransactionID
-	}
-	return nil, nil
-}
+// 				entry := &models.TokenChain{
+// 					TokenID:       tokenID,
+// 					TransactionID: tx.ID,
+// 					Role:          role,
+// 					Position:      tokenDetails.LatestPosition,
+// 				}
+// 				if err = w.AddTokenChainEntry(entry); err != nil {
+// 					log.Error("failed to add token chain entry", "err", err)
+// 					return fmt.Errorf("failed to add token chain entry: %w", err), nil
+// 				}
+// 			}
+// 		}
+// 		if trep.NextTransactionID == "" {
+// 			break
+// 		}
+// 		syncReq.TransactionID = trep.NextTransactionID
+// 	}
+// 	return nil, nil
+// }
 
 // TokenChainIntigrityCheck verifies each token's chain integrity.
 // peer is the pre-resolved peer for the initiator (caller obtains via getPeer).
@@ -537,7 +536,7 @@ func TokenChainIntigrityCheck(txnInfo *models.TransactionInfo, peer *ipfsport.Pe
 			tokenDetails, err := w.GetTokenByTokenID(t.TokenID)
 			if err != nil {
 				log.Debug("token not found locally, syncing full chain", "tokenID", t.TokenID)
-				if syncErr, _ := SyncTransactionChainFrom(peer, t.TokenID, w, log); syncErr != nil {
+				if syncErr, _ := rubixsync.SyncTransactionChainFrom(peer, t.TokenID, w, log); syncErr != nil {
 					return fmt.Errorf("failed to sync token chain for %s: %w", t.TokenID, syncErr), false
 				}
 				continue
@@ -565,7 +564,7 @@ func TokenChainIntigrityCheck(txnInfo *models.TransactionInfo, peer *ipfsport.Pe
 			if err := json.Unmarshal(previousTransaction.Info, &previousTransactionInfo); err != nil {
 				return fmt.Errorf("failed to unmarshal previous transaction info for token %s: %w", t.TokenID, err), false
 			}
-			role := FindTokenRoleInTxn(t.TokenID, &previousTransactionInfo)
+			role := rubixsync.FindTokenRoleInTxn(t.TokenID, &previousTransactionInfo)
 			if role == int16(models.GetTokenRoleID(constants.TokenRole_Pledge)) ||
 				role == int16(models.GetTokenRoleID(constants.TokenRole_Burn)) ||
 				role == int16(models.GetTokenRoleID(constants.TokenRole_Commit)) {
@@ -581,7 +580,7 @@ func TokenChainIntigrityCheck(txnInfo *models.TransactionInfo, peer *ipfsport.Pe
 					if err != nil {
 						log.Debug("token not found locally, syncing full chain", "tokenID", t.TokenID)
 
-						if syncErr, _ := SyncTransactionChainFrom(peer, t.TokenID, w, log); syncErr != nil {
+						if syncErr, _ := rubixsync.SyncTransactionChainFrom(peer, t.TokenID, w, log); syncErr != nil {
 							return fmt.Errorf("failed to sync token chain for %s: %w", t.TokenID, syncErr), false
 						}
 

--- a/core/core.go
+++ b/core/core.go
@@ -14,6 +14,7 @@ import (
 
 	ipfsnode "github.com/ipfs/go-ipfs-api"
 	"github.com/rubixchain/rubixgoplatform/constants"
+	"github.com/rubixchain/rubixgoplatform/core/api"
 	"github.com/rubixchain/rubixgoplatform/core/ipfsport"
 	"github.com/rubixchain/rubixgoplatform/core/storage"
 	"github.com/rubixchain/rubixgoplatform/core/wallet"
@@ -311,6 +312,8 @@ func (c *Core) SetupCore() error {
 	c.SetupToken()
 	c.QuroumSetup()
 	c.PinService()
+	api.SetupAPI(c.l, c.w, c.log)
+
 	// c.RestartIncompleteTokenChainSyncs()
 	//c.UnlockFTs()
 	// c.selfTransferService()

--- a/core/sync/transaction_chain.go
+++ b/core/sync/transaction_chain.go
@@ -1,0 +1,173 @@
+package sync
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/rubixchain/rubixgoplatform/constants"
+	"github.com/rubixchain/rubixgoplatform/core/ipfsport"
+	"github.com/rubixchain/rubixgoplatform/core/wallet"
+	"github.com/rubixchain/rubixgoplatform/types/models"
+	"github.com/rubixchain/rubixgoplatform/util"
+	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
+	"github.com/rubixchain/rubixgoplatform/wrapper/logger"
+)
+
+const APISyncTransactionChain = "/api/sync-transaction-chain"
+
+// GetTransactionsForChainSync returns serialized transactions and the next transaction ID
+// for the given token starting from fromTransactionID. It wraps wallet.Wallet.GetTransactions
+// for use by transaction-chain sync flows.
+func GetTransactionsForChainSync(w *wallet.Wallet, tokenID, fromTransactionID string) ([][]byte, string, error) {
+	return w.GetTransactions(tokenID, fromTransactionID)
+}
+
+// SyncTransactionChain handles a sync request for a token's transaction chain.
+func SyncTransactionChain(req *ensweb.Request, l *ipfsport.Listener, w *wallet.Wallet, log logger.Logger) *ensweb.Result {
+	var syncRequest models.TransactionChainSyncRequest
+	var syncReply models.TransactionChainSyncReply
+	err := l.ParseJSON(req, &syncRequest)
+	if err != nil {
+		log.Error("failed to parse transaction chain sync request")
+		return l.RenderJSON(req, &models.TransactionChainSyncReply{Status: false, Message: "Failed to parse sync request"}, http.StatusOK)
+	}
+	transactions, nextTransactionID, err := GetTransactionsForChainSync(w, syncRequest.TokenID, syncRequest.TransactionID)
+	if err != nil {
+		log.Error("failed to get transactions")
+		return l.RenderJSON(req, &models.TransactionChainSyncReply{Status: false, Message: "Failed to get transactions"}, http.StatusOK)
+	}
+	syncReply.Transactions = transactions
+	syncReply.NextTransactionID = nextTransactionID
+	syncReply.Status = true
+	syncReply.Message = "Successfully got transactions"
+	return l.RenderJSON(req, &syncReply, http.StatusOK)
+}
+
+// FindTokenRoleInTxn determines the role a token played in a given transaction.
+func FindTokenRoleInTxn(tokenID string, txInfo *models.TransactionInfo) int16 {
+	if txInfo.Tokens != nil {
+		for _, lists := range [][]*models.TokenInfo{
+			txInfo.Tokens.RBT, txInfo.Tokens.NFT,
+			txInfo.Tokens.FT, txInfo.Tokens.SmartContract,
+		} {
+			for _, t := range lists {
+				if t.TokenID == tokenID {
+					return int16(models.GetTokenRoleID(constants.TokenRole_Transfer))
+				}
+			}
+		}
+	}
+
+	for _, t := range txInfo.CommittedTokens {
+		if t.TokenID == tokenID {
+			return int16(models.GetTokenRoleID(constants.TokenRole_Commit))
+		}
+	}
+
+	for _, q := range txInfo.Quorums {
+		for _, t := range q.Tokens {
+			if t.TokenID == tokenID {
+				return int16(models.GetTokenRoleID(constants.TokenRole_Pledge))
+			}
+		}
+	}
+
+	return int16(models.GetTokenRoleID(constants.TokenRole_Transfer))
+}
+
+// SyncTransactionChainFrom fetches missing transactions from a peer and writes them locally.
+func SyncTransactionChainFrom(p *ipfsport.Peer, tokenID string, w *wallet.Wallet, log logger.Logger) (error, *models.TransactionChainSyncReply) {
+	var err error
+
+	latestTransactionID := w.GetLatestTransactionID(tokenID)
+	if latestTransactionID == "" {
+		log.Error("failed to get latest transaction id")
+		return err, nil
+	}
+
+	syncReq := models.TransactionChainSyncRequest{
+		TokenID:       tokenID,
+		TransactionID: latestTransactionID,
+	}
+
+	for {
+		var trep models.TransactionChainSyncReply
+		err = p.SendJSONRequest("POST", APISyncTransactionChain, nil, &syncReq, &trep, false)
+		if err != nil {
+			log.Error("failed to sync transaction chain")
+			return err, nil
+		}
+		if !trep.Status {
+			log.Error("failed to sync transaction chain")
+			return fmt.Errorf(trep.Message), nil
+		}
+		if len(trep.Transactions) > 0 {
+			for _, txn := range trep.Transactions {
+				tx, err := util.TransactionFromBytes(txn)
+				if tx == nil {
+					log.Error("failed to convert transaction bytes to transaction")
+					return fmt.Errorf("failed to convert transaction bytes to transaction"), nil
+				}
+				var txInfo models.TransactionInfo
+				if err = json.Unmarshal(tx.Info, &txInfo); err != nil {
+					log.Error("failed to unmarshal transaction info", "err", err)
+					return fmt.Errorf("failed to unmarshal transaction info: %w", err), nil
+				}
+
+				role := FindTokenRoleInTxn(tokenID, &txInfo)
+
+				if err = w.CreateTransaction(tx); err != nil {
+					log.Error("failed to add transaction to transactions table", "err", err)
+					return fmt.Errorf("failed to add transaction: %w", err), nil
+				}
+
+				tokenDetails, err := w.GetTokenByTokenID(tokenID)
+				if err != nil {
+					newToken := models.Token{
+						TokenID:        tokenID,
+						TokenStatus:    constants.TokenStatus_Free,
+						DID:            txInfo.Owner,
+						TransactionID:  tx.ID,
+						TokenType:      int16(models.GetTokenTypeID(constants.TokenType_RBT)),
+						LatestPosition: 0,
+						LatestRole:     role,
+						CreatedAt:      time.Now(),
+						UpdatedAt:      time.Now(),
+					}
+					if createErr := w.CreateRBTToken(newToken); createErr != nil {
+						log.Error("failed to create token", "err", createErr)
+						return fmt.Errorf("failed to create token: %w", createErr), nil
+					}
+					tokenDetails = newToken
+				} else {
+					tokenDetails.DID = txInfo.Owner
+					tokenDetails.TransactionID = tx.ID
+					tokenDetails.LatestPosition++
+					tokenDetails.LatestRole = role
+					if updateErr := w.UpdateToken(tokenDetails); updateErr != nil {
+						log.Error("failed to update token", "err", updateErr)
+						return fmt.Errorf("failed to update token: %w", updateErr), nil
+					}
+				}
+
+				entry := &models.TokenChain{
+					TokenID:       tokenID,
+					TransactionID: tx.ID,
+					Role:          role,
+					Position:      tokenDetails.LatestPosition,
+				}
+				if err = w.AddTokenChainEntry(entry); err != nil {
+					log.Error("failed to add token chain entry", "err", err)
+					return fmt.Errorf("failed to add token chain entry: %w", err), nil
+				}
+			}
+		}
+		if trep.NextTransactionID == "" {
+			break
+		}
+		syncReq.TransactionID = trep.NextTransactionID
+	}
+	return nil, nil
+}

--- a/core/token.go
+++ b/core/token.go
@@ -91,7 +91,7 @@ type PubSubEnvelope struct {
 
 func (c *Core) SetupToken() {
 	c.l.AddRoute(APISyncTokenChain, "POST", c.syncTokenChain)
-	c.l.AddRoute(APISyncTransactionChain, "POST", c.syncTransactionChain)
+	// c.l.AddRoute(APISyncTransactionChain, "POST", c.syncTransactionChain)
 	c.l.AddRoute(APISyncGenesisAndLatestBlock, "POST", c.syncGenesisAndLatestBlock)
 	c.l.AddRoute(APIUpdateStatus, "PUT", c.updateStatus)
 	c.l.AddRoute(APIGetTokenStatus, "GET", c.getTokenStatus)
@@ -2139,7 +2139,7 @@ func (c *Core) AddTokenToRespectiveTable(tokenId string, tokenOwner string, rece
 					TransactionID: event.TransactionID,
 					PublisherDID:  event.PublisherDID,
 					BlockHeight:   event.LatestBlockHeight,
-					SyncStatus:     syncStatus,
+					SyncStatus:    syncStatus,
 					TokenStatus:   tokenStatus,
 					// TokenValue:    event.TokenValue,
 				}
@@ -2632,25 +2632,106 @@ func (c *Core) relaseToken(release *bool, token string) {
 }
 
 // syncTransactionChain handles a sync request for a token's transaction chain.
-// (upstream addition — Category B)
-func (c *Core) syncTransactionChain(req *ensweb.Request) *ensweb.Result {
-	var syncRequest models.TransactionChainSyncRequest
-	var syncReply models.TransactionChainSyncReply
-	err := c.l.ParseJSON(req, &syncRequest)
-	if err != nil {
-		c.log.Error("failed to parse transaction chain sync request")
-		return c.l.RenderJSON(req, &models.TransactionChainSyncReply{Status: false, Message: "Failed to parse sync request"}, http.StatusOK)
-	}
-	//TODO: Implement GetTransactions function
-	transactions, nextTransactionID, err := c.w.GetTransactions(syncRequest.TokenID, syncRequest.TransactionID)
-	if err != nil {
-		c.log.Error("failed to get transactions")
-		return c.l.RenderJSON(req, &models.TransactionChainSyncReply{Status: false, Message: "Failed to get transactions"}, http.StatusOK)
-	}
-	syncReply.Transactions = transactions
-	syncReply.NextTransactionID = nextTransactionID
-	syncReply.Status = true
-	syncReply.Message = "Successfully got transactions"
-	return c.l.RenderJSON(req, &syncReply, http.StatusOK)
-}
+// // (upstream addition — Category B)
+// func (c *Core) syncTransactionChain(req *ensweb.Request) *ensweb.Result {
+// 	return rubixsync.SyncTransactionChain(req, c.l, c.w, c.log)
+// }
 
+// syncTransactionChainFrom fetches missing transactions from a peer and writes them locally.
+// (upstream addition — Category B)
+// func (c *Core) SyncTransactionChainFrom(p *ipfsport.Peer, token string) (error, *models.TransactionChainSyncReply) {
+// 	var err error
+
+// 	latestTransactionID := c.w.GetLatestTransactionID(token)
+// 	if latestTransactionID == "" {
+// 		c.log.Error("failed to get latest transaction id")
+// 		return err, nil
+// 	}
+// 	// if latestTransactionID == previousTransactionID {
+// 	// 	return nil, nil
+// 	// }
+
+// 	syncReq := models.TransactionChainSyncRequest{
+// 		TokenID:       token,
+// 		TransactionID: latestTransactionID,
+// 	}
+
+// 	for {
+// 		var trep models.TransactionChainSyncReply
+// 		err = p.SendJSONRequest("POST", APISyncTransactionChain, nil, &syncReq, &trep, false)
+// 		if err != nil {
+// 			c.log.Error("failed to sync transaction chain")
+// 			return err, nil
+// 		}
+// 		if !trep.Status {
+// 			c.log.Error("failed to sync transaction chain")
+// 			return fmt.Errorf(trep.Message), nil
+// 		}
+// 		if len(trep.Transactions) > 0 {
+// 			for _, txn := range trep.Transactions {
+// 				tx, err := util.TransactionFromBytes(txn)
+// 				if tx == nil {
+// 					c.log.Error("failed to convert transaction bytes to transaction")
+// 					return fmt.Errorf("failed to convert transaction bytes to transaction"), nil
+// 				}
+// 				var txInfo models.TransactionInfo
+// 				if err = json.Unmarshal(tx.Info, &txInfo); err != nil {
+// 					c.log.Error("failed to unmarshal transaction info", "err", err)
+// 					return fmt.Errorf("failed to unmarshal transaction info: %w", err), nil
+// 				}
+
+// 				role := rubixsync.FindTokenRoleInTxn(token, &txInfo)
+
+// 				if err = c.w.CreateTransaction(tx); err != nil {
+// 					c.log.Error("failed to add transaction to transactions table", "err", err)
+// 					return fmt.Errorf("failed to add transaction: %w", err), nil
+// 				}
+
+// 				tokenDetails, err := c.w.GetTokenByTokenID(token)
+// 				if err != nil {
+// 					newToken := models.Token{
+// 						TokenID:        token,
+// 						TokenStatus:    constants.TokenStatus_Free,
+// 						DID:            txInfo.Owner,
+// 						TransactionID:  tx.ID,
+// 						TokenType:      int16(models.GetTokenTypeID(constants.TokenType_RBT)),
+// 						LatestPosition: 0,
+// 						LatestRole:     role,
+// 						CreatedAt:      time.Now(),
+// 						UpdatedAt:      time.Now(),
+// 					}
+// 					if createErr := c.w.CreateRBTToken(newToken); createErr != nil {
+// 						c.log.Error("failed to create token", "err", createErr)
+// 						return fmt.Errorf("failed to create token: %w", createErr), nil
+// 					}
+// 					tokenDetails = newToken
+// 				} else {
+// 					tokenDetails.DID = txInfo.Owner
+// 					tokenDetails.TransactionID = tx.ID
+// 					tokenDetails.LatestPosition++
+// 					tokenDetails.LatestRole = role
+// 					if updateErr := c.w.UpdateToken(tokenDetails); updateErr != nil {
+// 						c.log.Error("failed to update token", "err", updateErr)
+// 						return fmt.Errorf("failed to update token: %w", updateErr), nil
+// 					}
+// 				}
+
+// 				entry := &models.TokenChain{
+// 					TokenID:       token,
+// 					TransactionID: tx.ID,
+// 					Role:          role,
+// 					Position:      tokenDetails.LatestPosition,
+// 				}
+// 				if err = c.w.AddTokenChainEntry(entry); err != nil {
+// 					c.log.Error("failed to add token chain entry", "err", err)
+// 					return fmt.Errorf("failed to add token chain entry: %w", err), nil
+// 				}
+// 			}
+// 		}
+// 		if trep.NextTransactionID == "" {
+// 			break
+// 		}
+// 		syncReq.TransactionID = trep.NextTransactionID
+// 	}
+// 	return nil, nil
+// }

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -245,7 +245,7 @@ func (c *Core) syncTransactionTokens(
 				continue
 			}
 			//Handling the response in the future.
-			err, _ := consensus.SyncTransactionChainFrom(peer, token.PreviousTransactionID, token.TokenID, c.w, c.log)
+			err, _ := consensus.SyncTransactionChainFrom(peer, token.TokenID, c.w, c.log)
 			if err != nil {
 				return err
 			}

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -5,9 +5,9 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/rubixchain/rubixgoplatform/core/consensus"
 	"github.com/rubixchain/rubixgoplatform/core/ipfsport"
 	"github.com/rubixchain/rubixgoplatform/core/model"
+	rubixsync "github.com/rubixchain/rubixgoplatform/core/sync"
 	"github.com/rubixchain/rubixgoplatform/core/wallet"
 	"github.com/rubixchain/rubixgoplatform/types/models"
 	"github.com/rubixchain/rubixgoplatform/util"
@@ -245,7 +245,7 @@ func (c *Core) syncTransactionTokens(
 				continue
 			}
 			//Handling the response in the future.
-			err, _ := consensus.SyncTransactionChainFrom(peer, token.TokenID, c.w, c.log)
+			err, _ := rubixsync.SyncTransactionChainFrom(peer, token.TokenID, c.w, c.log)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
This PR refactors transaction-chain sync responsibilities out of core/consensus into the core/sync package and updates API wiring accordingly.

**What changed**

1. moved sync-chain logic into core/sync/transaction_chain.go

   - SyncTransactionChainFrom

   - FindTokenRoleInTxn

   - GetTransactionsForChainSync (wallet wrapper)

    - SyncTransactionChain (request handler logic)

- updated core/consensus/checks.go to call sync package functions instead of local consensus implementations

- updated core/transaction.go and core/token.go to use sync package functions
