### PR TITLE
fixing the previous transaction ownership is failing for the unpledged token

### DIFF
--- a/command/command.go
+++ b/command/command.go
@@ -604,7 +604,6 @@ func (cmd *Command) runApp() {
 	if cmd.fullNode {
 		cmd.log.Info("Node is running as a Full node")
 		rubixCore.SubscribeTCDetails()
-		rubixCore.RetryFailedTokenSync()
 	}
 
 	ch := make(chan os.Signal, 1)

--- a/core/core.go
+++ b/core/core.go
@@ -713,29 +713,6 @@ func (c *Core) tokenSyncCleanupRoutine() {
 	}
 }
 
-func (c *Core) RetryFailedTokenSync() {
-	go func() {
-		c.RetryTokenSyncTicker = time.NewTicker(1 * time.Hour)
-		defer c.RetryTokenSyncTicker.Stop()
-
-		for range c.RetryTokenSyncTicker.C {
-			retryErrChan := make(chan error, 1)
-			go func() {
-				retryErrChan <- c.RetryFailedTOSyncTokens()
-			}()
-
-			err := <-retryErrChan
-			if err != nil {
-				c.log.Error("RetryFailedTOSyncTokens execution failed", "err", err)
-			} else {
-				c.log.Info("RetryFailedTOSyncTokens executed successfully")
-			}
-
-		}
-
-	}()
-}
-
 // GetSyncTransactionChainData returns transaction chains for the given token IDs,
 // excluding any transactions whose IDs appear in excludeTxIDs.
 func (c *Core) GetSyncTransactionChainData(tokenIDs []string, excludeTxIDs []string) (map[string][]models.Transactions, error) {

--- a/core/fullnode.go
+++ b/core/fullnode.go
@@ -3,7 +3,6 @@ package core
 import (
 	"encoding/json"
 	"fmt"
-	"strings"
 	"sync/atomic"
 	"time"
 
@@ -222,7 +221,6 @@ func (c *Core) processSingleTransaction(newEvent *models.EventTransaction) error
 	}
 
 	//store the transaction
-	c.log.Debug("processSingleTransaction: about to persist fullnode transaction", txn, "TransactionInfo", transactionInfo)
 	if err := c.w.PersistFullNodeTransaction(c.w.Ctx, &wallet.FullNodePersistenceRequest{
 		Transaction:     txn,
 		TransactionInfo: transactionInfo,
@@ -275,47 +273,6 @@ func (c *Core) ShutdownTxnProcessor() {
 			c.log.Warn("Transaction workers shutdown timeout - forcing termination")
 		}
 	}
-}
-
-func (c *Core) RetryFailedTOSyncTokens() error {
-	failedToSyncTokens, err := c.w.GetAllFailedToSyncTokens()
-	if err != nil {
-		if strings.Contains(err.Error(), "no records found") {
-			c.log.Info("There are no failed tokens to sync")
-			return nil
-		} else {
-			c.log.Error("failed to get tokens which are failed to sync ", "error", err)
-			return err
-		}
-
-	}
-	if failedToSyncTokens == nil {
-		c.log.Info("There are NO failed to sync tokens which needs retry of syncing")
-	} else {
-		for _, failedToSyncToken := range failedToSyncTokens {
-			//call synctokenchain api to sync each token
-			//connect to publisher and fetch complete token chain
-			p, err := c.getPeer(failedToSyncToken.Did)
-			if err != nil {
-				c.log.Error("failed to sync full token chain, failed to open peer connection with publisher ", failedToSyncToken.Did, "error: ", err)
-				return fmt.Errorf("failed to open peer connection with publisher %v, error: %v", failedToSyncToken.Did, err)
-			}
-			defer p.Close()
-			tokenSyncInfo := &TokenSyncInfo{
-				TokenID:   failedToSyncToken.TokenID,
-				TokenType: failedToSyncToken.TokenType,
-				AssetType: failedToSyncToken.AssetType,
-			}
-			err = c.SyncFullTokenChainForFullNode(p, *tokenSyncInfo)
-			if err != nil {
-				c.log.Error("failed to sync token chain for token ", failedToSyncToken.TokenID, "error", err)
-				return fmt.Errorf("failed to get latest block for token %s - may need sync", failedToSyncToken.TokenID)
-
-			}
-		}
-	}
-
-	return nil
 }
 
 // This function process incoming transaction history details and add it to Fullnode transaction history table

--- a/core/sync.go
+++ b/core/sync.go
@@ -494,7 +494,7 @@ func (c *Core) applyTokenChainFromSyncForFullNode(tokenID string, remoteTxs []ty
 	}
 	c.log.Debug("applyTokenChainFromSyncForFullNode: Starting sync",
 		"tokenID", tokenID,
-		"remoteTxs", fmt.Sprintf("%+v", remoteTxs),
+		"remoteTxs", len(remoteTxs),
 		"prevTxID", prevTxID,
 	)
 

--- a/core/wallet/fullnode_persistence.go
+++ b/core/wallet/fullnode_persistence.go
@@ -2,6 +2,7 @@ package wallet
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -243,7 +244,7 @@ func deriveFullNodeTokenState(existing fullNodeTokenState, txInfo *models.Transa
 			state.tokenValue = derivedValue
 		}
 	}
