### PR TITLE
Fix Unregistered Initiator DID

### DIFF
--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -104,6 +104,23 @@ func (c *Core) requestPledgeTokenHandler(request *ensweb.Request) *ensweb.Result
 		return c.l.RenderJSON(request, &response, http.StatusNotFound)
 	}
 	dc := c.pqc[did]
+
+	// add initiator peer details to dids table, if it is not already present
+	if isExist := c.IsDIDExist(pledgeTokenRequest.InitiatorPeerInfo.DID); !isExist {
+		if pledgeTokenRequest.InitiatorPeerInfo.PeerID != c.peerID {
+			pledgeTokenRequest.InitiatorPeerInfo.Local = false
+		} else {
+			pledgeTokenRequest.InitiatorPeerInfo.Local = true
+		}
+		err = c.AddPeerDetails(*pledgeTokenRequest.InitiatorPeerInfo)
+		if err != nil {
+			errMsg := fmt.Sprintf("requestPledgeTokenHandler: Failed to add initiator peer info to db; err: %v", err)
+			c.log.Error(errMsg)
+			response.Message = errMsg
+			return c.l.RenderJSON(request, &response, http.StatusBadRequest)
+		}
+	}
+
 	// Strict minimal liquidity guard (260409-0ko):
 	// Cheap pre-check to short-circuit pledge requests when the quorum clearly
 	// does not have enough free RBT balance. This avoids entering
@@ -219,7 +236,6 @@ func (c *Core) initiateConsensusHandler(request *ensweb.Request) *ensweb.Result 
 			transactionTokens = append(transactionTokens, sc.TokenID)
 		}
 	}
-
 
 	//Need to call ValidateTransaction function here
 	initiatorDIDCrypto, err := c.InitialiseDID(txnInfo.Initiator)

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/rubixchain/rubixgoplatform/constants"
 	"github.com/rubixchain/rubixgoplatform/core/consensus"
 	"github.com/rubixchain/rubixgoplatform/core/model"
 	"github.com/rubixchain/rubixgoplatform/core/wallet"
@@ -176,6 +177,14 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 	pledgeTokenRequest := models.PledgeTokenRequest{
 		ReferenceId:      reqID,
 		TransactionValue: transactionValue,
+	}
+
+	// prepare did info to share with receiver
+	algoID, _ := c.w.GetDidAlgoIDByName(constants.DidAlgo_SECP256K1)
+	pledgeTokenRequest.InitiatorPeerInfo = &models.DID{
+		DID:    initiatorDID,
+		PeerID: c.peerID,
+		AlgoID: algoID,
 	}
 
 	var pledgeTokenResponse models.PledgeTokenResponse
@@ -582,6 +591,14 @@ func (c *Core) sendTokensToReceiver(
 		sendTokensRequest.NFTOwnershipTransfer = request.Tokens.TransferNFTOwnership
 	}
 
