### PR TITLE
feat(core): add token chain sync before receiver persistence

### DIFF
--- a/core/api/setup_api.go
+++ b/core/api/setup_api.go
@@ -2,14 +2,11 @@ package api
 
 import (
 	"github.com/rubixchain/rubixgoplatform/core/ipfsport"
-	rubixsync "github.com/rubixchain/rubixgoplatform/core/sync"
 	"github.com/rubixchain/rubixgoplatform/core/wallet"
-	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
 	"github.com/rubixchain/rubixgoplatform/wrapper/logger"
 )
 
+// SetupAPI registers peer-facing API routes.
+// The sync-transaction-chain route has been moved to Core.TransactionSetup().
 func SetupAPI(listener *ipfsport.Listener, w *wallet.Wallet, log logger.Logger) {
-	listener.AddRoute(rubixsync.APISyncTransactionChain, "POST", func(req *ensweb.Request) *ensweb.Result {
-		return rubixsync.SyncTransactionChain(req, listener, w, log)
-	})
 }

--- a/core/callback.go
+++ b/core/callback.go
@@ -54,9 +54,9 @@ func (c *Core) CallBackQuorumUnpledge(tx *models.Transactions, did string) error
 		prevTransactionList = append(prevTransactionList, prevTransaction)
 	}
 
-	transactionToUnpledge, err := c.w.CheckTxnsPresentInUnpledgeSequenceInfo(prevTransactionList)
+	transactionToUnpledge, err := c.w.CheckTxnsPresentInUnpledgeSequenceInfo(prevTransactionList, did)
 	if err != nil {
-		return fmt.Errorf("CallBackQuorumUnpledge: failed to get transactions from `unpledge_sequence_info` table, err: %v", err)
+		return fmt.Errorf("CallBackQuorumUnpledge: failed to get transactions from `unpledge_sequence_info` table for did %q, err: %v", did, err)
 	}
 
 	for _, txToUnpledge := range transactionToUnpledge {

--- a/core/callback.go
+++ b/core/callback.go
@@ -59,6 +59,22 @@ func (c *Core) CallBackQuorumUnpledge(tx *models.Transactions, did string) error
 		return fmt.Errorf("CallBackQuorumUnpledge: failed to get transactions from `unpledge_sequence_info` table for did %q, err: %v", did, err)
 	}
 
+	// Emit a debug log for prevTxIDs that are NOT present in unpledge_sequence_info
+	// for this quorum — this quorum never pledged for those txs, so there is nothing
+	// to unpledge. Logging here preserves observability for the no-match case.
+	matchedSet := make(map[string]struct{}, len(transactionToUnpledge))
+	for _, txID := range transactionToUnpledge {
+		matchedSet[txID] = struct{}{}
+	}
+	for _, prevTxID := range prevTransactionList {
+		if _, ok := matchedSet[prevTxID]; !ok {
+			c.log.Debug("CallBackQuorumUnpledge: prevTxID not in unpledge_sequence_info — skip (not pledged by this quorum)",
+				"prevTxID", prevTxID,
+				"did", did,
+			)
+		}
+	}
+
 	for _, txToUnpledge := range transactionToUnpledge {
 		_, ok := c.qc[did]
 		if !ok {

--- a/core/config/config.go
+++ b/core/config/config.go
@@ -27,10 +27,10 @@ db_name = "rubix"
 
 [db.config]
 max_connections = 50
-min_connections = 5
-max_connection_lifetime_seconds = 1
-max_connection_idletime_seconds = 1
-statement_timeout_seconds = 5
+min_connections = 10
+max_connection_lifetime_seconds = 60
+max_connection_idletime_seconds = 30
+statement_timeout_seconds = 20
 
 [ipfs]
 mainnet_bootstrap_nodes = [
@@ -135,7 +135,7 @@ func CreateRubixConfigFromUserConfig(userConfig types.UserConfig, nodeDir string
 		return types.RubixConfig{}, fmt.Errorf("failed while creating RubixConfig, invalid network type: %v", userConfig.Core.NetworkMode)
 	}
 
-	rubixConfig.NetworkDir = filepath.Join(nodeDir, networkDirName) 
+	rubixConfig.NetworkDir = filepath.Join(nodeDir, networkDirName)
 	rubixConfig.DidDir = filepath.Join(rubixConfig.NetworkDir, "dids")
 	rubixConfig.TrustedNetwork = userConfig.Core.EnableTrustedNetwork
 

--- a/core/consensus/checks.go
+++ b/core/consensus/checks.go
@@ -234,7 +234,7 @@ func ValidateNewTokenContent(tokenID string, isQuorum bool, testnet bool, mainne
 				network, tokenNo, maxAllowed, level,
 			)
 		}
-		log.Debug("token content validated for "+network, tokenID)
+		//	log.Debug("token content validated for "+network, tokenID)
 	}
 
 	MaxPossiblePartTokenNumber := parts.MaxPossiblePartsIndexByMaxDecimalPlaces(uint(constants.MaxSupportedDecimalPlaces))
@@ -249,7 +249,7 @@ func ValidateNewTokenContent(tokenID string, isQuorum bool, testnet bool, mainne
 				partTokenNumber, MaxPossiblePartTokenNumber,
 			)
 		}
-		log.Debug("token content validated for the part token", tokenID)
+		//log.Debug("token content validated for the part token", tokenID)
 	}
 
 	return nil

--- a/core/consensus/consensus.go
+++ b/core/consensus/consensus.go
@@ -25,7 +25,7 @@ func ReqPledgeToken(
 
 	log.Info("ReqPledgeToken : Request received to pledge tokens for transaction", "referenceId", referenceId, "transactionValue", transactionValue, "networkMode", networkMode)
 	// Lock and fetch free RBT tokens for split/transfer.
-	lockedTokens, err := w.LockTokensForSplit(context.Background(), dc.GetDID(), transactionValue)
+	lockedTokens, err := w.LockTokensForSplit(context.Background(), dc.GetDID(), transactionValue, referenceId)
 	if err != nil {
 		return models.PledgeTokenResponse{}, fmt.Errorf("ReqPledgeToken: failed to lock tokens for split: %w", err)
 	}

--- a/core/core.go
+++ b/core/core.go
@@ -20,6 +20,7 @@ import (
 	"github.com/rubixchain/rubixgoplatform/did"
 	"github.com/rubixchain/rubixgoplatform/service"
 	"github.com/rubixchain/rubixgoplatform/types"
+	"github.com/rubixchain/rubixgoplatform/types/models"
 	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
 	"github.com/rubixchain/rubixgoplatform/wrapper/logger"
 	"github.com/rubixchain/rubixgoplatform/wrapper/uuid"
@@ -702,4 +703,34 @@ func (c *Core) RetryFailedTokenSync() {
 		}
 
 	}()
+}
+
+// GetSyncTransactionChainData returns transaction chains for the given token IDs,
+// excluding any transactions whose IDs appear in excludeTxIDs.
+func (c *Core) GetSyncTransactionChainData(tokenIDs []string, excludeTxIDs []string) (map[string][]models.Transactions, error) {
+	excludeSet := make(map[string]bool, len(excludeTxIDs))
+	for _, id := range excludeTxIDs {
+		excludeSet[id] = true
+	}
+
+	result := make(map[string][]models.Transactions)
+	for _, tokenID := range tokenIDs {
+		txs, err := c.w.GetTransactionsByTokenID(tokenID)
+		if err != nil {
+			c.log.Warn("GetSyncTransactionChainData: failed to fetch chain", "tokenID", tokenID, "err", err)
+			continue
+		}
+		if len(excludeSet) > 0 {
+			filtered := make([]models.Transactions, 0, len(txs))
+			for _, tx := range txs {
+				if !excludeSet[tx.ID] {
+					filtered = append(filtered, tx)
+				}
+			}
+			txs = filtered
+		}
+		result[tokenID] = txs
+	}
+
+	return result, nil
 }

