### PR TITLE
Fix CreateDID

### DIFF
--- a/cmd/dev/main_old.go
+++ b/cmd/dev/main_old.go
@@ -104,7 +104,7 @@ func main_old() {
 	w := c.GetWallet()
 
 	// Step B: Create sender DID (real keypair + IPFS CID + Postgres upsert)
-	senderDID, err := c.CreateDID(&types.DIDCreate{PrivPWD: "test-sender-pwd"}, true)
+	senderDID, err := c.CreateDID(&types.DIDCreate{PrivPWD: "test-sender-pwd"})
 	if err != nil {
 		log.Fatalf("CreateDID(sender) failed: %v", err)
 	}
@@ -320,7 +320,7 @@ func main_old() {
 
 	// Step G: Create receiver DID (real keypair + IPFS CID + Postgres upsert)
 	fmt.Println("\n--- Step G: Create receiver DID ---")
-	receiverDID, err := c.CreateDID(&types.DIDCreate{PrivPWD: "test-receiver-pwd"}, true)
+	receiverDID, err := c.CreateDID(&types.DIDCreate{PrivPWD: "test-receiver-pwd"})
 	if err != nil {
 		log.Fatalf("CreateDID(receiver) failed: %v", err)
 	}

--- a/cmd/dev/setup.go
+++ b/cmd/dev/setup.go
@@ -44,7 +44,7 @@ func createDIDs(c *core.Core, count int) []string {
 	for range count {
 		didID, err := c.CreateDID(&types.DIDCreate{
 			PrivPWD: "pwd-1",
-		}, true)
+		})
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/core/did.go
+++ b/core/did.go
@@ -169,8 +169,8 @@ func (c *Core) InitDIDModule() {
 	}
 }
 
-func (c *Core) CreateDID(didCreate *types.DIDCreate, localDID bool) (did string, err error) {
-	if localDID { // create key pair from mnemonic an d then did from the private key
+func (c *Core) CreateDID(didCreate *types.DIDCreate) (did string, err error) {
+	if didCreate.PubKey == "" { // create key pair from mnemonic and then did from the private key
 		did, err = c.d.CreateDID(didCreate)
 		if err != nil {
 			return "", fmt.Errorf("Core: CreateDID: faile create did locally, err: %w", err)
@@ -189,7 +189,7 @@ func (c *Core) CreateDID(didCreate *types.DIDCreate, localDID bool) (did string,
 	dt := &models.DID{
 		DID:    did,
 		PeerID: c.peerID,
-		Local:  localDID,
+		Local:  true,
 	}
 	algoID, err := c.w.GetDidAlgoIDByName(constants.DidAlgo_SECP256K1)
 	if err != nil {

--- a/server/did.go
+++ b/server/did.go
@@ -53,15 +53,7 @@ func (s *Server) APICreateDID(req *ensweb.Request) *ensweb.Result {
 		return s.BasicResponse(req, false, "failed to parse did configuration", nil)
 	}
 
-	// depending on pub key passed or not, direct the function call
-	var didLocal bool
-	if didCreate.PubKey == "" {
-		didLocal = true // create key pair and did locally
-	} else {
-		didLocal = false // create did from the input public key
-	}
-
-	did, err := s.c.CreateDID(&didCreate, didLocal)
+	did, err := s.c.CreateDID(&didCreate)
 	if err != nil {
 		s.log.Error("failed to create did", "err", err)
 		return s.BasicResponse(req, false, err.Error(), nil)


### PR DESCRIPTION
Previously, DIDs created with public key were trated as non-local DID as their private key is not in the node, and maintained local column in dids table as False. 

In this PR, we are updating that. Any DID created in the node and has the peerID of the node, shall be treated as local DID, and the local column in dids table should be True for those.