+	// prepare did info to share with receiver
+	algoID, _ := c.w.GetDidAlgoIDByName(constants.DidAlgo_SECP256K1)
+	sendTokensRequest.InitiatorPeerInfo = &models.DID{
+		DID:    txInfo.Initiator,
+		PeerID: c.peerID,
+		AlgoID: algoID,
+	}
+
 	// Send tokens to receiver with 2-minute timeout
 	// SendJSONRequest has built-in retry logic (3 attempts with exponential backoff)
 	err = receiverPeer.SendJSONRequest(
@@ -648,6 +665,14 @@ func (c *Core) sendTokensToReceiverSync(
 		sendTokensRequest.NFTOwnershipTransfer = request.Tokens.TransferNFTOwnership
 	}
 
+	// prepare did info to share with receiver
+	algoID, _ := c.w.GetDidAlgoIDByName(constants.DidAlgo_SECP256K1)
+	sendTokensRequest.InitiatorPeerInfo = &models.DID{
+		DID:    txInfo.Initiator,
+		PeerID: c.peerID,
+		AlgoID: algoID,
+	}
+
 	// Send tokens to receiver with 2-minute timeout
 	// SendJSONRequest has built-in retry logic (3 attempts with exponential backoff)
 	err = receiverPeer.SendJSONRequest(
@@ -697,6 +722,22 @@ func (c *Core) SendTokens(request *ensweb.Request) *ensweb.Result {
 		c.log.Error("SendTokens: Failed to parse json request", "err", err)
 		crep.Message = "SendTokens: Failed to parse json request"
 		return c.l.RenderJSON(request, &crep, http.StatusBadRequest)
+	}
+
+	// add initiator peer details to dids table, if not there
+	if isExist := c.IsDIDExist(sendTokensRequest.InitiatorPeerInfo.DID); !isExist {
+		if sendTokensRequest.InitiatorPeerInfo.PeerID != c.peerID {
+			sendTokensRequest.InitiatorPeerInfo.Local = false
+		} else {
+			sendTokensRequest.InitiatorPeerInfo.Local = true
+		}
+		err = c.AddPeerDetails(*sendTokensRequest.InitiatorPeerInfo)
+		if err != nil {
+			errMsg := fmt.Sprintf("SendTokens: Failed to add initiator peer info to db; err: %v", err)
+			c.log.Error(errMsg)
+			crep.Message = errMsg
+			return c.l.RenderJSON(request, &crep, http.StatusBadRequest)
+		}
 	}
 
 	if sendTokensRequest.TransactionInfo == nil || sendTokensRequest.Signature == nil {

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -180,7 +180,13 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 	}
 
 	// prepare did info to share with receiver
-	algoID, _ := c.w.GetDidAlgoIDByName(constants.DidAlgo_SECP256K1)
+	algoID, err := c.w.GetDidAlgoIDByName(constants.DidAlgo_SECP256K1)
+	if err != nil {
+		errMsg := fmt.Sprintf("InitiateTransaction: Failed to get algoID of Initiator, quorumDID: %s, err: %v", quorumAddresses[0], err)
+		c.log.Error(errMsg)
+		resp.Message = errMsg
+		return resp
+	}
 	pledgeTokenRequest.InitiatorPeerInfo = &models.DID{
 		DID:    initiatorDID,
 		PeerID: c.peerID,
@@ -592,7 +598,14 @@ func (c *Core) sendTokensToReceiver(
 	}
 
 	// prepare did info to share with receiver
-	algoID, _ := c.w.GetDidAlgoIDByName(constants.DidAlgo_SECP256K1)
+	algoID, err := c.w.GetDidAlgoIDByName(constants.DidAlgo_SECP256K1)
+	if err != nil {
+		c.log.Warn("sendTokensToReceiver: failed to get algo ID of Initiator (will sync later)",
+			"receiver", receiverDID,
+			"transactionID", transactionID,
+			"err", err)
+		return
+	}
 	sendTokensRequest.InitiatorPeerInfo = &models.DID{
 		DID:    txInfo.Initiator,
 		PeerID: c.peerID,
@@ -666,7 +679,12 @@ func (c *Core) sendTokensToReceiverSync(
 	}
 
 	// prepare did info to share with receiver
-	algoID, _ := c.w.GetDidAlgoIDByName(constants.DidAlgo_SECP256K1)
+	algoID, err := c.w.GetDidAlgoIDByName(constants.DidAlgo_SECP256K1)
+	if err != nil {
+		errMsg := fmt.Sprintf("sendTokensToReceiver: failed to get algo ID of Initiator, will sync later; receiver: %s, transactionID: %s, err: %s", receiverDID, transactionID, err)
+		c.log.Warn(errMsg)
+		return fmt.Errorf(errMsg)
+	}
 	sendTokensRequest.InitiatorPeerInfo = &models.DID{
 		DID:    txInfo.Initiator,
 		PeerID: c.peerID,

--- a/types/models/transaction_info.go
+++ b/types/models/transaction_info.go
@@ -1,6 +1,8 @@
 package models
 
-import "encoding/json"
+import (
+	"encoding/json"
+)
 
 type TransactionInfo struct {
 	Initiator       string             `json:"initiator"`
@@ -81,8 +83,9 @@ type SmartContractInfo struct {
 }
 
 type PledgeTokenRequest struct {
-	ReferenceId      string  `json:"referenceId"`
-	TransactionValue float64 `json:"transactionValue"`
+	ReferenceId       string  `json:"referenceId"`
+	TransactionValue  float64 `json:"transactionValue"`
+	InitiatorPeerInfo *DID    `json:"initiator_info"`
 }
 
 type PledgeTokenResponse struct {
@@ -95,6 +98,7 @@ type SendTokensRequest struct {
 	NFTOwnershipTransfer bool               `json:"nftOwnershipTransfer"`
 	TransactionInfo      *TransactionInfo   `json:"transactionInfo"`
 	Signature            *Signature         `json:"signature"`
+	InitiatorPeerInfo    *DID               `json:"initiator_info"`
 }
 
 // TokenChainResponse represents a single transaction in the smart contract token chain


### PR DESCRIPTION
This PR is adding a new Field `InitiatorPeerInfo` to the `PledgeTokenRequest` and `SendTokensRequest` structs. 

The purpose of the new field is that, if the Quorum or the Receiver does not have Initiator peer info in `dids` table, then they can add it while receiving pledge request/ send token request from the Initiator.

This would help the Quorum and Receiver to send **tokenchain sync request** to the Initiator flawlessly.

The data type / structure of the new field `InitiatorPeerInfo` is 
```
type DID struct {
	DID    string `db:"did"`
	PeerID string `db:"peer_id"`
	Local  bool   `db:"local"`
	AlgoID int64  `db:"algo_id"`
}
```