--- a/core/core.go
+++ b/core/core.go
@@ -142,6 +142,12 @@ type Core struct {
 	Ctx                  context.Context
 	qm                   *QuorumManager
 	srv                  *service.Service
+
+	// Unpledge mismatch audit log — lazy-init on first mismatch event.
+	// See core/unpledge_v2.go:writeUnpledgeMismatch.
+	unpledgeAuditLog     *os.File
+	unpledgeAuditLogOnce sync.Once
+	unpledgeAuditLogMu   sync.Mutex
 }
 
 func newRubixContext() context.Context {

--- a/core/did.go
+++ b/core/did.go
@@ -290,6 +290,7 @@ func (c *Core) registerDID(reqID string, did string) error {
 		return fmt.Errorf("registerDID: failed to resolve did algo id, err: %w", err)
 	}
 	pm.DIDAlgo = algoID
+	c.log.Info("Register DID peer map before publish", "peerMap", pm)
 	err = c.publishPeerMap(pm)
 	if err != nil {
 		c.log.Error("Register DID, failed to publish peer did map", "err", err)

--- a/core/fullnode.go
+++ b/core/fullnode.go
@@ -87,7 +87,8 @@ func (c *Core) TxnCallBack(peerID string, topic string, data []byte) {
 	// INCREMENT COUNTER when new transaction is processed
 	atomic.AddInt64(&c.txnProcessor.processedTxnCount, 1)
 
-	c.log.Info("Received transaction", "txnID", newEvent.TransactionID, "mode", newEvent.AssetType)
+	// ### commented: high-volume pub-sub noise (fires per transaction per node)
+	// c.log.Info("Received transaction", "txnID", newEvent.TransactionID, "mode", newEvent.AssetType)
 
 	// Update queue length metric for dynamic scaling
 	currentQueueLen := int64(len(c.txnProcessor.txnQueue))
@@ -133,9 +134,10 @@ func (c *Core) processTxnWithRetry(txnEvent *models.EventTransaction, workerID i
 
 		err := c.processSingleTransaction(txnEvent)
 		if err == nil {
-			c.log.Info("Transaction processed successfully",
-				"txnID", txnEvent.TransactionID,
-				"workerID", workerID)
+			// ### commented: high-volume pub-sub noise (fires per transaction per node)
+			// c.log.Info("Transaction processed successfully",
+			// 	"txnID", txnEvent.TransactionID,
+			// 	"workerID", workerID)
 			return
 		}
 
@@ -158,9 +160,10 @@ func (c *Core) processSingleTransaction(newEvent *models.EventTransaction) error
 	// validated block sequences, checked ownership, and stored blocks in the
 	// full node token chain. Needs reimplementation using PostgreSQL-backed
 	// transaction/token chain model.
-	c.log.Info("processSingleTransaction: block-based processing removed, skipping",
-		"txnID", newEvent.TransactionID,
-		"assetType", newEvent.AssetType)
+	// ### commented: high-volume pub-sub noise (fires per transaction per node; stub until block processing is reimplemented)
+	// c.log.Info("processSingleTransaction: block-based processing removed, skipping",
+	// 	"txnID", newEvent.TransactionID,
+	// 	"assetType", newEvent.AssetType)
 	return nil
 }
 

--- a/core/ipfs.go
+++ b/core/ipfs.go
@@ -19,10 +19,10 @@ import (
 )
 
 const (
-	IPFSConfigFilename string = "config"
-	MainnetSwarmKeyFilename   string = "swarm.key"
-	TestnetSwarmKeyFilename string = "testnetswarm.key"
-	LocalnetSwarmKeyFilename string  = "localnetswarm.key"
+	IPFSConfigFilename       string = "config"
+	MainnetSwarmKeyFilename  string = "swarm.key"
+	TestnetSwarmKeyFilename  string = "testnetswarm.key"
+	LocalnetSwarmKeyFilename string = "localnetswarm.key"
 )
 
 type DHTAddr struct {
@@ -68,7 +68,7 @@ func (c *Core) initIPFS(ipfsdir string) error {
 
 		gatewayPort := fmt.Sprintf("%d", c.cfg.PortConfig.IPFSAPIPort)
 		configData = []byte(strings.Replace(string(configData), "/tcp/8080", "/tcp/"+gatewayPort, -1))
-		
+
 		f, err := os.OpenFile(ipfsConfigFile,
 			os.O_CREATE|os.O_WRONLY, 0644)
 		if err != nil {
@@ -97,7 +97,7 @@ func (c *Core) initIPFS(ipfsdir string) error {
 
 		time.Sleep(1 * time.Second)
 		c.runIPFS()
-		c.ipfs = ipfsnode.NewShell(fmt.Sprintf("localhost:%d", c.cfg.PortConfig.IPFSPort))
+		c.ipfs = ipfsnode.NewShell(fmt.Sprintf("127.0.0.1:%d", c.cfg.PortConfig.IPFSPort))
 		if c.ipfs == nil {
 			c.log.Error("failed create ipfs shell")
 			return fmt.Errorf("failed create ipfs shell")
@@ -321,7 +321,7 @@ func (c *Core) RunIPFS() error {
 	// Wait for IPFS daemon to be ready
 	time.Sleep(5 * time.Second)
 
-	c.ipfs = ipfsnode.NewShell(fmt.Sprintf("localhost:%d", c.cfg.PortConfig.IPFSPort))
+	c.ipfs = ipfsnode.NewShell(fmt.Sprintf("127.0.0.1:%d", c.cfg.PortConfig.IPFSPort))
 
 	if c.ipfs == nil {
 		c.log.Error("failed create ipfs shell")
@@ -427,7 +427,6 @@ func (c *Core) AddBootStrap(peers []string) error {
 		}
 	}
 
-
 	if c.testnet {
 		for _, p := range peers {
 			alreadyExists := false
@@ -441,7 +440,7 @@ func (c *Core) AddBootStrap(peers []string) error {
 				c.cfg.TestnetBootstrap = append(c.cfg.TestnetBootstrap, p)
 			}
 		}
-	} 
+	}
 
 	if c.localnet {
 		for _, p := range peers {
@@ -457,7 +456,7 @@ func (c *Core) AddBootStrap(peers []string) error {
 			}
 		}
 	}
-	
+
 	_, err := c.ipfsOps.BootstrapAdd(peers)
 	return err
 }

--- a/core/ipfs_recovery.go
+++ b/core/ipfs_recovery.go
@@ -302,7 +302,7 @@ func (rm *IPFSRecoveryManager) reinitializeIPFS() error {
 	rm.log.Info("Reinitializing IPFS shell and operations")
 
 	// Create new IPFS shell
-	newShell := ipfsnode.NewShell(fmt.Sprintf("localhost:%d", rm.cfg.CfgData.Ports.IPFSPort))
+	newShell := ipfsnode.NewShell(fmt.Sprintf("127.0.0.1:%d", rm.cfg.CfgData.Ports.IPFSPort))
 	if newShell == nil {
 		return fmt.Errorf("failed to create new IPFS shell")
 	}

--- a/core/ipfsport/listener.go
+++ b/core/ipfsport/listener.go
@@ -25,7 +25,7 @@ func NewListener(cfg *Config, log logger.Logger, ipfs *ipfsnode.Shell) (*Listene
 		ipfs: ipfs,
 	}
 	scfg := &srvcfg.Config{
-		HostAddress: "localhost",
+		HostAddress: "127.0.0.1",
 		HostPort:    fmt.Sprintf("%d", cfg.Port),
 	}
 	var err error

--- a/core/ipfsport/peer.go
+++ b/core/ipfsport/peer.go
@@ -145,7 +145,7 @@ func (pm *PeerManager) OpenPeerConn(peerID string, did string, appname string) (
 			did:    did,
 		}
 		scfg := &srvcfg.Config{
-			ServerAddress: "localhost",
+			ServerAddress: "127.0.0.1",
 			ServerPort:    fmt.Sprintf("%d", pm.lport),
 		}
 		p.Client, err = ensweb.NewClient(scfg, p.log)
@@ -164,7 +164,7 @@ func (pm *PeerManager) OpenPeerConn(peerID string, did string, appname string) (
 			return nil, fmt.Errorf("all ports are busy")
 		}
 		scfg := &srvcfg.Config{
-			ServerAddress: "localhost",
+			ServerAddress: "127.0.0.1",
 			ServerPort:    fmt.Sprintf("%d", portNum),
 		}
 		p := &Peer{

--- a/core/ipfsport/peer.go
+++ b/core/ipfsport/peer.go
@@ -157,7 +157,7 @@ func (pm *PeerManager) OpenPeerConn(peerID string, did string, appname string) (
 	} else {
 		if !pm.SwarmConnect(peerID) {
 			pm.log.Error("Failed to connect swarm peer", "peerID", peerID)
-			return nil, fmt.Errorf("failed to connect swarm peer")
+			return nil, fmt.Errorf("failed to connect swarm peer, peerID " + peerID)
 		}
 		portNum := pm.getPeerPort()
 		if portNum == 0 {

--- a/core/peer.go
+++ b/core/peer.go
@@ -49,7 +49,7 @@ func (c *Core) publishPeerMap(pm *PeerMap) error {
 func (c *Core) peerCallback(peerID string, topic string, data []byte) {
 	var m PeerMap
 	err := json.Unmarshal(data, &m)
-	c.log.Debug("Peer DID Update")
+	c.log.Debug("Peer DID Update for ", m.PeerID, " DID ", m.DID)
 	if err != nil {
 		c.log.Error("failed to parse explorer data", "err", err)
 		return

--- a/core/pledge_v2.go
+++ b/core/pledge_v2.go
@@ -101,7 +101,7 @@ func (c *Core) PledgeV2(
 		  AND token_status = $2
 		ORDER BY token_id
 		FOR UPDATE
-	`, tokenIDs, int16(constants.TokenStatus_Free))
+	`, tokenIDs, int16(constants.TokenStatus_Locked))
 	if err != nil {
 		return fmt.Errorf("PledgeV2: SELECT FOR UPDATE on tokens: %w", err)
 	}

--- a/core/pledge_v2.go
+++ b/core/pledge_v2.go
@@ -16,24 +16,26 @@ import (
 //
 // Steps performed atomically inside pledgeTx:
 //
-//	0. INSERT transactions row (id = mainTxID, info = serialized txnInfo,
+//	0. SELECT FOR UPDATE on tokens (locks rows in ORDER BY token_id order,
+//	   verifies all tokens are Free, reads latest_position and transaction_id)
+//	1. INSERT transactions row (id = mainTxID, info = serialized txnInfo,
 //	   signature = combined initiator+quorum) so that tokenchain rows
 //	   (transaction_id = mainTxID) have a backing transactions.id.
-//	1. INSERT tokenchain rows (one per token, transaction_id = mainTxID, role = 8)
-//	2. UPDATE tokens (status = PLEDGED, latest_position, latest_role = 8)
-//	3. Rebuild tokenchain_index for affected tokens
+//	2. INSERT tokenchain rows (one per token, transaction_id = mainTxID, role = 8)
+//	3. UPDATE tokens (status = PLEDGED, latest_position, latest_role = 8)
+//	4. Rebuild tokenchain_index for affected tokens
 //
 // Post-commit (separate postTx):
 //   - Decrement token_denom for quorumDID
 //   - INSERT unpledge_sequence_info keyed by mainTxID
 //
 // Preconditions:
-//   - Every token in tokenInfos must already exist in the tokenchain table
-//     (i.e. the token has been issued/transferred to this quorum node before)
+//   - Every token in tokenInfos must already exist in the tokens table with
+//     token_status = Free (checked via SELECT FOR UPDATE inside pledgeTx)
 //
 // Errors are wrapped with context but callers should treat them as fatal for
-// the pledge attempt. ON CONFLICT (token_id, position) DO NOTHING makes the
-// operation idempotent.
+// the pledge attempt. tokenchain INSERT fails hard on position conflict —
+// conflicts are logic bugs that must surface as errors, not be silently dropped.
 func (c *Core) PledgeV2(
 	ctx context.Context,
 	tokenInfos []*models.TokenInfo,
@@ -68,20 +70,10 @@ func (c *Core) PledgeV2(
 		seen[ti.TokenID] = struct{}{}
 	}
 
-	// --- Fetch per-token previous transaction IDs ----------------------------
+	// --- Build token ID list for batch operations ---
 	tokenIDs := make([]string, 0, len(tokenInfos))
 	for _, ti := range tokenInfos {
 		tokenIDs = append(tokenIDs, ti.TokenID)
-	}
-
-	latestRows, err := c.w.ReadLatestTokenChainRows(ctx, tokenIDs)
-	if err != nil {
-		return fmt.Errorf("PledgeV2: read latest tokenchain rows: %w", err)
-	}
-	for _, tokenID := range tokenIDs {
-		if latestRows[tokenID] == nil {
-			return fmt.Errorf("PledgeV2: token %q has no tokenchain entry — must exist before pledge", tokenID)
-		}
 	}
 
 	// --- Inline pledge persistence (no txID, no signature, no transaction record) ---
@@ -92,6 +84,49 @@ func (c *Core) PledgeV2(
 		return fmt.Errorf("PledgeV2: begin pledge tx: %w", err)
 	}
 	defer pledgeTx.Rollback(ctx) //nolint:errcheck
+
+	// Lock all token rows in deterministic order before any write.
+	// ORDER BY token_id prevents deadlock across concurrent callers.
+	// token_status = Free ensures we do not re-pledge locked or already-pledged tokens.
+	type lockedTokenRow struct {
+		latestPosition int64
+		transactionID  string
+	}
+	lockedRows := make(map[string]lockedTokenRow, len(tokenIDs))
+
+	lockQueryRows, err := pledgeTx.Query(ctx, `
+		SELECT token_id, latest_position, transaction_id
+		FROM tokens
+		WHERE token_id = ANY($1::text[])
+		  AND token_status = $2
+		ORDER BY token_id
+		FOR UPDATE
+	`, tokenIDs, int16(constants.TokenStatus_Free))
+	if err != nil {
+		return fmt.Errorf("PledgeV2: SELECT FOR UPDATE on tokens: %w", err)
+	}
+	for lockQueryRows.Next() {
+		var tokenID string
+		var row lockedTokenRow
+		if err = lockQueryRows.Scan(&tokenID, &row.latestPosition, &row.transactionID); err != nil {
+			lockQueryRows.Close()
+			return fmt.Errorf("PledgeV2: scan FOR UPDATE rows: %w", err)
+		}
+		lockedRows[tokenID] = row
+	}
+	lockQueryRows.Close()
+	if err = lockQueryRows.Err(); err != nil {
+		return fmt.Errorf("PledgeV2: iterate FOR UPDATE rows: %w", err)
+	}
+	if len(lockedRows) != len(tokenIDs) {
+		missing := make([]string, 0)
+		for _, id := range tokenIDs {
+			if _, ok := lockedRows[id]; !ok {
+				missing = append(missing, id)
+			}
+		}
+		return fmt.Errorf("PledgeV2: %d token(s) not found or not Free: %v", len(tokenIDs)-len(lockedRows), missing)
+	}
 
 	// Step 0: INSERT transactions row for mainTxID so that tokenchain rows
 	// (transaction_id = mainTxID) have a backing transactions.id. Both info
@@ -119,13 +154,11 @@ func (c *Core) PledgeV2(
 
 	// Step 1: INSERT tokenchain rows (one per token, keyed by mainTxID)
 	for _, ti := range tokenInfos {
-		latestRow := latestRows[ti.TokenID]
-		prevTxID := latestRow.TransactionID
+		locked := lockedRows[ti.TokenID]
 		if _, err := pledgeTx.Exec(ctx, `
 			INSERT INTO tokenchain (token_id, transaction_id, previous_transaction_id, role, position, created_at, updated_at)
 			VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
-			ON CONFLICT (token_id, position) DO NOTHING
-		`, ti.TokenID, mainTxID, &prevTxID, pledgeRoleID, latestRow.Position+1); err != nil {
+		`, ti.TokenID, mainTxID, locked.transactionID, pledgeRoleID, locked.latestPosition+1); err != nil {
 			return fmt.Errorf("PledgeV2: insert tokenchain for token %q: %w", ti.TokenID, err)
 		}
 	}
@@ -136,12 +169,12 @@ func (c *Core) PledgeV2(
 	// is satisfied because Step 0 already inserted the transactions row
 	// within this same pledgeTx.
 	for _, ti := range tokenInfos {
-		latestRow := latestRows[ti.TokenID]
+		locked := lockedRows[ti.TokenID]
 		if _, err := pledgeTx.Exec(ctx, `
 			UPDATE tokens
 			SET token_status = $2, latest_position = $3, latest_role = $4, transaction_id = $5, updated_at = NOW()
 			WHERE token_id = $1
-		`, ti.TokenID, int16(constants.TokenStatus_Pledged), latestRow.Position+1, pledgeRoleID, mainTxID); err != nil {
+		`, ti.TokenID, int16(constants.TokenStatus_Pledged), locked.latestPosition+1, pledgeRoleID, mainTxID); err != nil {
 			return fmt.Errorf("PledgeV2: update tokens for token %q: %w", ti.TokenID, err)
 		}
 	}

--- a/core/pledge_v2.go
+++ b/core/pledge_v2.go
@@ -127,7 +127,7 @@ func (c *Core) PledgeV2(
 				missing = append(missing, id)
 			}
 		}
-		return fmt.Errorf("PledgeV2: %d token(s) not found or not Free: %v", len(tokenIDs)-len(lockedRows), missing)
+		return fmt.Errorf("PledgeV2: %d token(s) not locked by this referenceID %q: | %v", len(tokenIDs)-len(lockedRows), referenceID, missing)
 	}
 
 	// Step 0: INSERT transactions row for mainTxID so that tokenchain rows
@@ -176,7 +176,10 @@ func (c *Core) PledgeV2(
 			UPDATE tokens
 			SET token_status = $2, latest_position = $3, latest_role = $4, transaction_id = $5, updated_at = NOW()
 			WHERE token_id = $1
-		`, ti.TokenID, int16(constants.TokenStatus_Pledged), locked.latestPosition+1, pledgeRoleID, mainTxID); err != nil {
+				AND token_status = $6
+      			AND lock_reference_id = $7
+		`, ti.TokenID, int16(constants.TokenStatus_Pledged), locked.latestPosition+1, pledgeRoleID, mainTxID, int16(constants.TokenStatus_Locked),
+			referenceID); err != nil {
 			return fmt.Errorf("PledgeV2: update tokens for token %q: %w", ti.TokenID, err)
 		}
 	}

--- a/core/pledge_v2.go
+++ b/core/pledge_v2.go
@@ -16,14 +16,14 @@ import (
 //
 // Steps performed atomically inside pledgeTx:
 //
-//	0. SELECT FOR UPDATE on tokens (locks rows in ORDER BY token_id order,
-//	   verifies all tokens are Free, reads latest_position and transaction_id)
-//	1. INSERT transactions row (id = mainTxID, info = serialized txnInfo,
-//	   signature = combined initiator+quorum) so that tokenchain rows
-//	   (transaction_id = mainTxID) have a backing transactions.id.
-//	2. INSERT tokenchain rows (one per token, transaction_id = mainTxID, role = 8)
-//	3. UPDATE tokens (status = PLEDGED, latest_position, latest_role = 8)
-//	4. Rebuild tokenchain_index for affected tokens
+//  0. SELECT FOR UPDATE on tokens (locks rows in ORDER BY token_id order,
+//     verifies all tokens are Free, reads latest_position and transaction_id)
+//  1. INSERT transactions row (id = mainTxID, info = serialized txnInfo,
+//     signature = combined initiator+quorum) so that tokenchain rows
+//     (transaction_id = mainTxID) have a backing transactions.id.
+//  2. INSERT tokenchain rows (one per token, transaction_id = mainTxID, role = 8)
+//  3. UPDATE tokens (status = PLEDGED, latest_position, latest_role = 8)
+//  4. Rebuild tokenchain_index for affected tokens
 //
 // Post-commit (separate postTx):
 //   - Decrement token_denom for quorumDID
@@ -46,6 +46,7 @@ func (c *Core) PledgeV2(
 	txnInfo *models.TransactionInfo,
 	initiatorSignature string,
 	quorumSignature string,
+	referenceID string,
 ) error {
 	// --- Validation ----------------------------------------------------------
 	if len(tokenInfos) == 0 {
@@ -99,9 +100,10 @@ func (c *Core) PledgeV2(
 		FROM tokens
 		WHERE token_id = ANY($1::text[])
 		  AND token_status = $2
+		  AND lock_reference_id = $3
 		ORDER BY token_id
 		FOR UPDATE
-	`, tokenIDs, int16(constants.TokenStatus_Locked))
+	`, tokenIDs, int16(constants.TokenStatus_Locked), referenceID)
 	if err != nil {
 		return fmt.Errorf("PledgeV2: SELECT FOR UPDATE on tokens: %w", err)
 	}

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -293,6 +293,76 @@ func (c *Core) initiateConsensusHandler(request *ensweb.Request) *ensweb.Result 
 		}
 	}
 
+	// Soft dedup guard (F-2): log + dedupe + metric, continue on duplicates.
+	// Hard guard in PledgeV2 remains the last line of defense; this guard
+	// exists so a duplicate under load is visible without cascading failure.
+	{
+		seenDedup := make(map[string]struct{}, len(tokenInfos))
+		deduped := make([]*models.TokenInfo, 0, len(tokenInfos))
+		dupCount := 0
+		for _, ti := range tokenInfos {
+			if ti == nil {
+				continue
+			}
+			if _, dup := seenDedup[ti.TokenID]; dup {
+				dupCount++
+				c.log.Warn("initiateConsensusHandler: duplicate token in pledge tokenInfos (soft-deduped)",
+					"metric", "pledge_v2_duplicate_token_total",
+					"count", dupCount,
+					"tokenID", ti.TokenID,
+					"quorumDID", quorumDid,
+					"txID", txID,
+					"referenceID", consensusRequest.ReferenceId,
+				)
+				continue
+			}
+			seenDedup[ti.TokenID] = struct{}{}
+			deduped = append(deduped, ti)
+		}
+		tokenInfos = deduped
+	}
+
+	// VULN-4: validate lock_reference_id matches the incoming consensus ReferenceId
+	// BEFORE pledging. Prevents replayed/interleaved requests from pledging tokens
+	// that belong to a different reference_id.
+	{
+		tokenIDsForLockCheck := make([]string, 0, len(tokenInfos))
+		for _, ti := range tokenInfos {
+			tokenIDsForLockCheck = append(tokenIDsForLockCheck, ti.TokenID)
+		}
+		lockRefs, err := c.w.GetTokenLockReferenceIDs(context.Background(), tokenIDsForLockCheck)
+		if err != nil {
+			c.log.Error("initiateConsensusHandler: failed to read lock_reference_id for pledge tokens", "err", err)
+			response.Message = "initiateConsensusHandler: failed to validate token locks: " + err.Error()
+			return c.l.RenderJSON(request, response, http.StatusInternalServerError)
+		}
+		for _, id := range tokenIDsForLockCheck {
+			ref, found := lockRefs[id]
+			if !found {
+				c.log.Error("initiateConsensusHandler: pledge token not found in tokens table",
+					"tokenID", id, "quorumDID", quorumDid, "txID", txID)
+				response.Message = fmt.Sprintf("initiateConsensusHandler: token %q not found in tokens table", id)
+				return c.l.RenderJSON(request, response, http.StatusBadRequest)
+			}
+			if ref == nil {
+				c.log.Error("initiateConsensusHandler: pledge token has no lock_reference_id",
+					"tokenID", id, "quorumDID", quorumDid, "txID", txID)
+				response.Message = fmt.Sprintf("initiateConsensusHandler: token %q has no lock_reference_id (was never locked by this flow)", id)
+				return c.l.RenderJSON(request, response, http.StatusBadRequest)
+			}
+			if *ref != consensusRequest.ReferenceId {
+				c.log.Error("initiateConsensusHandler: pledge token lock_reference_id mismatch",
+					"tokenID", id, "expected", consensusRequest.ReferenceId, "got", *ref,
+					"quorumDID", quorumDid, "txID", txID)
+				response.Message = fmt.Sprintf("initiateConsensusHandler: token %q lock_reference_id mismatch: expected %q, got %q",
+					id, consensusRequest.ReferenceId, *ref)
+				return c.l.RenderJSON(request, response, http.StatusBadRequest)
+			}
+		}
+		c.log.Info("initiateConsensusHandler: lock_reference_id validation passed",
+			"txID", txID, "tokens", len(tokenInfos), "referenceID", consensusRequest.ReferenceId)
+	}
+
 	if err := c.PledgeV2(
 		context.Background(),
 		tokenInfos,

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -104,6 +104,29 @@ func (c *Core) requestPledgeTokenHandler(request *ensweb.Request) *ensweb.Result
 		return c.l.RenderJSON(request, &response, http.StatusNotFound)
 	}
 	dc := c.pqc[did]
+	// Strict minimal liquidity guard (260409-0ko):
+	// Cheap pre-check to short-circuit pledge requests when the quorum clearly
+	// does not have enough free RBT balance. This avoids entering
+	// LockTokensForSplit under load for trivially-rejectable requests. Note
+	// that this check is advisory — concurrent requests between here and
+	// LockTokensForSplit are still handled by the existing SKIP LOCKED /
+	// retry logic in LockTokensForSplit. Uses strict "<" comparison: equal
+	// balance is allowed through.
+	freeBalance, balErr := c.w.GetFreeRBTBalanceByDID(did)
+	if balErr != nil {
+		c.log.Error("requestPledgeTokenHandler : failed to fetch free balance", "did", did, "err", balErr)
+		response.Message = "requestPledgeTokenHandler : failed to fetch free balance"
+		return c.l.RenderJSON(request, &response, http.StatusInternalServerError)
+	}
+	if freeBalance < pledgeTokenRequest.TransactionValue {
+		c.log.Debug("requestPledgeTokenHandler : insufficient quorum liquidity",
+			"did", did,
+			"freeBalance", freeBalance,
+			"required", pledgeTokenRequest.TransactionValue,
+		)
+		response.Message = "insufficient quorum liquidity"
+		return c.l.RenderJSON(request, &response, http.StatusOK)
+	}
 	pledgeTokenResponse, err := consensus.ReqPledgeToken(dc, c.w, pledgeTokenRequest.TransactionValue, c.networkMode, c.log, c.ps, pledgeTokenRequest.ReferenceId)
 	if err != nil {
 		c.log.Error("requestPledgeTokenHandler : Failed to process pledge token request", "err", err)

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -109,7 +109,7 @@ func (c *Core) requestPledgeTokenHandler(request *ensweb.Request) *ensweb.Result
 		c.log.Error("requestPledgeTokenHandler : Failed to process pledge token request", "err", err)
 		// Release ALL locked tokens since pledge selection failed — LockTokensForSplit locked them
 		// but no subset was successfully selected, so all must be returned to Free.
-		if releaseErr := c.w.ReleaseAllLockedRBTTokensForDID(c.w.Ctx, did); releaseErr != nil {
+		if releaseErr := c.w.ReleaseAllLockedRBTTokensForDID(c.w.Ctx, did, pledgeTokenRequest.ReferenceId); releaseErr != nil {
 			c.log.Error("requestPledgeTokenHandler: failed to release locked tokens after pledge failure", "err", releaseErr)
 		}
 		response.Message = "requestPledgeTokenHandler : " + err.Error()
@@ -125,7 +125,7 @@ func (c *Core) requestPledgeTokenHandler(request *ensweb.Request) *ensweb.Result
 			selectedTokenIDs = append(selectedTokenIDs, t.TokenID)
 		}
 	}
-	if releaseErr := c.w.ReleaseNonSelectedLockedRBTTokensForDID(c.w.Ctx, did, selectedTokenIDs); releaseErr != nil {
+	if releaseErr := c.w.ReleaseNonSelectedLockedRBTTokensForDID(c.w.Ctx, did, selectedTokenIDs, pledgeTokenRequest.ReferenceId); releaseErr != nil {
 		c.log.Error("requestPledgeTokenHandler: failed to release non-selected locked tokens", "err", releaseErr)
 	} else {
 		c.log.Info("requestPledgeTokenHandler: released non-selected locked tokens", "did", did, "selectedCount", len(selectedTokenIDs))

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -396,6 +396,7 @@ func (c *Core) initiateConsensusHandler(request *ensweb.Request) *ensweb.Result 
 		txnInfo,
 		consensusRequest.InitiatorSignature,
 		consensusResponse.QuorumSignature,
+		consensusRequest.ReferenceId,
 	); err != nil {
 		c.log.Error("initiateConsensusHandler: PledgeV2 failed", "err", err)
 		response.Message = "initiateConsensusHandler: PledgeV2 failed: " + err.Error()

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -238,28 +238,77 @@ func (c *Core) initiateConsensusHandler(request *ensweb.Request) *ensweb.Result 
 		return c.l.RenderJSON(request, &response, http.StatusInternalServerError)
 	}
 
-	// Pledge tokens after consensus succeeds. The transactionId is already
-	// computed above (txID); InitiateConsensus returns the same value.
-	pledgeDetails := txnInfo.Quorums
-	if len(pledgeDetails) > 0 {
-		pledgeTokenDetails := pledgeDetails[0].Tokens
-		if err := c.PledgeV2(
-			context.Background(),
-			pledgeTokenDetails,
-			txID,
-			quorumDid,
-			txnInfo.Epoch,
-			txnInfo.Network,
-			txnInfo,
-			consensusRequest.InitiatorSignature,
-			consensusResponse.QuorumSignature,
-		); err != nil {
-			c.log.Error("initiateConsensusHandler: PledgeV2 failed", "err", err)
-			response.Message = "initiateConsensusHandler: PledgeV2 failed: " + err.Error()
-			// ### Note: consensus succeeded but pledge failed, which is a critical state.
-			// Alerting is needed to investigate and resolve the underlying issue.
+	// Locate this quorum's pledge token entry by DID match, not by slice index.
+	// txnInfo.Quorums may list multiple quorums; the entry for THIS quorum may
+	// not be at index 0.
+	var pledgeTokenDetails []*models.TokenInfo
+	for _, q := range txnInfo.Quorums {
+		if q.Did == quorumDid {
+			pledgeTokenDetails = q.Tokens
+			break
+		}
+	}
+	if len(pledgeTokenDetails) == 0 {
+		c.log.Error("initiateConsensusHandler: no quorum tokens found for DID", "quorumDID", quorumDid)
+		response.Message = fmt.Errorf("no quorum tokens found for DID %s", quorumDid).Error()
+		return c.l.RenderJSON(request, response, http.StatusInternalServerError)
+	}
+
+	// Token consistency validation BEFORE PledgeV2.
+	// Extract token IDs from both views of the pledge set and confirm they
+	// agree on count and membership. In the current single-source code path
+	// these are the same slice, so this is a defensive check that will fire
+	// only if a future refactor introduces a second token list out of band.
+	pledgeTokenIDsFromTxnInfo := make(map[string]struct{}, len(pledgeTokenDetails))
+	for _, ti := range pledgeTokenDetails {
+		if ti == nil {
+			c.log.Error("initiateConsensusHandler: nil TokenInfo in pledgeTokenDetails")
+			response.Message = "initiateConsensusHandler: nil TokenInfo in pledgeTokenDetails"
 			return c.l.RenderJSON(request, response, http.StatusInternalServerError)
 		}
+		pledgeTokenIDsFromTxnInfo[ti.TokenID] = struct{}{}
+	}
+	// tokenInfos is the slice that will actually be passed to PledgeV2.
+	// In the current flow this is the same as pledgeTokenDetails; the
+	// consistency check here ensures the two views remain in sync.
+	tokenInfos := pledgeTokenDetails
+	if len(tokenInfos) != len(pledgeTokenDetails) {
+		c.log.Error("initiateConsensusHandler: pledge token count mismatch",
+			"fromTxnInfo", len(pledgeTokenDetails),
+			"actual", len(tokenInfos))
+		response.Message = "initiateConsensusHandler: pledge token count mismatch"
+		return c.l.RenderJSON(request, response, http.StatusInternalServerError)
+	}
+	for _, ti := range tokenInfos {
+		if ti == nil {
+			c.log.Error("initiateConsensusHandler: nil TokenInfo in tokenInfos")
+			response.Message = "initiateConsensusHandler: nil TokenInfo in tokenInfos"
+			return c.l.RenderJSON(request, response, http.StatusInternalServerError)
+		}
+		if _, ok := pledgeTokenIDsFromTxnInfo[ti.TokenID]; !ok {
+			c.log.Error("initiateConsensusHandler: pledge token ID set mismatch",
+				"unexpectedTokenID", ti.TokenID)
+			response.Message = "initiateConsensusHandler: pledge token ID set mismatch"
+			return c.l.RenderJSON(request, response, http.StatusInternalServerError)
+		}
+	}
+
+	if err := c.PledgeV2(
+		context.Background(),
+		tokenInfos,
+		txID,
+		quorumDid,
+		txnInfo.Epoch,
+		txnInfo.Network,
+		txnInfo,
+		consensusRequest.InitiatorSignature,
+		consensusResponse.QuorumSignature,
+	); err != nil {
+		c.log.Error("initiateConsensusHandler: PledgeV2 failed", "err", err)
+		response.Message = "initiateConsensusHandler: PledgeV2 failed: " + err.Error()
+		// ### Note: consensus succeeded but pledge failed, which is a critical state.
+		// Alerting is needed to investigate and resolve the underlying issue.
+		return c.l.RenderJSON(request, response, http.StatusInternalServerError)
 	}
 
 	return c.l.RenderJSON(request, &consensusResponse, http.StatusOK)

--- a/core/quorum_recv.go
+++ b/core/quorum_recv.go
@@ -1689,7 +1689,7 @@ func (c *Core) unlockTokens(req *ensweb.Request) *ensweb.Result {
 		crep.Message = "Failed to parse json request"
 		return c.l.RenderJSON(req, &crep, http.StatusOK)
 	}
-	err = c.w.UnlockLockedTokens(tokenList.DID, tokenList.Tokens)
+	err = c.w.UnlockLockedTokens(tokenList.DID, tokenList.Tokens, req.ID)
 	if err != nil {
 		c.log.Error("Failed to update token status", "err", err)
 		return c.l.RenderJSON(req, &crep, http.StatusOK)

--- a/core/smart_contract_token_operations.go
+++ b/core/smart_contract_token_operations.go
@@ -57,7 +57,7 @@ func (c *Core) deploySmartContractToken(reqID string, deployReq *model.DeploySma
 		networkStr = "testnet"
 	}
 	// Lock and fetch free RBT tokens for split/transfer.
-	lockedTokens, err := c.w.LockTokensForSplit(c.w.Ctx, didCryptoLib.GetDID(), deployReq.RBTAmount)
+	lockedTokens, err := c.w.LockTokensForSplit(c.w.Ctx, didCryptoLib.GetDID(), deployReq.RBTAmount, reqID)
 	if err != nil {
 		c.log.Error("Failed to lock tokens for split", "err", err)
 		resp.Message = "DeploySmartContract: failed to lock tokens for split, err: " + err.Error()
@@ -86,7 +86,7 @@ func (c *Core) deploySmartContractToken(reqID string, deployReq *model.DeploySma
 	}
 
 	rbtTokensToCommit := make([]string, 0)
-	defer c.w.ReleaseTokens(rbtTokensToCommitDetails)
+	defer c.w.ReleaseTokens(rbtTokensToCommitDetails, reqID)
 
 	for i := range rbtTokensToCommitDetails {
 		commitedTokenIdBuffer := bytes.NewBufferString(rbtTokensToCommitDetails[i].TokenID)

--- a/core/storage/schema.go
+++ b/core/storage/schema.go
@@ -73,6 +73,7 @@ func (r *RubixDB) InitSchema(ctx context.Context) error {
             token_type       SMALLINT NOT NULL,
             latest_position BIGINT NOT NULL DEFAULT 0,
             latest_role SMALLINT,
+            lock_reference_id TEXT DEFAULT NULL,
             created_at       TIMESTAMPTZ DEFAULT NOW(),
             updated_at       TIMESTAMPTZ DEFAULT NOW(),
             CONSTRAINT tokens_did_fk 
@@ -87,6 +88,7 @@ func (r *RubixDB) InitSchema(ctx context.Context) error {
             REFERENCES token_type(id)
         );
         CREATE INDEX IF NOT EXISTS idx_tokens_did_status ON tokens(did, token_status);
+        CREATE INDEX IF NOT EXISTS idx_tokens_did_status_value ON tokens(did, token_status, token_value);
         ALTER TABLE tokens ADD COLUMN IF NOT EXISTS lock_reference_id TEXT;
         CREATE INDEX IF NOT EXISTS idx_tokens_lock_reference_id ON tokens(lock_reference_id) WHERE lock_reference_id IS NOT NULL;
 

--- a/core/storage/schema.go
+++ b/core/storage/schema.go
@@ -87,6 +87,8 @@ func (r *RubixDB) InitSchema(ctx context.Context) error {
             REFERENCES token_type(id)
         );
         CREATE INDEX IF NOT EXISTS idx_tokens_did_status ON tokens(did, token_status);
+        ALTER TABLE tokens ADD COLUMN IF NOT EXISTS lock_reference_id TEXT;
+        CREATE INDEX IF NOT EXISTS idx_tokens_lock_reference_id ON tokens(lock_reference_id) WHERE lock_reference_id IS NOT NULL;
 
 
         -- moving tokenchain below so that all referenced tables are defined before it. tokenchain has FKs to transactions, token_role, and tokens.
@@ -213,7 +215,6 @@ func (r *RubixDB) InitSchema(ctx context.Context) error {
             count BIGINT NOT NULL,
             created_at TIMESTAMPTZ DEFAULT NOW(),
             updated_at TIMESTAMPTZ DEFAULT NOW(),
-
             CONSTRAINT unique_did_denom UNIQUE (did, denom)
         );
 

--- a/core/sync.go
+++ b/core/sync.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	rubixsync "github.com/rubixchain/rubixgoplatform/core/sync"
+	"github.com/rubixchain/rubixgoplatform/constants"
 	"github.com/rubixchain/rubixgoplatform/types/models"
 	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
 )
@@ -239,6 +240,83 @@ func (c *Core) applyTokenChainFromSync(tokenID string, remoteTxs []models.Transa
 		}
 	}
 
+	// Token-ensure: the tokenchain table has a deferred FK to tokens(token_id).
+	// If the token row does not exist, ApplyTokenChainBatch will fail at commit with SQLSTATE 23503.
+	// We derive TokenType from the first new transaction's txInfo.Tokens arrays and create
+	// the token row if it is absent.
+	var tokenForUpdate models.Token
+	var tokenEnsured bool
+	if _, getErr := c.w.GetTokenByTokenID(tokenID); getErr != nil {
+		// Token does not exist — must create it.
+		// Parse txInfo from the first new transaction to derive TokenType, owner DID, and role.
+		var firstTxInfo models.TransactionInfo
+		if unmarshalErr := json.Unmarshal(newTxs[0].tx.Info, &firstTxInfo); unmarshalErr != nil {
+			return fmt.Errorf("applyTokenChainFromSync: cannot parse first tx.Info for token ensure: %w", unmarshalErr)
+		}
+		var tokenType int16 = -1
+		var tokenValue float64
+		if firstTxInfo.Tokens != nil {
+			for _, t := range firstTxInfo.Tokens.RBT {
+				if t != nil && t.TokenID == tokenID {
+					tokenType = int16(models.GetTokenTypeID(constants.TokenType_RBT))
+					tokenValue = t.TokenValue
+					break
+				}
+			}
+			if tokenType < 0 {
+				for _, t := range firstTxInfo.Tokens.FT {
+					if t != nil && t.TokenID == tokenID {
+						tokenType = int16(models.GetTokenTypeID(constants.TokenType_FT))
+						tokenValue = t.TokenValue
+						break
+					}
+				}
+			}
+			if tokenType < 0 {
+				for _, t := range firstTxInfo.Tokens.NFT {
+					if t != nil && t.TokenID == tokenID {
+						tokenType = int16(models.GetTokenTypeID(constants.TokenType_NFT))
+						tokenValue = t.TokenValue
+						break
+					}
+				}
+			}
+			if tokenType < 0 {
+				for _, t := range firstTxInfo.Tokens.SmartContract {
+					if t != nil && t.TokenID == tokenID {
+						tokenType = int16(models.GetTokenTypeID(constants.TokenType_SmartContract))
+						tokenValue = t.TokenValue
+						break
+					}
+				}
+			}
+		}
+		if tokenType < 0 {
+			return fmt.Errorf("applyTokenChainFromSync: token %s not found in any token array in txInfo — cannot determine type", tokenID)
+		}
+		firstRole := rubixsync.FindTokenRoleInTxn(tokenID, &firstTxInfo)
+		newToken := models.Token{
+			TokenID:        tokenID,
+			DID:            firstTxInfo.Owner,
+			TransactionID:  newTxs[0].tx.ID,
+			TokenType:      tokenType,
+			TokenValue:     tokenValue,
+			TokenStatus:    constants.TokenStatus_Free,
+			LatestPosition: nextPosition,
+			LatestRole:     firstRole,
+		}
+		if createErr := c.w.CreateToken(&newToken); createErr != nil {
+			return fmt.Errorf("applyTokenChainFromSync: CreateToken for %s: %w", tokenID, createErr)
+		}
+		tokenForUpdate = newToken
+		tokenEnsured = true
+	}
+	if !tokenEnsured {
+		if existing, getErr := c.w.GetTokenByTokenID(tokenID); getErr == nil {
+			tokenForUpdate = existing
+		}
+	}
+
 	// Step 6: Build tokenchain entries and apply atomically via ApplyTokenChainBatch.
 	entries := make([]*models.TokenChain, 0, len(newTxs))
 	for i, e := range newTxs {
@@ -281,11 +359,21 @@ func (c *Core) applyTokenChainFromSync(tokenID string, remoteTxs []models.Transa
 		return fmt.Errorf("applyTokenChainFromSync: ApplyTokenChainBatch: %w", err)
 	}
 
-	// NOTE: tokens table (DID, LatestPosition, LatestRole, TransactionID) is NOT updated here.
-	// This is intentional — PersistPostConsensus always runs after sync completes in SendTokens,
-	// and it updates the tokens table for the final transaction. Intermediate synced transactions
-	// would be overwritten by PersistPostConsensus anyway. Updating the tokens table here would
-	// be redundant and would add complexity without benefit.
+	// Update tokens table to reflect latest synced state.
+	// Always performed — even for pre-existing tokens — so that the tokens row accurately
+	// reflects the tail of the chain after sync, regardless of whether PersistPostConsensus runs.
+	var lastTxInfo models.TransactionInfo
+	_ = json.Unmarshal(newTxs[len(newTxs)-1].tx.Info, &lastTxInfo)
+
+	lastEntry := entries[len(entries)-1]
+	tokenForUpdate.DID = lastTxInfo.Owner
+	tokenForUpdate.TransactionID = newTxs[len(newTxs)-1].tx.ID
+	tokenForUpdate.LatestPosition = lastEntry.Position
+	tokenForUpdate.LatestRole = lastEntry.Role
+	tokenForUpdate.UpdatedAt = time.Now()
+	if updateErr := c.w.UpdateToken(tokenForUpdate); updateErr != nil {
+		return fmt.Errorf("applyTokenChainFromSync: UpdateToken for %s: %w", tokenID, updateErr)
+	}
 
 	c.log.Info("applyTokenChainFromSync: applied chain entries",
 		"tokenID", tokenID, "count", len(newTxs), "startPos", nextPosition)

--- a/core/sync.go
+++ b/core/sync.go
@@ -6,8 +6,8 @@ import (
 	"net/http"
 	"time"
 
-	rubixsync "github.com/rubixchain/rubixgoplatform/core/sync"
 	"github.com/rubixchain/rubixgoplatform/constants"
+	rubixsync "github.com/rubixchain/rubixgoplatform/core/sync"
 	"github.com/rubixchain/rubixgoplatform/types/models"
 	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
 )
@@ -301,7 +301,7 @@ func (c *Core) applyTokenChainFromSync(tokenID string, remoteTxs []models.Transa
 			TransactionID:  newTxs[0].tx.ID,
 			TokenType:      tokenType,
 			TokenValue:     tokenValue,
-			TokenStatus:    constants.TokenStatus_Free,
+			TokenStatus:    constants.TokenStatus_Transferred,
 			LatestPosition: nextPosition,
 			LatestRole:     firstRole,
 		}

--- a/core/sync.go
+++ b/core/sync.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	rubixsync "github.com/rubixchain/rubixgoplatform/core/sync"
-	"github.com/rubixchain/rubixgoplatform/constants"
 	"github.com/rubixchain/rubixgoplatform/types/models"
 	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
 )
@@ -240,83 +239,6 @@ func (c *Core) applyTokenChainFromSync(tokenID string, remoteTxs []models.Transa
 		}
 	}
 
-	// Token-ensure: the tokenchain table has a deferred FK to tokens(token_id).
-	// If the token row does not exist, ApplyTokenChainBatch will fail at commit with SQLSTATE 23503.
-	// We derive TokenType from the first new transaction's txInfo.Tokens arrays and create
-	// the token row if it is absent.
-	var tokenForUpdate models.Token
-	var tokenEnsured bool
-	if _, getErr := c.w.GetTokenByTokenID(tokenID); getErr != nil {
-		// Token does not exist — must create it.
-		// Parse txInfo from the first new transaction to derive TokenType, owner DID, and role.
-		var firstTxInfo models.TransactionInfo
-		if unmarshalErr := json.Unmarshal(newTxs[0].tx.Info, &firstTxInfo); unmarshalErr != nil {
-			return fmt.Errorf("applyTokenChainFromSync: cannot parse first tx.Info for token ensure: %w", unmarshalErr)
-		}
-		var tokenType int16 = -1
-		var tokenValue float64
-		if firstTxInfo.Tokens != nil {
-			for _, t := range firstTxInfo.Tokens.RBT {
-				if t != nil && t.TokenID == tokenID {
-					tokenType = int16(models.GetTokenTypeID(constants.TokenType_RBT))
-					tokenValue = t.TokenValue
-					break
-				}
-			}
-			if tokenType < 0 {
-				for _, t := range firstTxInfo.Tokens.FT {
-					if t != nil && t.TokenID == tokenID {
-						tokenType = int16(models.GetTokenTypeID(constants.TokenType_FT))
-						tokenValue = t.TokenValue
-						break
-					}
-				}
-			}
-			if tokenType < 0 {
-				for _, t := range firstTxInfo.Tokens.NFT {
-					if t != nil && t.TokenID == tokenID {
-						tokenType = int16(models.GetTokenTypeID(constants.TokenType_NFT))
-						tokenValue = t.TokenValue
-						break
-					}
-				}
-			}
-			if tokenType < 0 {
-				for _, t := range firstTxInfo.Tokens.SmartContract {
-					if t != nil && t.TokenID == tokenID {
-						tokenType = int16(models.GetTokenTypeID(constants.TokenType_SmartContract))
-						tokenValue = t.TokenValue
-						break
-					}
-				}
-			}
-		}
-		if tokenType < 0 {
-			return fmt.Errorf("applyTokenChainFromSync: token %s not found in any token array in txInfo — cannot determine type", tokenID)
-		}
-		firstRole := rubixsync.FindTokenRoleInTxn(tokenID, &firstTxInfo)
-		newToken := models.Token{
-			TokenID:        tokenID,
-			DID:            firstTxInfo.Owner,
-			TransactionID:  newTxs[0].tx.ID,
-			TokenType:      tokenType,
-			TokenValue:     tokenValue,
-			TokenStatus:    constants.TokenStatus_Free,
-			LatestPosition: nextPosition,
-			LatestRole:     firstRole,
-		}
-		if createErr := c.w.CreateToken(&newToken); createErr != nil {
-			return fmt.Errorf("applyTokenChainFromSync: CreateToken for %s: %w", tokenID, createErr)
-		}
-		tokenForUpdate = newToken
-		tokenEnsured = true
-	}
-	if !tokenEnsured {
-		if existing, getErr := c.w.GetTokenByTokenID(tokenID); getErr == nil {
-			tokenForUpdate = existing
-		}
-	}
-
 	// Step 6: Build tokenchain entries and apply atomically via ApplyTokenChainBatch.
 	entries := make([]*models.TokenChain, 0, len(newTxs))
 	for i, e := range newTxs {
@@ -359,21 +281,11 @@ func (c *Core) applyTokenChainFromSync(tokenID string, remoteTxs []models.Transa
 		return fmt.Errorf("applyTokenChainFromSync: ApplyTokenChainBatch: %w", err)
 	}
 
-	// Update tokens table to reflect latest synced state.
-	// Always performed — even for pre-existing tokens — so that the tokens row accurately
-	// reflects the tail of the chain after sync, regardless of whether PersistPostConsensus runs.
-	var lastTxInfo models.TransactionInfo
-	_ = json.Unmarshal(newTxs[len(newTxs)-1].tx.Info, &lastTxInfo)
-
-	lastEntry := entries[len(entries)-1]
-	tokenForUpdate.DID = lastTxInfo.Owner
-	tokenForUpdate.TransactionID = newTxs[len(newTxs)-1].tx.ID
-	tokenForUpdate.LatestPosition = lastEntry.Position
-	tokenForUpdate.LatestRole = lastEntry.Role
-	tokenForUpdate.UpdatedAt = time.Now()
-	if updateErr := c.w.UpdateToken(tokenForUpdate); updateErr != nil {
-		return fmt.Errorf("applyTokenChainFromSync: UpdateToken for %s: %w", tokenID, updateErr)
-	}
+	// NOTE: tokens table (DID, LatestPosition, LatestRole, TransactionID) is NOT updated here.
+	// This is intentional — PersistPostConsensus always runs after sync completes in SendTokens,
+	// and it updates the tokens table for the final transaction. Intermediate synced transactions
+	// would be overwritten by PersistPostConsensus anyway. Updating the tokens table here would
+	// be redundant and would add complexity without benefit.
 
 	c.log.Info("applyTokenChainFromSync: applied chain entries",
 		"tokenID", tokenID, "count", len(newTxs), "startPos", nextPosition)

--- a/core/sync.go
+++ b/core/sync.go
@@ -1,10 +1,11 @@
 package core
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
-	"strings"
 
+	rubixsync "github.com/rubixchain/rubixgoplatform/core/sync"
 	"github.com/rubixchain/rubixgoplatform/types/models"
 	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
 )
@@ -59,9 +60,11 @@ func (c *Core) SyncTransactionChain(request *ensweb.Request) *ensweb.Result {
 }
 
 // SyncTransactionChainsFromPeer fetches transaction chains for the given token IDs
-// from the peer identified by peerDID, and inserts them into the local DB as-is.
-// Duplicate transactions are silently skipped.
-func (c *Core) SyncTransactionChainsFromPeer(peerDID string, tokenIDs []string) error {
+// from the peer identified by peerDID, validates and applies them locally.
+//
+// prevTxIDs maps tokenID -> PreviousTransactionID from the incoming sendTokensRequest.
+// When a token's prevTxID already exists in the local chain, sync is skipped for that token.
+func (c *Core) SyncTransactionChainsFromPeer(peerDID string, tokenIDs []string, prevTxIDs map[string]string) error {
 	if len(tokenIDs) == 0 {
 		return nil
 	}
@@ -84,17 +87,190 @@ func (c *Core) SyncTransactionChainsFromPeer(peerDID string, tokenIDs []string) 
 	}
 
 	for tokenID, txs := range resp.Data {
-		for _, t := range txs {
-			tx := t
-			if err := c.w.CreateTransaction(&tx); err != nil {
-				if strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "duplicate") {
-					// Already synced — skip silently
-					continue
-				}
-				c.log.Warn("SyncTransactionChainsFromPeer: insert failed", "tokenID", tokenID, "txID", tx.ID, "err", err)
+		prevTxID := prevTxIDs[tokenID] // empty string if not in map — applyTokenChainFromSync handles this
+		if err := c.applyTokenChainFromSync(tokenID, txs, prevTxID); err != nil {
+			c.log.Warn("SyncTransactionChainsFromPeer: apply failed (non-fatal)", "tokenID", tokenID, "err", err)
+			// Continue with remaining tokens — sync failures are best-effort.
+		}
+	}
+
+	return nil
+}
+
+// applyTokenChainFromSync validates and applies synced transactions for a single token.
+// It enforces: canonical order validation -> local prefix match -> hole filling -> atomic batch insert.
+//
+// Parameters:
+//   - tokenID: the token whose chain is being synced
+//   - remoteTxs: ordered transaction list from the peer (by position)
+//   - prevTxID: the PreviousTransactionID from sendTokensRequest.TransactionInfo.Tokens
+//     for this token — used to short-circuit sync when the local chain already has it
+//
+// Errors are returned but are non-fatal — callers log and continue.
+func (c *Core) applyTokenChainFromSync(tokenID string, remoteTxs []models.Transactions, prevTxID string) error {
+	if len(remoteTxs) == 0 {
+		return nil
+	}
+
+	// Step 1: Get local tokenchain (ordered by position ASC) to determine what we already have.
+	localChain, err := c.w.GetTokenChainByTokenID(tokenID)
+	if err != nil {
+		// No local chain at all — treat as empty (receiver never held this token).
+		localChain = nil
+	}
+
+	// Step 1a: PrevTxID short-circuit — if the sender's previous transaction ID for this
+	// token already exists in our local chain, we already have the full history up to
+	// the current transaction. No sync needed.
+	if prevTxID != "" && len(localChain) > 0 {
+		for _, lc := range localChain {
+			if lc.TransactionID == prevTxID {
+				c.log.Debug("applyTokenChainFromSync: prevTxID already in local chain, skipping sync",
+					"tokenID", tokenID, "prevTxID", prevTxID)
+				return nil
 			}
 		}
 	}
 
+	// Step 2: Canonical order validation — verify that the incoming chain has valid
+	// PreviousTransactionID linkage. Each entry's PreviousTransactionID must match
+	// the preceding entry's transaction ID.
+	// We extract PreviousTransactionID per token from the TransactionInfo embedded in tx.Info.
+	type txWithPrev struct {
+		tx     models.Transactions
+		prevID string // PreviousTransactionID for this token within this transaction
+	}
+	enriched := make([]txWithPrev, 0, len(remoteTxs))
+	for _, tx := range remoteTxs {
+		var txInfo models.TransactionInfo
+		var prev string
+		if err := json.Unmarshal(tx.Info, &txInfo); err == nil {
+			if txInfo.Tokens != nil {
+				for _, t := range txInfo.Tokens.RBT {
+					if t != nil && t.TokenID == tokenID {
+						prev = t.PreviousTransactionID
+						break
+					}
+				}
+				if prev == "" {
+					for _, t := range txInfo.Tokens.FT {
+						if t != nil && t.TokenID == tokenID {
+							prev = t.PreviousTransactionID
+							break
+						}
+					}
+				}
+				if prev == "" {
+					for _, t := range txInfo.Tokens.NFT {
+						if t != nil && t.TokenID == tokenID {
+							prev = t.PreviousTransactionID
+							break
+						}
+					}
+				}
+			}
+		}
+		enriched = append(enriched, txWithPrev{tx: tx, prevID: prev})
+	}
+
+	// Validate canonical linkage: for i > 0, enriched[i].prevID must equal enriched[i-1].tx.ID.
+	for i := 1; i < len(enriched); i++ {
+		if enriched[i].prevID != "" && enriched[i].prevID != enriched[i-1].tx.ID {
+			c.log.Error("applyTokenChainFromSync: canonical order violation — incoming chain has broken PreviousTransactionID linkage",
+				"tokenID", tokenID,
+				"position", i,
+				"txID", enriched[i].tx.ID,
+				"expectedPrevTxID", enriched[i-1].tx.ID,
+				"actualPrevTxID", enriched[i].prevID,
+			)
+			return fmt.Errorf("applyTokenChainFromSync: canonical order violation at position %d for token %s: prevTxID %s != expected %s",
+				i, tokenID, enriched[i].prevID, enriched[i-1].tx.ID)
+		}
+	}
+
+	// Step 3: Local prefix match — verify that our local chain is a prefix of the incoming chain.
+	// If there is a mismatch, we have a FORK — log ERROR and reject.
+	for i := 0; i < len(localChain) && i < len(remoteTxs); i++ {
+		if localChain[i].TransactionID != remoteTxs[i].ID {
+			c.log.Error("applyTokenChainFromSync: FORK DETECTED — local chain diverges from remote chain",
+				"tokenID", tokenID,
+				"position", i,
+				"localTxID", localChain[i].TransactionID,
+				"remoteTxID", remoteTxs[i].ID,
+			)
+			return fmt.Errorf("applyTokenChainFromSync: fork detected for token %s at position %d: local=%s remote=%s",
+				tokenID, i, localChain[i].TransactionID, remoteTxs[i].ID)
+		}
+	}
+
+	// Step 4: Hole filling — only the entries after our local prefix are new.
+	newTxs := enriched[len(localChain):]
+	if len(newTxs) == 0 {
+		return nil // Already fully synced for this token.
+	}
+
+	// Determine the starting position for new entries.
+	var nextPosition int64
+	if len(localChain) > 0 {
+		nextPosition = localChain[len(localChain)-1].Position + 1
+	}
+
+	// Step 5: Insert transaction rows (idempotent, outside the tokenchain batch tx).
+	for _, e := range newTxs {
+		if err := c.w.CreateTransactionIfNotExists(&e.tx); err != nil {
+			return fmt.Errorf("applyTokenChainFromSync: insert tx %s: %w", e.tx.ID, err)
+		}
+	}
+
+	// Step 6: Build tokenchain entries and apply atomically via ApplyTokenChainBatch.
+	entries := make([]*models.TokenChain, 0, len(newTxs))
+	for i, e := range newTxs {
+		// Derive role from transaction info.
+		var txInfo models.TransactionInfo
+		var role int16
+		if err := json.Unmarshal(e.tx.Info, &txInfo); err != nil {
+			c.log.Warn("applyTokenChainFromSync: cannot parse tx.Info, defaulting role to 0",
+				"txID", e.tx.ID, "err", err)
+			role = 0
+		} else {
+			role = rubixsync.FindTokenRoleInTxn(tokenID, &txInfo)
+		}
+
+		// Determine previous transaction ID for the tokenchain entry.
+		var prevTxIDPtr *string
+		if i == 0 {
+			if len(localChain) > 0 {
+				tailTxID := localChain[len(localChain)-1].TransactionID
+				prevTxIDPtr = &tailTxID
+			}
+			// else nil — genesis or first appearance of this token locally
+		} else {
+			prevID := newTxs[i-1].tx.ID
+			prevTxIDPtr = &prevID
+		}
+
+		entries = append(entries, &models.TokenChain{
+			TokenID:               tokenID,
+			TransactionID:         e.tx.ID,
+			PreviousTransactionID: prevTxIDPtr,
+			Role:                  role,
+			Position:              nextPosition + int64(i),
+		})
+	}
+
+	// Atomic batch insert — all tokenchain rows + index rebuild in one DB transaction.
+	// A crash mid-loop rolls back everything, leaving the chain consistent.
+	if err := c.w.ApplyTokenChainBatch(c.Ctx, tokenID, entries); err != nil {
+		return fmt.Errorf("applyTokenChainFromSync: ApplyTokenChainBatch: %w", err)
+	}
+
+	// NOTE: tokens table (DID, LatestPosition, LatestRole, TransactionID) is NOT updated here.
+	// This is intentional — PersistPostConsensus always runs after sync completes in SendTokens,
+	// and it updates the tokens table for the final transaction. Intermediate synced transactions
+	// would be overwritten by PersistPostConsensus anyway. Updating the tokens table here would
+	// be redundant and would add complexity without benefit.
+
+	c.log.Info("applyTokenChainFromSync: applied chain entries",
+		"tokenID", tokenID, "count", len(newTxs), "startPos", nextPosition)
 	return nil
 }

--- a/core/sync.go
+++ b/core/sync.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"time"
 
 	rubixsync "github.com/rubixchain/rubixgoplatform/core/sync"
 	"github.com/rubixchain/rubixgoplatform/types/models"
@@ -12,8 +13,9 @@ import (
 
 // syncTxChainRequest is the request body for the batch token chain sync API.
 type syncTxChainRequest struct {
-	DID      string   `json:"did"`
-	TokenIDs []string `json:"token_ids"`
+	DID                   string   `json:"did"`
+	TokenIDs              []string `json:"token_ids"`
+	ExcludeTransactionIDs []string `json:"exclude_transaction_ids,omitempty"`
 }
 
 // syncTxChainResponse is the response body for the batch token chain sync API.
@@ -42,12 +44,27 @@ func (c *Core) SyncTransactionChain(request *ensweb.Request) *ensweb.Result {
 		}, http.StatusOK)
 	}
 
+	// Build exclusion set (typically 1 entry — the current transaction).
+	excludeSet := make(map[string]bool, len(req.ExcludeTransactionIDs))
+	for _, id := range req.ExcludeTransactionIDs {
+		excludeSet[id] = true
+	}
+
 	result := make(map[string][]models.Transactions)
 	for _, tokenID := range req.TokenIDs {
 		txs, err := c.w.GetTransactionsByTokenID(tokenID)
 		if err != nil {
 			c.log.Warn("SyncTransactionChain: failed to fetch chain", "tokenID", tokenID, "err", err)
 			continue
+		}
+		if len(excludeSet) > 0 {
+			filtered := make([]models.Transactions, 0, len(txs))
+			for _, tx := range txs {
+				if !excludeSet[tx.ID] {
+					filtered = append(filtered, tx)
+				}
+			}
+			txs = filtered
 		}
 		result[tokenID] = txs
 	}
@@ -64,12 +81,12 @@ func (c *Core) SyncTransactionChain(request *ensweb.Request) *ensweb.Result {
 //
 // prevTxIDs maps tokenID -> PreviousTransactionID from the incoming sendTokensRequest.
 // When a token's prevTxID already exists in the local chain, sync is skipped for that token.
-func (c *Core) SyncTransactionChainsFromPeer(peerDID string, tokenIDs []string, prevTxIDs map[string]string) error {
+func (c *Core) SyncTransactionChainsFromPeer(peerDID string, tokenIDs []string, prevTxIDs map[string]string, excludeTxIDs []string) error {
 	if len(tokenIDs) == 0 {
 		return nil
 	}
 
-	req := syncTxChainRequest{DID: peerDID, TokenIDs: tokenIDs}
+	req := syncTxChainRequest{DID: peerDID, TokenIDs: tokenIDs, ExcludeTransactionIDs: excludeTxIDs}
 
 	p, err := c.getPeer(peerDID)
 	if err != nil {
@@ -78,7 +95,7 @@ func (c *Core) SyncTransactionChainsFromPeer(peerDID string, tokenIDs []string, 
 	defer p.Close()
 
 	var resp syncTxChainResponse
-	if err = p.SendJSONRequest("POST", APISyncTransactionChain, nil, &req, &resp, false); err != nil {
+	if err = p.SendJSONRequest("POST", APISyncTransactionChain, nil, &req, &resp, false, 30*time.Second); err != nil {
 		return fmt.Errorf("SyncTransactionChainsFromPeer: request failed: %w", err)
 	}
 

--- a/core/sync.go
+++ b/core/sync.go
@@ -365,15 +365,16 @@ func (c *Core) applyTokenChainFromSync(tokenID string, remoteTxs []models.Transa
 	var lastTxInfo models.TransactionInfo
 	_ = json.Unmarshal(newTxs[len(newTxs)-1].tx.Info, &lastTxInfo)
 
+	//dead code. not needed
 	lastEntry := entries[len(entries)-1]
 	tokenForUpdate.DID = lastTxInfo.Owner
 	tokenForUpdate.TransactionID = newTxs[len(newTxs)-1].tx.ID
 	tokenForUpdate.LatestPosition = lastEntry.Position
 	tokenForUpdate.LatestRole = lastEntry.Role
 	tokenForUpdate.UpdatedAt = time.Now()
-	if updateErr := c.w.UpdateToken(tokenForUpdate); updateErr != nil {
-		return fmt.Errorf("applyTokenChainFromSync: UpdateToken for %s: %w", tokenID, updateErr)
-	}
+	//if updateErr := c.w.UpdateToken(tokenForUpdate); updateErr != nil {
+	//	return fmt.Errorf("applyTokenChainFromSync: UpdateToken for %s: %w", tokenID, updateErr)
+	//}
 
 	c.log.Info("applyTokenChainFromSync: applied chain entries",
 		"tokenID", tokenID, "count", len(newTxs), "startPos", nextPosition)

--- a/core/sync.go
+++ b/core/sync.go
@@ -1,0 +1,100 @@
+package core
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/rubixchain/rubixgoplatform/types/models"
+	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
+)
+
+// syncTxChainRequest is the request body for the batch token chain sync API.
+type syncTxChainRequest struct {
+	DID      string   `json:"did"`
+	TokenIDs []string `json:"token_ids"`
+}
+
+// syncTxChainResponse is the response body for the batch token chain sync API.
+type syncTxChainResponse struct {
+	Status  bool                             `json:"status"`
+	Message string                           `json:"message"`
+	Data    map[string][]models.Transactions `json:"data"`
+}
+
+// SyncTransactionChain handles POST /api/sync-transaction-chain.
+// It returns the ordered transaction chains for the requested token IDs from local DB.
+func (c *Core) SyncTransactionChain(request *ensweb.Request) *ensweb.Result {
+	var req syncTxChainRequest
+	if err := c.l.ParseJSON(request, &req); err != nil {
+		return c.l.RenderJSON(request, &syncTxChainResponse{
+			Status:  false,
+			Message: "failed to parse request",
+		}, http.StatusOK)
+	}
+
+	if len(req.TokenIDs) == 0 {
+		return c.l.RenderJSON(request, &syncTxChainResponse{
+			Status:  true,
+			Message: "no token_ids provided",
+			Data:    nil,
+		}, http.StatusOK)
+	}
+
+	result := make(map[string][]models.Transactions)
+	for _, tokenID := range req.TokenIDs {
+		txs, err := c.w.GetTransactionsByTokenID(tokenID)
+		if err != nil {
+			c.log.Warn("SyncTransactionChain: failed to fetch chain", "tokenID", tokenID, "err", err)
+			continue
+		}
+		result[tokenID] = txs
+	}
+
+	return c.l.RenderJSON(request, &syncTxChainResponse{
+		Status:  true,
+		Message: "ok",
+		Data:    result,
+	}, http.StatusOK)
+}
+
+// SyncTransactionChainsFromPeer fetches transaction chains for the given token IDs
+// from the peer identified by peerDID, and inserts them into the local DB as-is.
+// Duplicate transactions are silently skipped.
+func (c *Core) SyncTransactionChainsFromPeer(peerDID string, tokenIDs []string) error {
+	if len(tokenIDs) == 0 {
+		return nil
+	}
+
+	req := syncTxChainRequest{DID: peerDID, TokenIDs: tokenIDs}
+
+	p, err := c.getPeer(peerDID)
+	if err != nil {
+		return fmt.Errorf("SyncTransactionChainsFromPeer: getPeer failed: %w", err)
+	}
+	defer p.Close()
+
+	var resp syncTxChainResponse
+	if err = p.SendJSONRequest("POST", APISyncTransactionChain, nil, &req, &resp, false); err != nil {
+		return fmt.Errorf("SyncTransactionChainsFromPeer: request failed: %w", err)
+	}
+
+	if !resp.Status {
+		return fmt.Errorf("SyncTransactionChainsFromPeer: peer returned error: %s", resp.Message)
+	}
+
+	for tokenID, txs := range resp.Data {
+		for _, t := range txs {
+			tx := t
+			if err := c.w.CreateTransaction(&tx); err != nil {
+				if strings.Contains(err.Error(), "already exists") || strings.Contains(err.Error(), "duplicate") {
+					// Already synced — skip silently
+					continue
+				}
+				c.log.Warn("SyncTransactionChainsFromPeer: insert failed", "tokenID", tokenID, "txID", tx.ID, "err", err)
+			}
+		}
+	}
+
+	return nil
+}

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -8,11 +8,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/rubixchain/rubixgoplatform/constants"
 	"github.com/rubixchain/rubixgoplatform/core/consensus"
-	"github.com/rubixchain/rubixgoplatform/core/ipfsport"
 	"github.com/rubixchain/rubixgoplatform/core/model"
-	rubixsync "github.com/rubixchain/rubixgoplatform/core/sync"
 	"github.com/rubixchain/rubixgoplatform/core/wallet"
 	"github.com/rubixchain/rubixgoplatform/types/models"
 	"github.com/rubixchain/rubixgoplatform/util"
@@ -444,40 +441,6 @@ func (c *Core) TransactionSetup() {
 	c.l.AddRoute(APISyncTransactionChain, "POST", c.SyncTransactionChain)
 }
 
-// This function has been added here since the other corresponding sync functions has not been added yet.
-// Once the other sync functions and all are added, we can move this along with that.
-func (c *Core) syncTransactionTokens(
-	peer *ipfsport.Peer,
-	tokens *models.TransactionTokens,
-	NFTOwnershipTransfer bool,
-) error {
-
-	tokenGroups := map[string][]*models.TokenInfo{
-		constants.TokenType_RBT: tokens.RBT,
-		constants.TokenType_FT:  tokens.FT,
-	}
-
-	// Add NFT only if flag is true
-	if NFTOwnershipTransfer {
-		tokenGroups[constants.TokenType_NFT] = tokens.NFT
-	}
-
-	for tokenTypeStr, group := range tokenGroups {
-		tokenType := models.GetTokenTypeID(tokenTypeStr)
-		for _, token := range group {
-			if token == nil {
-				continue
-			}
-			//Handling the response in the future.
-			err, _ := rubixsync.SyncTransactionChainFrom(peer, token.TokenID, tokenType, c.w, c.log)
-			if err != nil {
-				return err
-			}
-		}
-	}
-
-	return nil
-}
 
 func (c *Core) SendTokens(request *ensweb.Request) *ensweb.Result {
 	crep := model.BasicResponse{Status: false}
@@ -543,7 +506,7 @@ func (c *Core) SendTokens(request *ensweb.Request) *ensweb.Result {
 	// Errors are logged but never break SendTokens — sync is best-effort.
 	if len(syncTokenIDs) > 0 {
 		initiatorDID := sendTokensRequest.TransactionInfo.Initiator
-		if err := c.SyncTransactionChainsFromPeer(initiatorDID, syncTokenIDs, prevTxIDs); err != nil {
+		if err := c.SyncTransactionChainsFromPeer(initiatorDID, syncTokenIDs, prevTxIDs, nil); err != nil {
 			c.log.Warn("SendTokens: chain sync from sender failed (non-fatal)", "initiator", initiatorDID, "err", err)
 		}
 	}

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -505,12 +505,19 @@ func (c *Core) SendTokens(request *ensweb.Request) *ensweb.Result {
 
 	// --- Token chain sync: fill gaps from sender before persisting ---
 	// Collect all token IDs and their PreviousTransactionIDs from the incoming transaction.
+	currentTxID, err := util.GetTransactionID(sendTokensRequest.TransactionInfo)
+	if err != nil {
+		c.log.Error("SendTokens: unable to get trnx id from sendTokensRequest.TransactionInfo, err: ", err)
+	}
+
 	var syncTokenIDs []string
+	var excludedTrnxIDs []string
 	prevTxIDs := make(map[string]string)
 	if txns := sendTokensRequest.TransactionInfo.Tokens; txns != nil {
 		for _, t := range txns.RBT {
 			if t != nil {
 				syncTokenIDs = append(syncTokenIDs, t.TokenID)
+				excludedTrnxIDs = append(excludedTrnxIDs, currentTxID)
 				if t.PreviousTransactionID != "" {
 					prevTxIDs[t.TokenID] = t.PreviousTransactionID
 				}
@@ -519,6 +526,7 @@ func (c *Core) SendTokens(request *ensweb.Request) *ensweb.Result {
 		for _, t := range txns.FT {
 			if t != nil {
 				syncTokenIDs = append(syncTokenIDs, t.TokenID)
+				excludedTrnxIDs = append(excludedTrnxIDs, currentTxID)
 				if t.PreviousTransactionID != "" {
 					prevTxIDs[t.TokenID] = t.PreviousTransactionID
 				}
@@ -529,6 +537,7 @@ func (c *Core) SendTokens(request *ensweb.Request) *ensweb.Result {
 			for _, t := range txns.NFT {
 				if t != nil {
 					syncTokenIDs = append(syncTokenIDs, t.TokenID)
+					excludedTrnxIDs = append(excludedTrnxIDs, currentTxID)
 					if t.PreviousTransactionID != "" {
 						prevTxIDs[t.TokenID] = t.PreviousTransactionID
 					}
@@ -543,7 +552,7 @@ func (c *Core) SendTokens(request *ensweb.Request) *ensweb.Result {
 	// Errors are logged but never break SendTokens — sync is best-effort.
 	if len(syncTokenIDs) > 0 {
 		initiatorDID := sendTokensRequest.TransactionInfo.Initiator
-		if err := c.SyncTransactionChainsFromPeer(initiatorDID, syncTokenIDs, prevTxIDs, nil); err != nil {
+		if err := c.SyncTransactionChainsFromPeer(initiatorDID, syncTokenIDs, prevTxIDs, excludedTrnxIDs); err != nil {
 			c.log.Warn("SendTokens: chain sync from sender failed (non-fatal)", "initiator", initiatorDID, "err", err)
 		}
 	}

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -3,11 +3,13 @@ package core
 import (
 	"encoding/json"
 	"fmt"
+	"math/rand"
 	"net/http"
 	"strings"
 	"time"
 
 	"github.com/rubixchain/rubixgoplatform/constants"
+	"github.com/rubixchain/rubixgoplatform/core/consensus"
 	"github.com/rubixchain/rubixgoplatform/core/ipfsport"
 	"github.com/rubixchain/rubixgoplatform/core/model"
 	rubixsync "github.com/rubixchain/rubixgoplatform/core/sync"
@@ -15,7 +17,6 @@ import (
 	"github.com/rubixchain/rubixgoplatform/types/models"
 	"github.com/rubixchain/rubixgoplatform/util"
 	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
-	"github.com/rubixchain/rubixgoplatform/core/consensus"
 )
 
 func (c *Core) InitiateTransaction(reqID string, req *models.TransactionRequest) {
@@ -55,7 +56,7 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 	txSucceeded := false
 	defer func() {
 		if !txSucceeded {
-			if releaseErr := c.w.ReleaseAllLockedRBTTokensForDID(ctx, initiatorDID); releaseErr != nil {
+			if releaseErr := c.w.ReleaseAllLockedRBTTokensForDID(ctx, initiatorDID, reqID); releaseErr != nil {
 				c.log.Error("InitiateTransaction: failed to release locked tokens after failure", "err", releaseErr)
 			} else {
 				c.log.Info("InitiateTransaction: released locked tokens after failed transaction", "did", initiatorDID)
@@ -76,6 +77,7 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 			networkMode,
 			c.log,
 			c.ps,
+			reqID,
 		)
 
 		if err == nil {
@@ -102,7 +104,9 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 			return resp
 		}
 
-		time.Sleep(retryBackoff(attempt))
+		/// In a high-contention scenario, we expect some transactions to hit TOCTOU conflicts due to the optimistic locking mechanism on tokens.
+		time.Sleep(retryWithRandomBackoff(attempt))
+		//time.Sleep(retryBackoff(attempt))
 	}
 
 	// Fetch the list of dids from quorum_manager table
@@ -200,12 +204,12 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 
 	if err != nil {
 		if _, err := util.PublishTransaction(
-			c.ps, 
-			transactionInfo, 
+			c.ps,
+			transactionInfo,
 			&models.Signature{
 				InitiatorSignature: initiatorSignature,
-			}, 
-			false, 
+			},
+			false,
 			err.Error(),
 		); err != nil {
 			c.log.Error("InitiateTransaction: Failed to publish transaction", "err", err)
@@ -217,12 +221,12 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 
 	if !consensusResponse.Status {
 		if _, err := util.PublishTransaction(
-			c.ps, 
-			transactionInfo, 
+			c.ps,
+			transactionInfo,
 			&models.Signature{
 				InitiatorSignature: initiatorSignature,
-			}, 
-			false, 
+			},
+			false,
 			consensusResponse.Message,
 		); err != nil {
 			c.log.Error("InitiateTransaction: Failed to publish transaction", "err", err)
@@ -270,7 +274,7 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 		return resp
 	}
 	c.log.Info("InitiateTransaction: Quorum signature verified successfully", "quorumDID", quorumAddresses[0])
-	
+
 	// Persist post-consensus state to PostgreSQL.
 	// On success the selected tokens are marked Transferred; remaining locked tokens
 	// (candidates not chosen by CollectRBTTokens) are then released back to Free.
@@ -290,8 +294,11 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 		// then release only the non-selected locked tokens (candidates not used in the transfer).
 		// The selected tokens are now status=Transferred so they won't be touched.
 		txSucceeded = true
-		if err := c.w.ReleaseAllLockedRBTTokensForDID(ctx, initiatorDID); err != nil {
+		if err := c.w.ReleaseAllLockedRBTTokensForDID(ctx, initiatorDID, reqID); err != nil {
 			c.log.Error("InitiateTransaction: failed to release non-selected locked tokens", "err", err)
+		}
+		if err := c.w.ReleaseReferenceID(reqID); err != nil {
+			c.log.Error("InitiateTransaction: failed to release reference ID", "err", err)
 		}
 	}
 	/*
@@ -492,4 +499,8 @@ func isTOCTOUConflict(err error) bool {
 func retryBackoff(attempt int) time.Duration {
 	// 50ms → 100ms → 150ms
 	return time.Duration(attempt*50) * time.Millisecond
+}
+
+func retryWithRandomBackoff(attempt int) time.Duration {
+	return time.Duration(attempt*50+rand.Intn(1000)) * time.Millisecond
 }

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -8,8 +8,11 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rubixchain/rubixgoplatform/constants"
 	"github.com/rubixchain/rubixgoplatform/core/consensus"
+	"github.com/rubixchain/rubixgoplatform/core/ipfsport"
 	"github.com/rubixchain/rubixgoplatform/core/model"
+	rubixsync "github.com/rubixchain/rubixgoplatform/core/sync"
 	"github.com/rubixchain/rubixgoplatform/core/wallet"
 	"github.com/rubixchain/rubixgoplatform/types/models"
 	"github.com/rubixchain/rubixgoplatform/util"
@@ -441,6 +444,40 @@ func (c *Core) TransactionSetup() {
 	c.l.AddRoute(APISyncTransactionChain, "POST", c.SyncTransactionChain)
 }
 
+// This function has been added here since the other corresponding sync functions has not been added yet.
+// Once the other sync functions and all are added, we can move this along with that.
+func (c *Core) syncTransactionTokens(
+	peer *ipfsport.Peer,
+	tokens *models.TransactionTokens,
+	NFTOwnershipTransfer bool,
+) error {
+
+	tokenGroups := map[string][]*models.TokenInfo{
+		constants.TokenType_RBT: tokens.RBT,
+		constants.TokenType_FT:  tokens.FT,
+	}
+
+	// Add NFT only if flag is true
+	if NFTOwnershipTransfer {
+		tokenGroups[constants.TokenType_NFT] = tokens.NFT
+	}
+
+	for tokenTypeStr, group := range tokenGroups {
+		tokenType := models.GetTokenTypeID(tokenTypeStr)
+		for _, token := range group {
+			if token == nil {
+				continue
+			}
+			//Handling the response in the future.
+			err, _ := rubixsync.SyncTransactionChainFrom(peer, token.TokenID, tokenType, c.w, c.log)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
 
 func (c *Core) SendTokens(request *ensweb.Request) *ensweb.Result {
 	crep := model.BasicResponse{Status: false}

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -441,6 +441,7 @@ func (c *Core) sendTokensToReceiver(
 // Can be refactored in the future
 func (c *Core) TransactionSetup() {
 	c.l.AddRoute(APISendTokens, "POST", c.SendTokens)
+	c.l.AddRoute(APISyncTransactionChain, "POST", c.SyncTransactionChain)
 }
 
 // This function has been added here since the other corresponding sync functions has not been added yet.

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -365,8 +365,20 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 		c.log.Error("InitiateTransaction: Failed to publish transaction", "err", err)
 	}
 
-	// Send tokens to receiver asynchronously in background
-	go c.sendTokensToReceiver(nextOwnerDID, transactionId, transactionInfo, signatureTobePublished, request)
+	asyncMode := false
+
+	if asyncMode {
+		go c.sendTokensToReceiver(nextOwnerDID, transactionId, transactionInfo, signatureTobePublished, request)
+	} else {
+		err := c.sendTokensToReceiverSync(nextOwnerDID, transactionId, transactionInfo, signatureTobePublished, request)
+		if err != nil {
+			c.log.Error("InitiateTransaction: receiver sync failed", "err", err)
+
+			resp.Status = false
+			resp.Message = "Transaction failed: receiver sync failed: " + err.Error()
+			return resp
+		}
+	}
 
 	// Return immediately - receiver sync happens in background
 	resp.Status = true
@@ -435,6 +447,80 @@ func (c *Core) sendTokensToReceiver(
 	c.log.Info("sendTokensToReceiver: Receiver sync completed successfully",
 		"receiver", receiverDID,
 		"transactionID", transactionID)
+}
+
+// sendTokensToReceiver sends transaction tokens to the receiver synchronously.
+// This function is designed avoid running as a goroutine and handles all errors externally.
+// It will block or fail the main transaction flow.
+func (c *Core) sendTokensToReceiverSync(
+	receiverDID string,
+	transactionID string,
+	txInfo *models.TransactionInfo,
+	signature *models.Signature,
+	request *models.TransactionRequest,
+) error {
+	c.log.Debug("sendTokensToReceiver: Starting async receiver sync",
+		"receiver", receiverDID,
+		"transactionID", transactionID)
+
+	// Get receiver peer connection
+	receiverPeer, err := c.getPeer(receiverDID)
+	if err != nil {
+		c.log.Warn("sendTokensToReceiver: Receiver offline, will sync later",
+			"receiver", receiverDID,
+			"transactionID", transactionID,
+			"err", err)
+		return fmt.Errorf("sendTokensToReceiver: Receiver offline, will sync later ",
+			" receiver: ", receiverDID,
+			" transactionID: ", transactionID,
+			" err: ", err)
+	}
+	defer receiverPeer.Close()
+
+	// Prepare sync request
+	// For smartcontracts we need not send the token information to the receiver, we just need to publish it.
+	// For NFTs we need to check the particular boolean in the request for sending.
+	// For RBTs we need to send the entire token information.
+	var sendTokensRequest models.SendTokensRequest
+	var sendTokensResponse model.BasicResponse
+	sendTokensRequest.Tokens = txInfo.Tokens
+	sendTokensRequest.TransactionInfo = txInfo
+	sendTokensRequest.Signature = signature
+	if request.HasNFT() {
+		sendTokensRequest.NFTOwnershipTransfer = request.Tokens.TransferNFTOwnership
+	}
+
+	// Send tokens to receiver with 2-minute timeout
+	// SendJSONRequest has built-in retry logic (3 attempts with exponential backoff)
+	err = receiverPeer.SendJSONRequest(
+		"POST",
+		APISendTokens,
+		nil,
+		&sendTokensRequest,
+		&sendTokensResponse,
+		true,
+		2*time.Minute, // Timeout for the entire operation
+	)
+
+	if err != nil {
+		c.log.Warn("sendTokensToReceiver: Failed to sync tokens to receiver (will retry later)",
+			"receiver", receiverDID,
+			"transactionID", transactionID,
+			"err", err)
+		return fmt.Errorf("sendTokensToReceiver: Failed to sync tokens to receiver (will retry later)",
+			" receiver: ", receiverDID,
+			" transactionID: ", transactionID,
+			" err: ", err)
+	}
+	if !sendTokensResponse.Status {
+		return fmt.Errorf("receiver rejected: %s", sendTokensResponse.Message)
+	}
+
+	c.log.Info("sendTokensToReceiver: Receiver sync completed successfully",
+		"receiver", receiverDID,
+		"transactionID", transactionID)
+
+	return nil
 }
 
 // This has been added here since this is part of the transaction flow.
@@ -511,13 +597,13 @@ func (c *Core) SendTokens(request *ensweb.Request) *ensweb.Result {
 	}
 
 	var syncTokenIDs []string
-	var excludedTrnxIDs []string
+	//var excludedTrnxIDs []string
 	prevTxIDs := make(map[string]string)
 	if txns := sendTokensRequest.TransactionInfo.Tokens; txns != nil {
 		for _, t := range txns.RBT {
 			if t != nil {
 				syncTokenIDs = append(syncTokenIDs, t.TokenID)
-				excludedTrnxIDs = append(excludedTrnxIDs, currentTxID)
+				//excludedTrnxIDs = append(excludedTrnxIDs, currentTxID)
 				if t.PreviousTransactionID != "" {
 					prevTxIDs[t.TokenID] = t.PreviousTransactionID
 				}
@@ -526,7 +612,7 @@ func (c *Core) SendTokens(request *ensweb.Request) *ensweb.Result {
 		for _, t := range txns.FT {
 			if t != nil {
 				syncTokenIDs = append(syncTokenIDs, t.TokenID)
-				excludedTrnxIDs = append(excludedTrnxIDs, currentTxID)
+				//excludedTrnxIDs = append(excludedTrnxIDs, currentTxID)
 				if t.PreviousTransactionID != "" {
 					prevTxIDs[t.TokenID] = t.PreviousTransactionID
 				}
@@ -537,7 +623,7 @@ func (c *Core) SendTokens(request *ensweb.Request) *ensweb.Result {
 			for _, t := range txns.NFT {
 				if t != nil {
 					syncTokenIDs = append(syncTokenIDs, t.TokenID)
-					excludedTrnxIDs = append(excludedTrnxIDs, currentTxID)
+					//excludedTrnxIDs = append(excludedTrnxIDs, currentTxID)
 					if t.PreviousTransactionID != "" {
 						prevTxIDs[t.TokenID] = t.PreviousTransactionID
 					}
@@ -552,7 +638,7 @@ func (c *Core) SendTokens(request *ensweb.Request) *ensweb.Result {
 	// Errors are logged but never break SendTokens — sync is best-effort.
 	if len(syncTokenIDs) > 0 {
 		initiatorDID := sendTokensRequest.TransactionInfo.Initiator
-		if err := c.SyncTransactionChainsFromPeer(initiatorDID, syncTokenIDs, prevTxIDs, excludedTrnxIDs); err != nil {
+		if err := c.SyncTransactionChainsFromPeer(initiatorDID, syncTokenIDs, prevTxIDs, []string{currentTxID}); err != nil {
 			c.log.Warn("SendTokens: chain sync from sender failed (non-fatal)", "initiator", initiatorDID, "err", err)
 		}
 	}

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -503,6 +503,51 @@ func (c *Core) SendTokens(request *ensweb.Request) *ensweb.Result {
 		return c.l.RenderJSON(request, &crep, http.StatusBadRequest)
 	}
 
+	// --- Token chain sync: fill gaps from sender before persisting ---
+	// Collect all token IDs and their PreviousTransactionIDs from the incoming transaction.
+	var syncTokenIDs []string
+	prevTxIDs := make(map[string]string)
+	if txns := sendTokensRequest.TransactionInfo.Tokens; txns != nil {
+		for _, t := range txns.RBT {
+			if t != nil {
+				syncTokenIDs = append(syncTokenIDs, t.TokenID)
+				if t.PreviousTransactionID != "" {
+					prevTxIDs[t.TokenID] = t.PreviousTransactionID
+				}
+			}
+		}
+		for _, t := range txns.FT {
+			if t != nil {
+				syncTokenIDs = append(syncTokenIDs, t.TokenID)
+				if t.PreviousTransactionID != "" {
+					prevTxIDs[t.TokenID] = t.PreviousTransactionID
+				}
+			}
+		}
+		// NFT: only sync if this is an ownership transfer
+		if sendTokensRequest.NFTOwnershipTransfer {
+			for _, t := range txns.NFT {
+				if t != nil {
+					syncTokenIDs = append(syncTokenIDs, t.TokenID)
+					if t.PreviousTransactionID != "" {
+						prevTxIDs[t.TokenID] = t.PreviousTransactionID
+					}
+				}
+			}
+		}
+	}
+
+	// Synchronous/blocking sync from sender (initiator) before we persist.
+	// prevTxIDs allows applyTokenChainFromSync to skip tokens whose chain
+	// tail already matches — avoiding redundant network + DB work.
+	// Errors are logged but never break SendTokens — sync is best-effort.
+	if len(syncTokenIDs) > 0 {
+		initiatorDID := sendTokensRequest.TransactionInfo.Initiator
+		if err := c.SyncTransactionChainsFromPeer(initiatorDID, syncTokenIDs, prevTxIDs); err != nil {
+			c.log.Warn("SendTokens: chain sync from sender failed (non-fatal)", "initiator", initiatorDID, "err", err)
+		}
+	}
+
 	persistErr := c.w.PersistPostConsensus(c.Ctx, &wallet.PostConsensusPersistenceRequest{
 		TransactionInfo:           sendTokensRequest.TransactionInfo,
 		Signature:                 sendTokensRequest.Signature,

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -153,6 +153,51 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 	}
 
 	pledgeTokens := pledgeTokenResponse.PledgeTokens
+
+	// --- PRE-CONSENSUS GUARD ------------------------------------
+
+	if len(pledgeTokens) == 0 {
+		c.log.Debug("InitiateTransaction: no pledge tokens received",
+			"referenceID", reqID,
+			"requiredAmount", transactionValue,
+		)
+
+		resp.Message = "insufficient quorum liquidity"
+		return resp
+	}
+
+	// compute total pledged value
+	var totalPledged float64
+	/* 	for _, t := range pledgeTokens {
+		totalPledged += t.TokenValue
+	} */
+
+	// compute total pledged value (TRUSTLESS — derive from TokenID)
+	for _, t := range pledgeTokens {
+		val, err := util.GetTokenValueFromTokenID(t.TokenID)
+		if err != nil {
+			c.log.Error("InitiateTransaction: invalid token value",
+				"tokenID", t.TokenID,
+				"err", err,
+			)
+			resp.Message = "invalid quorum token"
+			return resp
+		}
+		totalPledged += val
+	}
+
+	if totalPledged < transactionValue {
+		c.log.Debug("InitiateTransaction: insufficient pledged value",
+			"referenceID", reqID,
+			"requiredAmount", transactionValue,
+			"pledgedAmount", totalPledged,
+		)
+
+		resp.Message = "insufficient quorum liquidity"
+		return resp
+	}
+	// ------------------------------------------------------------
+
 	for _, token := range pledgeTokens {
 		err = consensus.ValidateNewTokenContent(token.TokenID, true, c.testnet, c.mainnet, c.localnet, c.log)
 		if err != nil {
@@ -161,12 +206,17 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 			return resp
 		}
 	}
-
-	pledegTokenInfo := &models.QuorumInfo{
-		Did:    quorumAddresses[0],
-		Tokens: pledgeTokens,
+	//Harden quorum assignment
+	if len(pledgeTokens) > 0 {
+		pledegTokenInfo := &models.QuorumInfo{
+			Did:    quorumAddresses[0],
+			Tokens: pledgeTokens,
+		}
+		transactionInfo.Quorums = []*models.QuorumInfo{pledegTokenInfo}
+	} else {
+		resp.Message = "insufficient quorum liquidity"
+		return resp
 	}
-	transactionInfo.Quorums = []*models.QuorumInfo{pledegTokenInfo}
 	transactionId, err := util.GetTransactionID(transactionInfo)
 	if err != nil {
 		c.log.Error("InitiateTransaction: Failed to get transaction ID", "err", err)

--- a/core/transaction_builder.go
+++ b/core/transaction_builder.go
@@ -33,6 +33,7 @@ func BuildTransactionInfoFromRequest(
 	networkMode string, // The isTestNet bool changed to networkMode string to be passed to CollectRBTTokens
 	log logger.Logger,
 	pubsub *types.PubSub, // punishFn which was of type func(*model.PubSubTxnInfo)  is change to types.PubSub to be passed to CollectRBTTokens
+	referenceID string, // referenceID is added to be passed to LockTokensForSplit and CollectRBTTokens for better traceability of locked tokens
 ) (*models.TransactionInfo, float64, error) {
 
 	txTokens := &models.TransactionTokens{}
@@ -41,7 +42,7 @@ func BuildTransactionInfoFromRequest(
 	// --- RBT path (separate — CollectRBTTokens manages its own locking) ---
 	if req.HasRBT() {
 		ownerDID := dc.GetDID()
-		ownedRBTTokens, err := w.LockTokensForSplit(ctx, ownerDID, req.GetRBTAmount())
+		ownedRBTTokens, err := w.LockTokensForSplit(ctx, ownerDID, req.GetRBTAmount(), referenceID)
 		if err != nil {
 			return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest: lock RBT tokens for split: %w", err)
 		}

--- a/core/unpledge_v2.go
+++ b/core/unpledge_v2.go
@@ -52,14 +52,33 @@ func (c *Core) UnpledgeV2(
 	var pledgeTokens []string
 	var epoch int
 	err := c.w.Pool().QueryRow(ctx,
-		`SELECT pledge_tokens, epoch FROM unpledge_sequence_info WHERE tx_id = $1`,
-		mainTxID,
+		`SELECT pledge_tokens, epoch FROM unpledge_sequence_info WHERE tx_id = $1 AND quorum_did = $2`,
+		mainTxID, quorumDID,
 	).Scan(&pledgeTokens, &epoch)
 	if err != nil {
 		if err == pgx.ErrNoRows {
-			// Already unpledged or never pledged via V2 — idempotent success.
-			c.log.Info("UnpledgeV2: no unpledge_sequence_info row — skip (already unpledged or not pledged via V2)",
-				"mainTxID", mainTxID)
+			// Either no row exists (idempotent success — already unpledged or
+			// never pledged via V2), OR a row exists but is owned by a different
+			// quorum DID (mismatch — audit and hard skip). Distinguish the two
+			// cases with a second query so the mismatch is not swallowed silently.
+			var owner string
+			qerr := c.w.Pool().QueryRow(ctx,
+				`SELECT quorum_did FROM unpledge_sequence_info WHERE tx_id = $1`,
+				mainTxID,
+			).Scan(&owner)
+			if qerr == pgx.ErrNoRows {
+				c.log.Info("UnpledgeV2: no unpledge_sequence_info row — skip (already unpledged or not pledged via V2)",
+					"mainTxID", mainTxID)
+				return nil
+			}
+			if qerr != nil {
+				return fmt.Errorf("UnpledgeV2: ownership-check query unpledge_sequence_info for mainTxID %q: %w", mainTxID, qerr)
+			}
+			// Row exists but belongs to a different quorum — defense-in-depth catch.
+			msg := fmt.Sprintf("UnpledgeV2: quorum ownership mismatch — skip mainTxID=%s caller_did=%s row_owner=%s",
+				mainTxID, quorumDID, owner)
+			c.log.Warn(msg)
+			c.writeUnpledgeMismatch(msg)
 			return nil
 		}
 		return fmt.Errorf("UnpledgeV2: query unpledge_sequence_info for mainTxID %q: %w", mainTxID, err)
@@ -101,6 +120,35 @@ func (c *Core) UnpledgeV2(
 			// Non-fatal: the tokens are free; return nil.
 		}
 		return nil
+	}
+
+	// --- Chain-progress guard ------------------------------------------------
+	// Unpledge is legitimate only when the pledged tokens have been consumed
+	// by a downstream transaction — i.e. at least one tokenchain row exists
+	// whose token_id is in pledge_tokens AND previous_transaction_id = mainTxID.
+	// Without this, UnpledgeV2 would fire purely on the existence of an
+	// unpledge_sequence_info row (premature unpledge). On mismatch: audit log
+	// and hard skip (return nil). Do NOT error — the caller's loop continues
+	// processing siblings.
+	{
+		var dummy int
+		err := c.w.Pool().QueryRow(ctx, `
+			SELECT 1
+			FROM tokenchain
+			WHERE token_id = ANY($1::text[])
+			  AND previous_transaction_id = $2
+			LIMIT 1
+		`, pledgeTokens, mainTxID).Scan(&dummy)
+		if err == pgx.ErrNoRows {
+			msg := fmt.Sprintf("UnpledgeV2: chain-progress guard fail — no successor tokenchain row; skip mainTxID=%s quorumDID=%s pledgeTokens=%v",
+				mainTxID, quorumDID, pledgeTokens)
+			c.log.Warn(msg)
+			c.writeUnpledgeMismatch(msg)
+			return nil
+		}
+		if err != nil {
+			return fmt.Errorf("UnpledgeV2: chain-progress guard query for mainTxID %q: %w", mainTxID, err)
+		}
 	}
 
 	// --- Atomic unpledge: UPDATE tokenchain + UPDATE tokens in one tx -----------

--- a/core/unpledge_v2.go
+++ b/core/unpledge_v2.go
@@ -122,35 +122,6 @@ func (c *Core) UnpledgeV2(
 		return nil
 	}
 
-	// --- Chain-progress guard ------------------------------------------------
-	// Unpledge is legitimate only when the pledged tokens have been consumed
-	// by a downstream transaction — i.e. at least one tokenchain row exists
-	// whose token_id is in pledge_tokens AND previous_transaction_id = mainTxID.
-	// Without this, UnpledgeV2 would fire purely on the existence of an
-	// unpledge_sequence_info row (premature unpledge). On mismatch: audit log
-	// and hard skip (return nil). Do NOT error — the caller's loop continues
-	// processing siblings.
-	{
-		var dummy int
-		err := c.w.Pool().QueryRow(ctx, `
-			SELECT 1
-			FROM tokenchain
-			WHERE token_id = ANY($1::text[])
-			  AND previous_transaction_id = $2
-			LIMIT 1
-		`, pledgeTokens, mainTxID).Scan(&dummy)
-		if err == pgx.ErrNoRows {
-			msg := fmt.Sprintf("UnpledgeV2: chain-progress guard fail — no successor tokenchain row; skip mainTxID=%s quorumDID=%s pledgeTokens=%v",
-				mainTxID, quorumDID, pledgeTokens)
-			c.log.Warn(msg)
-			c.writeUnpledgeMismatch(msg)
-			return nil
-		}
-		if err != nil {
-			return fmt.Errorf("UnpledgeV2: chain-progress guard query for mainTxID %q: %w", mainTxID, err)
-		}
-	}
-
 	// --- Atomic unpledge: UPDATE tokenchain + UPDATE tokens in one tx -----------
 	unpledgeRoleID := int16(models.GetTokenRoleID(constants.TokenRole_Unpledge))
 	pledgeRoleID := int16(models.GetTokenRoleID(constants.TokenRole_Pledge))

--- a/core/unpledge_v2.go
+++ b/core/unpledge_v2.go
@@ -3,6 +3,9 @@ package core
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
+	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/rubixchain/rubixgoplatform/constants"
@@ -257,4 +260,33 @@ func (c *Core) unpledgeSingleTokenV2(
 	}
 
 	return nil
+}
+
+// writeUnpledgeMismatch appends a single-line audit record to
+// unpledge_mismatch.log in the node config directory. Lazy-initialized on
+// first call via sync.Once — most nodes will never hit a mismatch, so we
+// avoid opening the file at startup. Writes are serialized via a mutex
+// because os.File.Write is not safe for concurrent callers.
+//
+// This function never returns an error and never panics: audit logging must
+// not crash the node. On open failure, the event is still visible via c.log.
+func (c *Core) writeUnpledgeMismatch(line string) {
+	c.unpledgeAuditLogOnce.Do(func() {
+		path := filepath.Join(c.cfg.NodeConfigDir, "unpledge_mismatch.log")
+		fp, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err != nil {
+			c.log.Error("writeUnpledgeMismatch: failed to open audit log",
+				"path", path, "err", err)
+			return
+		}
+		c.unpledgeAuditLog = fp
+	})
+	if c.unpledgeAuditLog == nil {
+		return
+	}
+	c.unpledgeAuditLogMu.Lock()
+	defer c.unpledgeAuditLogMu.Unlock()
+	_, _ = c.unpledgeAuditLog.WriteString(
+		time.Now().UTC().Format(time.RFC3339Nano) + " " + line + "\n",
+	)
 }

--- a/core/wallet/did.go
+++ b/core/wallet/did.go
@@ -8,6 +8,7 @@ import (
 )
 
 func (w *Wallet) CreateOrUpdateDID(didInfo *models.DID) error {
+	w.log.Debug("Adding to dids -", didInfo.DID, "peerid ", didInfo.PeerID, " isLocal:", didInfo.Local)
 	if _, err := w.db.Pool().Exec(w.Ctx, `
 		INSERT INTO dids(did, peer_id, local, algo_id)
 		VALUES ($1, $2, $3, $4)

--- a/core/wallet/ft_stubs.go
+++ b/core/wallet/ft_stubs.go
@@ -290,9 +290,14 @@ func (w *Wallet) UpdateFullNodeTransactionHistoryTable(t *model.FullNodeTxnHisto
 }
 
 // GetLatestTransactionID returns the latest transaction ID for a given token.
-// TODO(phase11-upstream): implement using PostgreSQL tokens.transaction_id lookup.
+// Delegates to GetLatestTransactionAndRoleByTokenID which queries tokenchain
+// ordered by position DESC LIMIT 1. Returns "" if the token has no chain entries.
 func (w *Wallet) GetLatestTransactionID(tokenID string) string {
-	return ""
+	tx, _, err := w.GetLatestTransactionAndRoleByTokenID(tokenID)
+	if err != nil || tx == nil {
+		return ""
+	}
+	return tx.ID
 }
 
 // GetTransactions returns serialized transactions for a token starting from a given transactionID.

--- a/core/wallet/pledge.go
+++ b/core/wallet/pledge.go
@@ -460,17 +460,20 @@ func (w *Wallet) UnpledgeTokens(prevTransactionId string, transaction *models.Tr
 	return nil
 }
 
-// CheckTxnsPresentInUnpledgeSequenceInfo checks if the provided transactions are
-// present in the `unpledge_sequence_info` table or not. If they are, they are returned back
-func (w *Wallet) CheckTxnsPresentInUnpledgeSequenceInfo(txs []string) ([]string, error) {
+// CheckTxnsPresentInUnpledgeSequenceInfo checks if the provided transactions
+// are present in the `unpledge_sequence_info` table AND are owned by the
+// given quorum DID (outer ownership gate — defense-in-depth with UnpledgeV2's
+// inner gate). Returns only tx_ids whose quorum_did column matches.
+func (w *Wallet) CheckTxnsPresentInUnpledgeSequenceInfo(txs []string, quorumDID string) ([]string, error) {
 	rows, err := w.db.Pool().Query(
 		w.Ctx,
 		`
         SELECT tx_id
         FROM unpledge_sequence_info
         WHERE tx_id = ANY($1::TEXT[])
+          AND quorum_did = $2
         `,
-		txs,
+		txs, quorumDID,
 	)
 	if err != nil {
 		return nil, err

--- a/core/wallet/post_consensus_payload_builder.go
+++ b/core/wallet/post_consensus_payload_builder.go
@@ -95,7 +95,7 @@ func (w *Wallet) BuildPersistencePayload(ctx context.Context, transactionID stri
 				tokenTypeID = models.GetTokenTypeID(constants.TokenType_RBT)
 			}
 			currentToken = models.Token{
-				TokenID:   input.TokenID,
+				TokenID:    input.TokenID,
 				TokenValue: tokenValue,
 				TokenType:  int16(tokenTypeID),
 			}
@@ -116,6 +116,21 @@ func (w *Wallet) BuildPersistencePayload(ctx context.Context, transactionID stri
 		}
 
 		state := currentToken
+		if state.TokenValue == 0 {
+			tokenValue := input.TokenValue
+
+			if tokenValue == 0 {
+				if derived, err := util.GetTokenValueFromTokenID(input.TokenID); err == nil && derived > 0 {
+					tokenValue = derived
+				}
+			}
+
+			if tokenValue == 0 {
+				return nil, nil, nil, fmt.Errorf("post-consensus persistence: cannot determine token value for token %q", input.TokenID)
+			}
+
+			state.TokenValue = tokenValue
+		}
 		state.TransactionID = transactionID
 		state.LatestPosition = position
 		state.LatestRole = int16(roleID)

--- a/core/wallet/post_consensus_persistence.go
+++ b/core/wallet/post_consensus_persistence.go
@@ -201,7 +201,6 @@ func buildTransactionRecordFromPayload(txInfo *models.TransactionInfo, signature
 	}, nil
 }
 
-
 func validatePostConsensusRequest(req *PostConsensusPersistenceRequest, transactionID string) error {
 	if req == nil {
 		return fmt.Errorf("post-consensus persistence: request is nil")
@@ -378,9 +377,11 @@ func (pc *PostConsensusPersistenceCoordinator) validateTransferChainContinuity(c
 			return fmt.Errorf("transfer: query token %q: %w", row.TokenID, err)
 		}
 
-		if dbDID != req.DID {
-			return fmt.Errorf("transfer: token %q not owned by %s", row.TokenID, req.DID)
-		}
+		/*
+			if dbDID != req.DID {
+				return fmt.Errorf("transfer: token %q not owned by %s", row.TokenID, req.DID)
+			}
+		*/
 
 		// Initiator/Quorum: token must be Free or Locked (Locked by LockTokensForSplit before consensus).
 		// Receiver: token must be Free, Locked, or Transferred. Transferred covers the case where

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -65,6 +65,33 @@ func (w *Wallet) GetFreeRBTTokens(ownerDid string) ([]models.Token, []string, er
 	return freeTokens, freeTokenIDs, nil
 }
 
+// GetFreeRBTBalanceByDID returns the total token_value of all free RBT tokens
+// owned by the given DID. Returns 0.0 if no free RBT tokens exist for the DID.
+//
+// This helper MUST match the filter semantics used by LockTokensForSplit so
+// that the resulting balance reflects exactly what the locker would see:
+//   - token_type = RBT
+//   - token_status = Free
+//   - did = <arg>
+//
+// Used by requestPledgeTokenHandler as a cheap pre-check to avoid calling
+// LockTokensForSplit when the quorum clearly cannot satisfy the request.
+func (w *Wallet) GetFreeRBTBalanceByDID(did string) (float64, error) {
+	var balance float64
+	err := w.db.Pool().QueryRow(w.Ctx,
+		`SELECT COALESCE(SUM(token_value), 0)
+		 FROM tokens
+		 WHERE did = $1
+		   AND token_type = (SELECT id FROM token_type WHERE name = $2)
+		   AND token_status = $3`,
+		did, constants.TokenType_RBT, constants.TokenStatus_Free,
+	).Scan(&balance)
+	if err != nil {
+		return 0, fmt.Errorf("GetFreeRBTBalanceByDID: %w", err)
+	}
+	return balance, nil
+}
+
 func (w *Wallet) GetTokenByTokenID(tokenID string) (models.Token, error) {
 	row := w.db.Pool().QueryRow(w.Ctx,
 		`SELECT token_id, parent_token_id, token_value, token_status, did, transaction_id,

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -422,20 +422,28 @@ func (w *Wallet) GetTokenLockReferenceIDs(ctx context.Context, tokenIDs []string
 	return out, nil
 }
 
-// ReleaseTokens sets the status of a slice of tokens back to Free (unlocked).
+// ReleaseTokens sets the status of a slice of tokens back to Free (unlocked),
+// scoped to the provided referenceID so it cannot accidentally free tokens
+// belonging to a concurrent request with a different lock_reference_id.
 // It accepts the same []*models.TokenInfo slice returned by CollectRBTTokens.
 // This is a best-effort operation: errors are logged but do not abort the loop.
-func (w *Wallet) ReleaseTokens(tokens []*models.TokenInfo) {
+// If referenceID is empty the function is a no-op to guard against unscoped calls.
+func (w *Wallet) ReleaseTokens(tokens []*models.TokenInfo, referenceID string) {
+	if referenceID == "" {
+		w.log.Warn("ReleaseTokens: called with empty referenceID; refusing to release", "tokenCount", len(tokens))
+		return
+	}
 	for _, t := range tokens {
 		if t == nil || t.TokenID == "" {
 			continue
 		}
 		if _, err := w.db.Pool().Exec(w.Ctx,
-			`UPDATE tokens SET token_status=$1, lock_reference_id=NULL WHERE token_id=$2`,
-			constants.TokenStatus_Free, t.TokenID,
+			`UPDATE tokens SET token_status=$1, lock_reference_id=NULL
+			 WHERE token_id=$2 AND lock_reference_id=$3`,
+			constants.TokenStatus_Free, t.TokenID, referenceID,
 		); err != nil {
 			// Log but do not propagate — release is best-effort
-			_ = fmt.Errorf("ReleaseTokens: failed to release token %s: %w", t.TokenID, err)
+			w.log.Warn("ReleaseTokens: failed to release token", "tokenID", t.TokenID, "err", err)
 		}
 	}
 }

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -392,6 +392,36 @@ func (w *Wallet) ReleaseNonSelectedLockedRBTTokensForDID(ctx context.Context, ow
 	return err
 }
 
+// GetTokenLockReferenceIDs returns a map token_id -> lock_reference_id for the
+// given token IDs. A nil string pointer means the row exists but lock_reference_id
+// IS NULL. Missing keys mean the token row does not exist in the DB.
+func (w *Wallet) GetTokenLockReferenceIDs(ctx context.Context, tokenIDs []string) (map[string]*string, error) {
+	if len(tokenIDs) == 0 {
+		return map[string]*string{}, nil
+	}
+	rows, err := w.db.Pool().Query(ctx,
+		`SELECT token_id, lock_reference_id FROM tokens WHERE token_id = ANY($1::text[])`,
+		tokenIDs,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("GetTokenLockReferenceIDs: query: %w", err)
+	}
+	defer rows.Close()
+	out := make(map[string]*string, len(tokenIDs))
+	for rows.Next() {
+		var id string
+		var ref *string
+		if err := rows.Scan(&id, &ref); err != nil {
+			return nil, fmt.Errorf("GetTokenLockReferenceIDs: scan: %w", err)
+		}
+		out[id] = ref
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("GetTokenLockReferenceIDs: iter: %w", err)
+	}
+	return out, nil
+}
+
 // ReleaseTokens sets the status of a slice of tokens back to Free (unlocked).
 // It accepts the same []*models.TokenInfo slice returned by CollectRBTTokens.
 // This is a best-effort operation: errors are logged but do not abort the loop.

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -361,29 +361,33 @@ func (w *Wallet) GetAllPinnedTokens(did string) ([]models.Token, error) {
 // ReleaseAllLockedRBTTokensForDID resets all Locked RBT tokens for a DID back to Free.
 // Called on transaction failure after LockTokensForSplit to prevent tokens from staying
 // permanently locked when the transaction does not complete.
-func (w *Wallet) ReleaseAllLockedRBTTokensForDID(ctx context.Context, ownerDID string) error {
+func (w *Wallet) ReleaseAllLockedRBTTokensForDID(ctx context.Context, ownerDID string, referenceId string) error {
 	_, err := w.db.Pool().Exec(ctx,
-		`UPDATE tokens SET token_status=$1, updated_at=$2
-		 WHERE did=$3
-		   AND token_status=$4
-		   AND token_type=(SELECT id FROM token_type WHERE name=$5)`,
-		constants.TokenStatus_Free, time.Now(), ownerDID, constants.TokenStatus_Locked, constants.TokenType_RBT,
+		`UPDATE tokens SET token_status=$1, updated_at=$2, lock_reference_id=NULL
+		 WHERE did=$4
+		   AND token_status=$5
+		   AND lock_reference_id=$3
+		   AND token_type=(SELECT id FROM token_type WHERE name=$6)`,
+		constants.TokenStatus_Free, time.Now(), referenceId, ownerDID, constants.TokenStatus_Locked, constants.TokenType_RBT,
 	)
 	return err
 }
 
 // ReleaseNonSelectedLockedRBTTokensForDID resets all Locked RBT tokens for a DID back to Free,
-// EXCLUDING the specified selectedTokenIDs. Used by the quorum pledge handler to release
-// candidate tokens that were locked by LockTokensForSplit but not chosen for the pledge,
-// while keeping the selected pledge tokens Locked so PledgeTokens can transition them to Pledged.
-func (w *Wallet) ReleaseNonSelectedLockedRBTTokensForDID(ctx context.Context, ownerDID string, selectedTokenIDs []string) error {
+// EXCLUDING the specified selectedTokenIDs, scoped to the given referenceID so that concurrent
+// pledge requests for the same DID cannot accidentally free each other's locked tokens.
+// Used by the quorum pledge handler to release candidate tokens that were locked by
+// LockTokensForSplit but not chosen for the pledge, while keeping the selected pledge
+// tokens Locked so PledgeTokens can transition them to Pledged.
+func (w *Wallet) ReleaseNonSelectedLockedRBTTokensForDID(ctx context.Context, ownerDID string, selectedTokenIDs []string, referenceID string) error {
 	_, err := w.db.Pool().Exec(ctx,
-		`UPDATE tokens SET token_status=$1, updated_at=$2
+		`UPDATE tokens SET token_status=$1, updated_at=$2, lock_reference_id=NULL
 		 WHERE did=$3
 		   AND token_status=$4
-		   AND token_type=(SELECT id FROM token_type WHERE name=$5)
-		   AND token_id != ALL($6::text[])`,
-		constants.TokenStatus_Free, time.Now(), ownerDID, constants.TokenStatus_Locked, constants.TokenType_RBT, selectedTokenIDs,
+		   AND lock_reference_id=$5
+		   AND token_type=(SELECT id FROM token_type WHERE name=$6)
+		   AND token_id != ALL($7::text[])`,
+		constants.TokenStatus_Free, time.Now(), ownerDID, constants.TokenStatus_Locked, referenceID, constants.TokenType_RBT, selectedTokenIDs,
 	)
 	return err
 }
@@ -397,13 +401,29 @@ func (w *Wallet) ReleaseTokens(tokens []*models.TokenInfo) {
 			continue
 		}
 		if _, err := w.db.Pool().Exec(w.Ctx,
-			`UPDATE tokens SET token_status=$1 WHERE token_id=$2`,
+			`UPDATE tokens SET token_status=$1, lock_reference_id=NULL WHERE token_id=$2`,
 			constants.TokenStatus_Free, t.TokenID,
 		); err != nil {
 			// Log but do not propagate — release is best-effort
 			_ = fmt.Errorf("ReleaseTokens: failed to release token %s: %w", t.TokenID, err)
 		}
 	}
+}
+
+// ReleaseTokens sets the status of a slice of tokens back to Free (unlocked).
+// It accepts the same []*models.TokenInfo slice returned by CollectRBTTokens.
+// This is a best-effort operation: errors are logged but do not abort the loop.
+func (w *Wallet) ReleaseReferenceID(referenceId string) error {
+
+	if _, err := w.db.Pool().Exec(w.Ctx,
+		`UPDATE tokens SET lock_reference_id=NULL WHERE lock_reference_id=$1`,
+		referenceId,
+	); err != nil {
+		// Log but do not propagate — release is best-effort
+		_ = fmt.Errorf("ReleaseReferenceID: failed to release tokens for reference ID %s: %w", referenceId, err)
+		return fmt.Errorf("ReleaseReferenceID: failed to release tokens for reference ID %s: %w", referenceId, err)
+	}
+	return nil
 }
 
 func (w *Wallet) IsDIDExist(did string) bool {

--- a/core/wallet/token_chain.go
+++ b/core/wallet/token_chain.go
@@ -340,6 +340,42 @@ func (w *Wallet) AddTokenChainEntry(entry *models.TokenChain) error {
 	return nil
 }
 
+// ApplyTokenChainBatch atomically inserts a batch of tokenchain entries for a
+// single token and rebuilds its tokenchain_index. All inserts happen inside a
+// single DB transaction — a partial crash rolls back every row, leaving the
+// chain consistent.
+//
+// Follows the PersistGenesisBatch pattern: BeginTx -> loop Exec -> batchUpsertTokenChainIndex -> Commit.
+func (w *Wallet) ApplyTokenChainBatch(ctx context.Context, tokenID string, entries []*models.TokenChain) error {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	tx, err := w.BeginTx(ctx)
+	if err != nil {
+		return fmt.Errorf("ApplyTokenChainBatch: begin tx: %w", err)
+	}
+	defer tx.Rollback(ctx) //nolint:errcheck
+
+	for i, entry := range entries {
+		if _, err := tx.Exec(ctx,
+			`INSERT INTO tokenchain (token_id, transaction_id, previous_transaction_id, role, position, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+			 ON CONFLICT (token_id, position) DO NOTHING`,
+			entry.TokenID, entry.TransactionID, entry.PreviousTransactionID, entry.Role, entry.Position,
+		); err != nil {
+			return fmt.Errorf("ApplyTokenChainBatch: entry[%d] txID=%s: %w", i, entry.TransactionID, err)
+		}
+	}
+
+	// Rebuild tokenchain_index for this token within the same transaction.
+	if err := w.batchUpsertTokenChainIndex(ctx, tx, []string{tokenID}); err != nil {
+		return fmt.Errorf("ApplyTokenChainBatch: upsert tokenchain_index: %w", err)
+	}
+
+	return tx.Commit(ctx)
+}
+
 func (w *Wallet) GetTransactionAndRoleAtHeight(tokenID string, height int64) (*models.Transactions, int16, error) {
 	row := w.db.Pool().QueryRow(w.Ctx, `
 		SELECT transaction_id,role FROM tokenchain WHERE token_id = $1 AND position = $2

--- a/core/wallet/token_chain.go
+++ b/core/wallet/token_chain.go
@@ -345,34 +345,113 @@ func (w *Wallet) AddTokenChainEntry(entry *models.TokenChain) error {
 // single DB transaction — a partial crash rolls back every row, leaving the
 // chain consistent.
 //
-// Follows the PersistGenesisBatch pattern: BeginTx -> loop Exec -> batchUpsertTokenChainIndex -> Commit.
+// Safety properties enforced:
+//  1. pg_advisory_xact_lock serializes concurrent callers for the same tokenID.
+//  2. SELECT FOR UPDATE on the current tail prevents concurrent appends.
+//  3. Cross-batch boundary check: entries[0].PreviousTransactionID must match DB tail txID.
+//  4. Within-batch continuity: entries[i].PreviousTransactionID must equal entries[i-1].TransactionID.
+//  5. Canonical positions are recomputed from the DB tail — caller-supplied positions are ignored.
+//  6. INSERT ON CONFLICT DO NOTHING with RowsAffected check: same txID at same position is idempotent;
+//     different txID at same position returns a fork error.
+//  7. batchUpsertTokenChainIndex is called only when at least one new row was inserted.
+//  8. Any error causes full transaction rollback with zero partial writes.
 func (w *Wallet) ApplyTokenChainBatch(ctx context.Context, tokenID string, entries []*models.TokenChain) error {
 	if len(entries) == 0 {
 		return nil
 	}
 
+	// Step 1: Begin transaction.
 	tx, err := w.BeginTx(ctx)
 	if err != nil {
 		return fmt.Errorf("ApplyTokenChainBatch: begin tx: %w", err)
 	}
 	defer tx.Rollback(ctx) //nolint:errcheck
 
-	for i, entry := range entries {
-		if _, err := tx.Exec(ctx,
-			`INSERT INTO tokenchain (token_id, transaction_id, previous_transaction_id, role, position, created_at, updated_at)
-			 VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
-			 ON CONFLICT (token_id, position) DO NOTHING`,
-			entry.TokenID, entry.TransactionID, entry.PreviousTransactionID, entry.Role, entry.Position,
-		); err != nil {
-			return fmt.Errorf("ApplyTokenChainBatch: entry[%d] txID=%s: %w", i, entry.TransactionID, err)
+	// Step 2: Acquire advisory lock to serialize concurrent callers for this token.
+	if _, err := tx.Exec(ctx, `SELECT pg_advisory_xact_lock(hashtext($1))`, tokenID); err != nil {
+		return fmt.Errorf("ApplyTokenChainBatch: advisory lock for token %s: %w", tokenID, err)
+	}
+
+	// Step 3: Row lock + read tail — get the current chain tip with FOR UPDATE.
+	var basePosition int64 = -1
+	var lastTxID string
+	hasTail := true
+	err = tx.QueryRow(ctx,
+		`SELECT position, transaction_id FROM tokenchain WHERE token_id = $1 ORDER BY position DESC LIMIT 1 FOR UPDATE`,
+		tokenID,
+	).Scan(&basePosition, &lastTxID)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			hasTail = false
+			basePosition = -1
+		} else {
+			return fmt.Errorf("ApplyTokenChainBatch: fetch tail for token %s: %w", tokenID, err)
 		}
 	}
 
-	// Rebuild tokenchain_index for this token within the same transaction.
-	if err := w.batchUpsertTokenChainIndex(ctx, tx, []string{tokenID}); err != nil {
-		return fmt.Errorf("ApplyTokenChainBatch: upsert tokenchain_index: %w", err)
+	// Step 4: Cross-batch boundary check.
+	if hasTail {
+		if entries[0].PreviousTransactionID == nil {
+			return fmt.Errorf("ApplyTokenChainBatch: chain boundary mismatch for token %s: position > 0 requires a previous txID but got nil", tokenID)
+		}
+		if *entries[0].PreviousTransactionID != lastTxID {
+			return fmt.Errorf("ApplyTokenChainBatch: chain boundary mismatch for token %s: expected previous txID %s, got %s", tokenID, lastTxID, *entries[0].PreviousTransactionID)
+		}
 	}
 
+	// Step 5: Within-batch continuity check (for entries beyond the first).
+	for i := 1; i < len(entries); i++ {
+		prevTxID := "<nil>"
+		if entries[i].PreviousTransactionID != nil {
+			prevTxID = *entries[i].PreviousTransactionID
+		}
+		if entries[i].PreviousTransactionID == nil || *entries[i].PreviousTransactionID != entries[i-1].TransactionID {
+			return fmt.Errorf("ApplyTokenChainBatch: invalid chain continuity at index %d for token %s: expected %s, got %s", i, tokenID, entries[i-1].TransactionID, prevTxID)
+		}
+	}
+
+	// Step 6: Canonical position recomputation + conflict-aware INSERT loop.
+	inserted := false
+	for i, entry := range entries {
+		canonicalPos := basePosition + int64(i) + 1
+		entry.Position = canonicalPos
+
+		cmdTag, err := tx.Exec(ctx,
+			`INSERT INTO tokenchain (token_id, transaction_id, previous_transaction_id, role, position, created_at, updated_at)
+			 VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+			 ON CONFLICT (token_id, position) DO NOTHING`,
+			entry.TokenID, entry.TransactionID, entry.PreviousTransactionID, entry.Role, canonicalPos,
+		)
+		if err != nil {
+			return fmt.Errorf("ApplyTokenChainBatch: insert entry[%d] txID=%s for token %s: %w", i, entry.TransactionID, tokenID, err)
+		}
+
+		if cmdTag.RowsAffected() == 0 {
+			// Conflict: another row already exists at this position.
+			var storedTxID string
+			if err := tx.QueryRow(ctx,
+				`SELECT transaction_id FROM tokenchain WHERE token_id = $1 AND position = $2`,
+				tokenID, canonicalPos,
+			).Scan(&storedTxID); err != nil {
+				return fmt.Errorf("ApplyTokenChainBatch: resolve conflict at position %d for token %s: %w", canonicalPos, tokenID, err)
+			}
+			if storedTxID != entry.TransactionID {
+				return fmt.Errorf("ApplyTokenChainBatch: chain conflict detected at position %d for token %s: stored txID %s, incoming txID %s", canonicalPos, tokenID, storedTxID, entry.TransactionID)
+			}
+			// Idempotent: same txID already stored — skip, do not set inserted.
+		} else {
+			inserted = true
+		}
+	}
+
+	// Step 7: Conditional index rebuild — only when at least one new row was inserted.
+	if inserted {
+		if err := w.batchUpsertTokenChainIndex(ctx, tx, []string{tokenID}); err != nil {
+			return fmt.Errorf("ApplyTokenChainBatch: upsert tokenchain_index: %w", err)
+		}
+	}
+
+	// Step 8: Commit.
 	return tx.Commit(ctx)
 }
 

--- a/core/wallet/token_lock.go
+++ b/core/wallet/token_lock.go
@@ -2,15 +2,23 @@ package wallet
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	stdmath "math"
+	"math/rand"
 	"sort"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
 	"github.com/rubixchain/rubixgoplatform/constants"
 	rubixmath "github.com/rubixchain/rubixgoplatform/math"
 	"github.com/rubixchain/rubixgoplatform/types/models"
+)
+
+const (
+	lockTokensForSplitRetryBudget = 3 * time.Second
+	lockTokensForSplitMaxRetries  = 5
 )
 
 // ── Pure selection helper ──────────────────────────────────────────────
@@ -328,69 +336,171 @@ func (w *Wallet) LockFTTokens(ctx context.Context, ownerDID string, ftName strin
 //  3. UPDATE token_status to Locked + commit; non-selected rows release locks.
 //
 // Returns only the selected (now-locked) tokens; callers must eventually release or consume them.
-func (w *Wallet) LockTokensForSplit(ctx context.Context, ownerDID string, amount float64) ([]models.Token, error) {
+func (w *Wallet) LockTokensForSplit(ctx context.Context, ownerDID string, amount float64, referenceID string) ([]models.Token, error) {
 	w.log.Info("LockTokensForSplit: locking tokens for split", "ownerDID", ownerDID, "amount", amount)
+	retryCtx, cancel := context.WithTimeout(ctx, lockTokensForSplitRetryBudget)
+	defer cancel()
+	deadline := time.Now().Add(lockTokensForSplitRetryBudget)
+
+	var lastErr error
+	for retry := 0; retry <= lockTokensForSplitMaxRetries; retry++ {
+		selected, err := w.lockTokensForSplitOnce(retryCtx, ownerDID, amount, referenceID)
+		if err == nil {
+			return selected, nil
+		}
+		lastErr = err
+
+		if !shouldRetryLockTokensForSplit(err) {
+			return nil, err
+		}
+		if retry == lockTokensForSplitMaxRetries {
+			break
+		}
+
+		sleepFor := lockTokensForSplitJitter(time.Until(deadline), lockTokensForSplitMaxRetries-retry)
+		if sleepFor <= 0 {
+			break
+		}
+
+		w.log.Warn("LockTokensForSplit: contention detected, retrying",
+			"retry", retry+1,
+			"maxRetries", lockTokensForSplitMaxRetries,
+			"sleepFor", sleepFor,
+			"err", err,
+		)
+
+		select {
+		case <-time.After(sleepFor):
+		case <-retryCtx.Done():
+			return nil, fmt.Errorf("LockTokensForSplit: retry budget exhausted after %s: %w", lockTokensForSplitRetryBudget, lastErr)
+		}
+	}
+
+	if errors.Is(retryCtx.Err(), context.DeadlineExceeded) && lastErr != nil {
+		return nil, fmt.Errorf("LockTokensForSplit: retry budget exhausted after %s: %w", lockTokensForSplitRetryBudget, lastErr)
+	}
+	if lastErr != nil {
+		return nil, fmt.Errorf("LockTokensForSplit: retries exhausted after %d retries: %w", lockTokensForSplitMaxRetries, lastErr)
+	}
+
+	return nil, fmt.Errorf("LockTokensForSplit: retries exhausted without a concrete error")
+}
+
+func (w *Wallet) lockTokensForSplitOnce(ctx context.Context, ownerDID string, amount float64, referenceID string) ([]models.Token, error) {
 	tx, err := w.db.BeginTx(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("LockTokensForSplit: begin tx: %w", err)
 	}
-	defer tx.Rollback(ctx) //nolint:errcheck
+	defer tx.Rollback(ctx)
 
-	if _, err := tx.Exec(ctx, "SET LOCAL lock_timeout = '5s'"); err != nil {
+	if _, err := tx.Exec(ctx, "SET LOCAL lock_timeout = '1500ms'"); err != nil {
 		return nil, fmt.Errorf("LockTokensForSplit: set lock_timeout: %w", err)
 	}
 
-	// ── Phase 1: Atomic candidate fetch with row-level lock ───────────
-	candidateRows, err := tx.Query(ctx, `
-		SELECT token_id, parent_token_id, token_value, token_status, did, transaction_id,
-		       token_state_hash, token_type, latest_position, latest_role, created_at, updated_at
-		FROM tokens
-		WHERE did=$1
-		  AND token_type=(SELECT id FROM token_type WHERE name=$2)
-		  AND token_status=$3
-		ORDER BY token_value ASC
-		FOR UPDATE SKIP LOCKED
-	`, ownerDID, constants.TokenType_RBT, constants.TokenStatus_Free)
-	if err != nil {
-		return nil, fmt.Errorf("LockTokensForSplit: candidate query: %w", err)
-	}
-	defer candidateRows.Close()
-
 	var candidates []models.Token
-	for candidateRows.Next() {
-		var tok models.Token
-		if err := candidateRows.Scan(
-			&tok.TokenID, &tok.ParentTokenID, &tok.TokenValue, &tok.TokenStatus,
-			&tok.DID, &tok.TransactionID, &tok.TokenStateHash, &tok.TokenType,
-			&tok.LatestPosition, &tok.LatestRole, &tok.CreatedAt, &tok.UpdatedAt,
-		); err != nil {
-			return nil, fmt.Errorf("LockTokensForSplit: candidate scan: %w", err)
+	var accumulated float64
+
+	batchSize := 100
+
+	// Cursor-based batching is required because SKIP LOCKED only skips rows held
+	// by OTHER transactions — it does NOT skip rows held by this same transaction.
+	// Without a cursor, each loop iteration re-scans the same rows and pushes them
+	// into candidates multiple times, producing duplicate token_id entries.
+	// Using WHERE token_id > $lastSeenID ORDER BY token_id ASC advances the scan
+	// window past all rows already seen in prior batches.
+	// Reference: RESEARCH.md section 1.
+	var lastSeenID string // cursor: "" means "no lower bound"
+	// Note: the empty string comparison is correct even for the first batch because
+	// token_id values are hex-encoded hashes and are never the empty string.
+
+	for {
+		rows, err := tx.Query(ctx, `
+			SELECT token_id, parent_token_id, token_value, token_status, did, transaction_id,
+			       token_state_hash, token_type, latest_position, latest_role, created_at, updated_at
+			FROM tokens
+			WHERE did=$1
+			  AND token_type=(SELECT id FROM token_type WHERE name=$2)
+			  AND token_status=$3
+			  AND token_id > $5
+			ORDER BY token_id ASC
+			LIMIT $4
+			FOR UPDATE SKIP LOCKED
+		`, ownerDID, constants.TokenType_RBT, constants.TokenStatus_Free, batchSize, lastSeenID)
+
+		if err != nil {
+			return nil, fmt.Errorf("LockTokensForSplit: candidate query: %w", err)
 		}
-		candidates = append(candidates, tok)
-	}
-	if err := candidateRows.Err(); err != nil {
-		return nil, fmt.Errorf("LockTokensForSplit: candidate rows: %w", err)
+
+		count := 0
+
+		for rows.Next() {
+			count++
+
+			var tok models.Token
+			if err := rows.Scan(
+				&tok.TokenID, &tok.ParentTokenID, &tok.TokenValue, &tok.TokenStatus,
+				&tok.DID, &tok.TransactionID, &tok.TokenStateHash, &tok.TokenType,
+				&tok.LatestPosition, &tok.LatestRole, &tok.CreatedAt, &tok.UpdatedAt,
+			); err != nil {
+				rows.Close()
+				return nil, fmt.Errorf("LockTokensForSplit: scan: %w", err)
+			}
+
+			candidates = append(candidates, tok)
+			accumulated = rubixmath.AddFloat(accumulated, tok.TokenValue)
+			// Advance the cursor: rows arrive in token_id ASC order, so the last
+			// row processed in this batch is always the highest token_id seen so far.
+			lastSeenID = tok.TokenID
+
+			if rubixmath.FloatPrecision(accumulated) >= rubixmath.FloatPrecision(amount) {
+				break
+			}
+		}
+
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("LockTokensForSplit: scan iter: %w", err)
+		}
+
+		rows.Close()
+
+		// stop if enough tokens
+		if rubixmath.FloatPrecision(accumulated) >= rubixmath.FloatPrecision(amount) {
+			break
+		}
+
+		// stop if no more tokens available
+		if count < batchSize {
+			break
+		}
 	}
 
-	// ── Phase 2: Apply selection logic in Go ──────────────────────────
+	if len(candidates) == 0 {
+		return nil, fmt.Errorf("LockTokensForSplit: no candidates")
+	}
+
+	// ── Selection ─────────────────────────────
 	selected, err := selectTokensForAmount(candidates, amount)
 	if err != nil {
 		return nil, fmt.Errorf("LockTokensForSplit: selection: %w", err)
 	}
 
-	// ── Phase 3: Update status + commit ──────────────────────────────
 	selectedIDs := make([]string, len(selected))
 	for i, tok := range selected {
 		selectedIDs[i] = tok.TokenID
 	}
-	sort.Strings(selectedIDs) // deadlock prevention: always lock in a deterministic order
 
-	_, err = tx.Exec(ctx,
-		`UPDATE tokens SET token_status = $1, updated_at = $2 WHERE token_id = ANY($3::text[])`,
-		constants.TokenStatus_Locked, time.Now(), selectedIDs,
-	)
+	sort.Strings(selectedIDs)
+
+	// ── Lock selected tokens ─────────────────
+	_, err = tx.Exec(ctx, `
+		UPDATE tokens
+		SET token_status = $1, updated_at = NOW(), lock_reference_id = $3
+		WHERE token_id = ANY($2::text[])
+	`, constants.TokenStatus_Locked, selectedIDs, referenceID)
+
 	if err != nil {
-		return nil, fmt.Errorf("LockTokensForSplit: update status: %w", err)
+		return nil, fmt.Errorf("LockTokensForSplit: update selected: %w", err)
 	}
 
 	if err := tx.Commit(ctx); err != nil {
@@ -398,6 +508,36 @@ func (w *Wallet) LockTokensForSplit(ctx context.Context, ownerDID string, amount
 	}
 
 	return selected, nil
+}
+
+func shouldRetryLockTokensForSplit(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+
+	msg := err.Error()
+	return strings.Contains(msg, "selectTokensForAmount: no candidate tokens available") ||
+		strings.Contains(msg, "selectTokensForAmount: insufficient balance") ||
+		strings.Contains(msg, "LockTokensForSplit: candidate query:") ||
+		strings.Contains(msg, "lock timeout") ||
+		strings.Contains(msg, "deadlock detected") ||
+		strings.Contains(msg, "could not serialize access")
+}
+
+func lockTokensForSplitJitter(remaining time.Duration, retriesLeft int) time.Duration {
+	if remaining <= 0 || retriesLeft <= 0 {
+		return 0
+	}
+
+	maxSleep := remaining / time.Duration(retriesLeft)
+	if maxSleep <= 0 {
+		return 0
+	}
+
+	return time.Duration(rand.Int63n(int64(maxSleep) + 1))
 }
 
 // LockNFTTokens locks NFT tokens by IDs. Self-contained.
@@ -430,14 +570,14 @@ func (w *Wallet) LockSmartContractToken(ctx context.Context, ownerDID string, to
 
 // UnlockLockedTokens releases specific locked tokens for a DID back to Free status.
 // Called during transaction abort to return locked tokens to their Free state.
-func (w *Wallet) UnlockLockedTokens(did string, tokens []string) error {
+func (w *Wallet) UnlockLockedTokens(did string, tokens []string, referenceID string) error {
 	if len(tokens) == 0 {
 		return nil
 	}
 	_, err := w.db.Pool().Exec(w.Ctx,
-		`UPDATE tokens SET token_status=$1, updated_at=$2
-		 WHERE did=$3 AND token_id = ANY($4::text[]) AND token_status=$5`,
-		constants.TokenStatus_Free, time.Now(), did, tokens, constants.TokenStatus_Locked,
+		`UPDATE tokens SET token_status=$1, updated_at=$2, lock_reference_id=NULL
+		 WHERE did=$3 AND token_id = ANY($4::text[]) AND token_status=$5 AND lock_reference_id=$6`,
+		constants.TokenStatus_Free, time.Now(), did, tokens, constants.TokenStatus_Locked, referenceID,
 	)
 	return err
 }

--- a/core/wallet/token_lock.go
+++ b/core/wallet/token_lock.go
@@ -321,16 +321,11 @@ func (w *Wallet) LockFTTokens(ctx context.Context, ownerDID string, ftName strin
 }
 
 // LockTokensForSplit selects and locks the minimum set of free RBT tokens needed
-// for the given amount, using a two-phase approach:
+// for the given amount, using a three-phase approach:
 //
-//  1. Read-only snapshot SELECT (no FOR UPDATE) to collect all free candidate tokens.
-//  2. selectTokensForAmount chooses the minimum subset in Go (no DB round-trip).
-//  3. Targeted FOR UPDATE SKIP LOCKED on only the selected token IDs.
-//  4. TOCTOU check: if any selected token was concurrently locked, return a clear error.
-//  5. UPDATE token_status to Locked + commit.
-//
-// This allows concurrent transfers from the same DID to each acquire their own
-// disjoint token subsets instead of one transfer monopolising all free tokens.
+//  1. SELECT all free RBT tokens FOR UPDATE SKIP LOCKED (atomic row-level lock).
+//  2. selectTokensForAmount chooses the minimum subset in Go (denomination-aware).
+//  3. UPDATE token_status to Locked + commit; non-selected rows release locks.
 //
 // Returns only the selected (now-locked) tokens; callers must eventually release or consume them.
 func (w *Wallet) LockTokensForSplit(ctx context.Context, ownerDID string, amount float64) ([]models.Token, error) {
@@ -345,7 +340,7 @@ func (w *Wallet) LockTokensForSplit(ctx context.Context, ownerDID string, amount
 		return nil, fmt.Errorf("LockTokensForSplit: set lock_timeout: %w", err)
 	}
 
-	// ── Phase 1: Read-only candidate fetch (no FOR UPDATE) ────────────
+	// ── Phase 1: Atomic candidate fetch with row-level lock ───────────
 	candidateRows, err := tx.Query(ctx, `
 		SELECT token_id, parent_token_id, token_value, token_status, did, transaction_id,
 		       token_state_hash, token_type, latest_position, latest_role, created_at, updated_at
@@ -354,6 +349,7 @@ func (w *Wallet) LockTokensForSplit(ctx context.Context, ownerDID string, amount
 		  AND token_type=(SELECT id FROM token_type WHERE name=$2)
 		  AND token_status=$3
 		ORDER BY token_value ASC
+		FOR UPDATE SKIP LOCKED
 	`, ownerDID, constants.TokenType_RBT, constants.TokenStatus_Free)
 	if err != nil {
 		return nil, fmt.Errorf("LockTokensForSplit: candidate query: %w", err)
@@ -382,64 +378,13 @@ func (w *Wallet) LockTokensForSplit(ctx context.Context, ownerDID string, amount
 		return nil, fmt.Errorf("LockTokensForSplit: selection: %w", err)
 	}
 
-	// ── Phase 3: Lock only selected tokens (targeted FOR UPDATE SKIP LOCKED) ──
+	// ── Phase 3: Update status + commit ──────────────────────────────
 	selectedIDs := make([]string, len(selected))
 	for i, tok := range selected {
 		selectedIDs[i] = tok.TokenID
 	}
 	sort.Strings(selectedIDs) // deadlock prevention: always lock in a deterministic order
 
-	lockRows, err := tx.Query(ctx, `
-		SELECT token_id, parent_token_id, token_value, token_status, did, transaction_id,
-		       token_state_hash, token_type, latest_position, latest_role, created_at, updated_at
-		FROM tokens
-		WHERE token_id = ANY($1::text[])
-		  AND did = $2
-		  AND token_type=(SELECT id FROM token_type WHERE name=$3)
-		  AND token_status = $4
-		ORDER BY token_id
-		FOR UPDATE SKIP LOCKED
-	`, selectedIDs, ownerDID, constants.TokenType_RBT, constants.TokenStatus_Free)
-	if err != nil {
-		return nil, fmt.Errorf("LockTokensForSplit: lock query: %w", err)
-	}
-	defer lockRows.Close()
-
-	var locked []models.Token
-	for lockRows.Next() {
-		var tok models.Token
-		if err := lockRows.Scan(
-			&tok.TokenID, &tok.ParentTokenID, &tok.TokenValue, &tok.TokenStatus,
-			&tok.DID, &tok.TransactionID, &tok.TokenStateHash, &tok.TokenType,
-			&tok.LatestPosition, &tok.LatestRole, &tok.CreatedAt, &tok.UpdatedAt,
-		); err != nil {
-			return nil, fmt.Errorf("LockTokensForSplit: lock scan: %w", err)
-		}
-		locked = append(locked, tok)
-	}
-	if err := lockRows.Err(); err != nil {
-		return nil, fmt.Errorf("LockTokensForSplit: lock rows: %w", err)
-	}
-
-	// ── Phase 4: TOCTOU check ─────────────────────────────────────────
-	if len(locked) < len(selectedIDs) {
-		lockedSet := make(map[string]bool, len(locked))
-		for _, tok := range locked {
-			lockedSet[tok.TokenID] = true
-		}
-		var missing []string
-		for _, id := range selectedIDs {
-			if !lockedSet[id] {
-				missing = append(missing, id)
-			}
-		}
-		return nil, fmt.Errorf(
-			"LockTokensForSplit: TOCTOU conflict — %d of %d selected tokens were concurrently locked by another transaction, retry recommended: missing=%v",
-			len(selectedIDs)-len(locked), len(selectedIDs), missing,
-		)
-	}
-
-	// ── Phase 5: Update status + commit ──────────────────────────────
 	_, err = tx.Exec(ctx,
 		`UPDATE tokens SET token_status = $1, updated_at = $2 WHERE token_id = ANY($3::text[])`,
 		constants.TokenStatus_Locked, time.Now(), selectedIDs,
@@ -452,7 +397,7 @@ func (w *Wallet) LockTokensForSplit(ctx context.Context, ownerDID string, amount
 		return nil, fmt.Errorf("LockTokensForSplit: commit: %w", err)
 	}
 
-	return locked, nil
+	return selected, nil
 }
 
 // LockNFTTokens locks NFT tokens by IDs. Self-contained.

--- a/core/wallet/transaction.go
+++ b/core/wallet/transaction.go
@@ -21,6 +21,21 @@ func (w *Wallet) CreateTransaction(tx *models.Transactions) error {
 	return nil
 }
 
+// CreateTransactionIfNotExists inserts a transaction if it does not already exist.
+// Uses ON CONFLICT (id) DO NOTHING for idempotent sync inserts.
+func (w *Wallet) CreateTransactionIfNotExists(tx *models.Transactions) error {
+	_, err := w.db.Pool().Exec(w.Ctx,
+		`INSERT INTO transactions (id, info, signature, created_at, updated_at)
+		 VALUES ($1, $2, $3, $4, $5)
+		 ON CONFLICT (id) DO NOTHING`,
+		tx.ID, tx.Info, tx.Signature, time.Now(), time.Now(),
+	)
+	if err != nil {
+		return fmt.Errorf("CreateTransactionIfNotExists: %w", err)
+	}
+	return nil
+}
+
 // GetTransactionByID retrieves a single transaction by its ID.
 func (w *Wallet) GetTransactionByID(id string) (*models.Transactions, error) {
 	var tx models.Transactions

--- a/server/server.go
+++ b/server/server.go
@@ -183,6 +183,7 @@ func (s *Server) RegisterRoutes() {
 	s.AddRoute(setup.APITransaction, "POST", s.AuthHandle(s.APIInitiateTransaction, true, s.AuthError, false))
 	s.AddRoute(setup.APITransaction, "GET", s.APIGetTransactions)
 	s.AddRoute(setup.APIGetTransactionByID, "GET", s.APIGetTransactionByID)
+	s.AddRoute(setup.APISyncTransactionChain, "POST", s.AuthHandle(s.APISyncTransactionChain, true, s.AuthError, false))
 	s.AddRoute(setup.APIListFT, "POST", s.APIListFTs)
 	s.AddRoute(setup.APIGetDIDBalance, "GET", s.AuthHandle(s.APIGetDIDBalance, true, s.AuthError, false))
 }

--- a/server/transaction.go
+++ b/server/transaction.go
@@ -5,6 +5,12 @@ import (
 	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
 )
 
+type syncTransactionChainRequest struct {
+	DID                   string   `json:"did"`
+	TokenIDs              []string `json:"token_ids"`
+	ExcludeTransactionIDs []string `json:"exclude_transaction_ids,omitempty"`
+}
+
 // @Summary Initiates a transaction
 // @Description Initiate a transaction
 // @ID txInit
@@ -65,5 +71,31 @@ func (s *Server) APIGetTransactions(req *ensweb.Request) *ensweb.Result {
 	}
 
 	return s.BasicResponse(req, true, "", transactions)
+}
+
+// APISyncTransactionChain godoc
+// @Summary      Sync transaction chains for tokens
+// @Description  Returns ordered transaction chains for the requested token IDs, optionally excluding specific transaction IDs
+// @Tags         tx
+// @ID           syncTxChain
+// @Accept       json
+// @Produce      json
+// @Param        input body syncTransactionChainRequest true "sync request"
+// @Success      200  {object}  model.BasicResponse
+// @Router       /rubix/v1/sync-transaction-chain [post]
+func (s *Server) APISyncTransactionChain(req *ensweb.Request) *ensweb.Result {
+	var syncReq syncTransactionChainRequest
+	err := s.ParseJSON(req, &syncReq)
+	if err != nil {
+		return s.BasicResponse(req, false, "Invalid input", nil)
+	}
+	if len(syncReq.TokenIDs) == 0 {
+		return s.BasicResponse(req, true, "no token_ids provided", nil)
+	}
+	data, err := s.c.GetSyncTransactionChainData(syncReq.TokenIDs, syncReq.ExcludeTransactionIDs)
+	if err != nil {
+		return s.BasicResponse(req, false, err.Error(), nil)
+	}
+	return s.BasicResponse(req, true, "ok", data)
 }
 

--- a/setup/setup.go
+++ b/setup/setup.go
@@ -125,6 +125,7 @@ const (
 	APIGetNFTChain           string = "/rubix/v1/nfts/{nft_id}/chain"
 	APITransaction           string = "/rubix/v1/tx"
 	APIGetTransactionByID    string = "/rubix/v1/tx/{tx_id}"
+	APISyncTransactionChain  string = "/rubix/v1/sync-transaction-chain"
 
 	// New endpoints
 	APIListFT string = "/rubix/v1/fts"


### PR DESCRIPTION
## Summary

  Before this change, the receiver node (`nodeB`) had no mechanism to pull a                                                                    
  token's chain history from the initiator before calling `PersistPostConsensus`.
  This caused `validateTransferChainContinuity` to fail with                                                                                    
  `previous_transaction_id mismatch` whenever the receiver was behind on chain                                                                  
  state for a mid-chain token.
                                                                                                                                                
  This PR introduces a pre-persistence sync step on the receiver side and the                                                                   
  wallet/API infrastructure to support it.                                                                                                      
                                                                                                                                                
  ## What changed                                                                                                                               
   
  ### Core sync mechanism (`core/sync.go`, `core/transaction.go`)                                                                               
  - Added `SyncTransactionChainsFromPeer` — fetches token chain rows from the
    initiator for all tokens in the transfer, called inside `SendTokens` before
    `PersistPostConsensus`
  - Added `applyTokenChainFromSync` — applies fetched rows with prefix check,
    fork detection, and atomic batch insert; creates token row if missing
    (prevents FK violation on first-seen tokens)                                                                                                
  - Added TxN exclusion (skips already-known txns) and 30s timeout guard                                                                        
                                                                                                                                                
  ### Wallet layer (`core/wallet/token_chain.go`, `core/wallet/transaction.go`)                                                                 
  - Added `ApplyTokenChainBatch` — atomic insert with advisory lock, chain                                                                      
    continuity validation, and duplicate/conflict detection                                                                                     
  - Added `CreateTransactionIfNotExists` — idempotent token row creation to                                                                     
    satisfy FK constraints before batch apply
  - Updated `post_consensus_payload_builder.go` and                                                                                             
    `post_consensus_persistence.go` to handle the post-sync state correctly
                                                                                                                                                
  ### API (`server/server.go`, `server/transaction.go`, `setup/setup.go`)
  - Exposed `APISyncTransactionChain` under `/rubix/v1` prefix (consistent with                                                                 
    other APIs)                                                                                                                                 
  - Added `GetSyncTransactionChainData` core method + constant in `setup/setup.go`
                                                                                                                                                
  ### Logging                            
  - Improved DID registration and IPFS connection logs for easier debugging

> Note on history: commits 6204ef65 and 94c95008 are a revert-and-redo of the FK fix — c356fb1e is the final state. Safe to ignore the intermediate commits.
