### PR TITLE
Fixing Get peerID in Testnet Mode

### DIFF
--- a/core/did.go
+++ b/core/did.go
@@ -308,36 +308,13 @@ func (c *Core) GetPeerDIDInfo(didStr string) (*models.DID, error) {
 
 	var peerID string
 
-	// In case of xell wallet, TRIE testnet and Rubix testnet have same swarm key but different peerIDs.
-	// So, an user should find another user's Rubix testnet DID-info in DIDTable and TRIE testnet DID-info in PeerDIDTable.
-	if c.testnet {
-		// 1. try DID table first
-		if _, err := c.w.GetDID(didStr); err == nil {
-			return &models.DID{
-				DID:    didStr,
-				PeerID: c.peerID,
-			}, nil
-		}
-
-		// 2. If missing, try peer table
-		peerID, _ = c.w.GetPeerID(didStr)
-
-		if peerID != "" {
-			return &models.DID{
-				DID:    didStr,
-				PeerID: peerID,
-			}, nil
-		}
-	} else {
-		// 1. Try peer table first
-		peerID, _ = c.w.GetPeerID(didStr)
-
-		if peerID != "" {
-			return &models.DID{
-				DID:    didStr,
-				PeerID: peerID,
-			}, nil
-		}
+	// 1. Try dids table first
+	peerID, _ = c.w.GetPeerID(didStr)
+	if peerID != "" {
+		return &models.DID{
+			DID:    didStr,
+			PeerID: peerID,
+		}, nil
 	}
 
 	// If peerID still missing, try resolving (via explorer or peer fetch)


### PR DESCRIPTION
This PR is resolving the GetPeerDIDInfo function for testnet mode. Previously, did table was only used for native DIDs. So, this function was assuming that any DID present in the `dids` table is a native DID. 

### Changes

GetPeerDIDInfo fetches peerID of any DID (native or peer) from the `dids` table