### PR TITLE
migrate ensweb jwt to golang-jwt v5

### DIFF
--- a/core/auth.go
+++ b/core/auth.go
@@ -58,7 +58,7 @@ func (c *Core) ValidateDIDToken(token string, tt string, did string) (*setup.Bea
 }
 
 func (c *Core) generateJWTToken(claims jwt.Claims) string {
-	token := jwt.NewWithClaims(jwt.GetSigningMethod("HS256"), claims)
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	tokenString, err := token.SignedString([]byte(c.secret))
 	if err != nil {
 		return ""

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,6 @@ require (
 	github.com/btcsuite/btcd v0.23.0 // indirect
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.0.1
 	github.com/denisenkom/go-mssqldb v0.12.3 // indirect
-	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/fatih/color v1.15.0
 	github.com/frankban/quicktest v1.14.0 // indirect
 	github.com/go-openapi/jsonreference v0.20.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -699,8 +699,6 @@ github.com/decred/dcrd/lru v1.0.0/go.mod h1:mxKOwFd7lFjN2GZYsiz/ecgqR6kkYAl+0pz0
 github.com/denisenkom/go-mssqldb v0.0.0-20191124224453-732737034ffd/go.mod h1:xbL0rPBG9cCiLr28tMa8zpbdarY27NDyej4t/EjAShU=
 github.com/denisenkom/go-mssqldb v0.12.3 h1:pBSGx9Tq67pBOTLmxNuirNTeB8Vjmf886Kx+8Y+8shw=
 github.com/denisenkom/go-mssqldb v0.12.3/go.mod h1:k0mtMFOnU+AihqFxPMiF05rtiDrorD1Vrm1KEz5hxDo=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible h1:7qlOGliEKZXTDg6OTjfoBKDXWrumCAMpl/TFQ4/5kLM=
-github.com/dgrijalva/jwt-go v3.2.0+incompatible/go.mod h1:E3ru+11k8xSBh+hMPgOLZmtrrCbhqsmaPHjLKYnJCaQ=
 github.com/dnaeon/go-vcr v1.1.0/go.mod h1:M7tiix8f0r6mKKJ3Yq/kqU1OYf3MnfmBWVbPx/yU9ko=
 github.com/dnaeon/go-vcr v1.2.0/go.mod h1:R4UdLID7HZT3taECzJs4YgbbH6PIGXB6W/sc5OLb6RQ=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=

--- a/grpcserver/grpc.go
+++ b/grpcserver/grpc.go
@@ -90,7 +90,7 @@ func ValidateJWTToken(tokenString string, claims jwt.Claims, secret string) (boo
 }
 
 func GenerateJWTToken(claims jwt.Claims, secret string) string {
-	token := jwt.NewWithClaims(jwt.GetSigningMethod("HS256"), claims)
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 	tokenString, err := token.SignedString([]byte(secret))
 	if err != nil {
 		return ""

--- a/wrapper/ensweb/auth.go
+++ b/wrapper/ensweb/auth.go
@@ -3,7 +3,7 @@ package ensweb
 import (
 	"net/http"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 func (s *Server) BasicAuthHandle(claims jwt.Claims, hf HandlerFunc, af AuthFunc, ef HandlerFunc) HandlerFunc {

--- a/wrapper/ensweb/entity.go
+++ b/wrapper/ensweb/entity.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/jinzhu/gorm"
 	"github.com/rubixchain/rubixgoplatform/crypto"
 	"github.com/rubixchain/rubixgoplatform/wrapper/uuid"
@@ -107,7 +107,7 @@ type BasicToken struct {
 	UserName string `json:"username"`
 	UserID   string `json:"user_id"`
 	Role     string `json:"role"`
-	jwt.StandardClaims
+	jwt.RegisteredClaims
 }
 
 type LoginRequest struct {
@@ -476,13 +476,13 @@ func (s *Server) LoginUser(tenantID interface{}, req *LoginRequest) *LoginRespon
 				role = "admin"
 			}
 		}
-		expiresAt := time.Now().Add(time.Minute * 60).Unix()
+		expiresAt := time.Now().Add(time.Minute * 60)
 		claims := BasicToken{
-			u.Name,
-			u.ID.String(),
-			role,
-			jwt.StandardClaims{
-				ExpiresAt: expiresAt,
+			UserName: u.Name,
+			UserID:   u.ID.String(),
+			Role:     role,
+			RegisteredClaims: jwt.RegisteredClaims{
+				ExpiresAt: jwt.NewNumericDate(expiresAt),
 			},
 		}
 

--- a/wrapper/ensweb/token.go
+++ b/wrapper/ensweb/token.go
@@ -3,7 +3,7 @@ package ensweb
 import (
 	"fmt"
 
-	"github.com/dgrijalva/jwt-go"
+	"github.com/golang-jwt/jwt/v5"
 )
 
 type TokenHelper interface {
@@ -42,7 +42,7 @@ func (t TokenType) String() string {
 
 // GenerateJWTToken will generate JWT token
 func (s *Server) GenerateJWTToken(claims jwt.Claims) string {
-	token := jwt.NewWithClaims(jwt.GetSigningMethod("HS256"), claims)
+	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
 
 	tokenString, err := token.SignedString([]byte(s.jwtSecret))
 	if err != nil {


### PR DESCRIPTION
This PR replaces the deprecated `github.com/dgrijalva/jwt-go` dependency in ensweb with `github.com/golang-jwt/jwt/v5`.

- `BasicToken` now uses `RegisteredClaims` from golang-jwt v5.
- Signing uses `jwt.SigningMethodHS256` (same in grpcserver and core helpers for consistency).
- `dgrijalva/jwt-go` is removed from go.mod.

made by mooncitydev