-	
+
 	if input.tokenInfo.Data != "" {
 		state.tokenStateHash = input.tokenInfo.Data
 	}
@@ -560,42 +561,125 @@ func (w *Wallet) PersistFullNodeSyncedTokenChain(
 	}
 
 	lastEntry := entries[len(entries)-1]
-	var tokenValue float64
-	var tokenStateHash string
+
+	// Locate the synced token in the transaction to decide the correct
+	// owner DID and tokenValue to persist. Resolution order:
+	//
+	//   1. lastTxInfo.Tokens.{RBT,FT,NFT,SmartContract}
+	//        → transfer/committed token — owner = lastTxInfo.Owner
+	//
+	//   2. lastTxInfo.Quorums[].Tokens
+	//        → pledge token of the LAST synced transaction
+	//        → owner = that QuorumInfo.Did
+	//        → value from QuorumInfo entry if non-zero, else derive from tokenID
+	//
+	//If token is not present in lastTransactionInfo, which means for the given
+	//transactionInfo it is the unpledged token, so it won't be there.
+	//In that case, search the token in the previous txnInfo(which is pledged txn) and update the token details accordingly.
+	//   3. entries' last PreviousTransactionID → find that tx in newTxs →
+	//      inspect its Quorums[].Tokens
+	//        → pledge token created by an earlier tx in this sync batch
+	//        → owner = that QuorumInfo.Did
+	//        → value from QuorumInfo entry if non-zero, else derive from tokenID
+	var (
+		tokenValue     float64
+		tokenStateHash string
+		pledgeOwnerDID string
+		foundIn        string // "transfer" | "pledge:last" | "pledge:prev" | ""
+	)
+
+	// Step 1: transfer / committed token lookup in the last transaction.
 	if lastTxInfo != nil && lastTxInfo.Tokens != nil {
-		for _, t := range lastTxInfo.Tokens.RBT {
-			if t != nil && t.TokenID == tokenID {
-				tokenValue = t.TokenValue
-				tokenStateHash = t.Data
+		transferLists := [][]*models.TokenInfo{
+			lastTxInfo.Tokens.RBT,
+			lastTxInfo.Tokens.FT,
+			lastTxInfo.Tokens.NFT,
+			lastTxInfo.Tokens.SmartContract,
+		}
+		for _, list := range transferLists {
+			for _, t := range list {
+				if t != nil && t.TokenID == tokenID {
+					tokenValue = t.TokenValue
+					tokenStateHash = t.Data
+					foundIn = "transfer"
+					break
+				}
+			}
+			if foundIn != "" {
 				break
 			}
 		}
-		if tokenValue == 0 {
-			for _, t := range lastTxInfo.Tokens.FT {
-				if t != nil && t.TokenID == tokenID {
-					tokenValue = t.TokenValue
-					tokenStateHash = t.Data
-					break
+	}
+
+	// Step 2: pledge token lookup in lastTxInfo.Quorums[].Tokens.
+	if foundIn == "" && lastTxInfo != nil {
+		for _, q := range lastTxInfo.Quorums {
+			if q == nil {
+				continue
+			}
+			for _, t := range q.Tokens {
+				if t == nil || t.TokenID != tokenID {
+					continue
 				}
+				if t.TokenValue > 0 {
+					tokenValue = t.TokenValue
+				} else {
+					v, err := util.GetTokenValueFromTokenID(tokenID)
+					if err != nil {
+						return fmt.Errorf("fullnode sync persistence: derive token value for pledge token %q: %w", tokenID, err)
+					}
+					tokenValue = v
+				}
+				tokenStateHash = t.Data
+				pledgeOwnerDID = q.Did
+				foundIn = "pledge:last"
+				break
+			}
+			if foundIn != "" {
+				break
 			}
 		}
-		if tokenValue == 0 {
-			for _, t := range lastTxInfo.Tokens.NFT {
-				if t != nil && t.TokenID == tokenID {
-					tokenValue = t.TokenValue
+	}
+
+	// Step 3: pledge token lookup in the previous transaction referenced by the
+	// last chain entry. The previous tx must be part of this sync batch (newTxs).
+	if foundIn == "" && lastEntry.PreviousTransactionID != nil && *lastEntry.PreviousTransactionID != "" {
+		prevTxID := *lastEntry.PreviousTransactionID
+		for i := range newTxs {
+			if newTxs[i].ID != prevTxID {
+				continue
+			}
+			var prevTxInfo models.TransactionInfo
+			if err := json.Unmarshal(newTxs[i].Info, &prevTxInfo); err != nil {
+				return fmt.Errorf("fullnode sync persistence: unmarshal prev tx %q info: %w", prevTxID, err)
+			}
+			for _, q := range prevTxInfo.Quorums {
+				if q == nil {
+					continue
+				}
+				for _, t := range q.Tokens {
+					if t == nil || t.TokenID != tokenID {
+						continue
+					}
+					if t.TokenValue > 0 {
+						tokenValue = t.TokenValue
+					} else {
+						v, err := util.GetTokenValueFromTokenID(tokenID)
+						if err != nil {
+							return fmt.Errorf("fullnode sync persistence: derive token value for pledge token %q (via prev tx %q): %w", tokenID, prevTxID, err)
+						}
+						tokenValue = v
+					}
 					tokenStateHash = t.Data
+					pledgeOwnerDID = q.Did
+					foundIn = "pledge:prev"
+					break
+				}
+				if foundIn != "" {
 					break
 				}
 			}
-		}
-		if tokenValue == 0 {
-			for _, t := range lastTxInfo.Tokens.SmartContract {
-				if t != nil && t.TokenID == tokenID {
-					tokenValue = t.TokenValue
-					tokenStateHash = t.Data
-					break
-				}
-			}
+			break
 		}
 	}
 
@@ -613,8 +697,15 @@ func (w *Wallet) PersistFullNodeSyncedTokenChain(
 	if tokenStateHash != "" {
 		tokenState.tokenStateHash = tokenStateHash
 	}
-	if lastTxInfo != nil && lastTxInfo.Owner != "" {
-		tokenState.did = lastTxInfo.Owner
+	switch foundIn {
+	case "pledge:last", "pledge:prev":
+		if pledgeOwnerDID != "" {
+			tokenState.did = pledgeOwnerDID
+		}
+	default:
+		if lastTxInfo != nil && lastTxInfo.Owner != "" {
+			tokenState.did = lastTxInfo.Owner
+		}
 	}
 	tokenState.transactionID = lastEntry.TransactionID
 	tokenState.latestPosition = lastEntry.Position


### PR DESCRIPTION
While syncing unpledged tokens from the quorum, the system attempted to derive the OwnerDID from the corresponding transactionInfo before persisting the token to the database. However, since unpledged tokens are not present in the unpledged transactionInfo, this lookup failed.

As a result, the logic incorrectly assigned the transaction’s OwnerDID as the owner of the unpledged token, leading to invalid ownership data and subsequent validation errors.

This PR fixes the issue by ensuring that the OwnerDID for unpledged tokens is derived correctly, without relying on missing or irrelevant transactionInfo.