### PR TITLE
Fix FT Transfer

### DIFF
--- a/command/did.go
+++ b/command/did.go
@@ -220,7 +220,6 @@ func (cmd *Command) GetRBTBalance() {
 		cmd.log.Error("Invalid response from the node", "err", err)
 		return
 	}
-	fmt.Printf("Response : %v\n", response)
 	if !response.Status {
 		cmd.log.Error("Failed to get account info", "message", response.Message)
 	} else {
@@ -254,7 +253,6 @@ func (cmd *Command) GetDIDBalance() {
 		cmd.log.Error("Invalid response from the node", "err", err)
 		return
 	}
-	fmt.Printf("Response : %v\n", response)
 	if !response.Status {
 		cmd.log.Error("Failed to get balance for DID ", cmd.did, "message", response.Message)
 	} else {

--- a/core/did.go
+++ b/core/did.go
@@ -319,7 +319,7 @@ func (c *Core) GetPeerDIDInfo(didStr string) (*models.DID, error) {
 
 	// If peerID still missing, try resolving (via explorer or peer fetch)
 	if peerID == "" {
-		if !c.testnet {
+		if !c.testnet || !c.localnet{
 			peerInfo, err := c.GetPeerFromExplorer(didStr)
 			if err != nil {
 				return nil, fmt.Errorf("explorer lookup failed: %w", err)

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -73,6 +73,13 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 			} else {
 				c.log.Info("InitiateTransaction: released locked RBT tokens after failed transaction", "did", initiatorDID)
 			}
+
+			// release all locked FTs
+			if releaseFtErr := c.w.ReleaseAllLockedFTTokensForDID(ctx, initiatorDID, reqID); releaseFtErr != nil {
+				c.log.Error("InitiateTransaction: failed to release locked FTs after failure", "err", releaseFtErr, "did", initiatorDID)
+			} else {
+				c.log.Info("InitiateTransaction: released locked FTs after failed transaction", "did", initiatorDID)
+			}
 			// Also release any locked NFT/SC tokens. These are locked by
 			// BuildTransactionInfoFromRequest via QueryAndLockForExecution + batch
 			// status UPDATE, but ReleaseAllLockedRBTTokensForDID only handles RBT.

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -744,6 +744,12 @@ func (c *Core) SendTokens(request *ensweb.Request) *ensweb.Result {
 
 	// add initiator peer details to dids table, if not there
 	if isExist := c.IsDIDExist(sendTokensRequest.InitiatorPeerInfo.DID); !isExist {
+		if sendTokensRequest.InitiatorPeerInfo.PeerID == "" {
+			errMsg := fmt.Sprintf("SendTokens: Failed to register initiator peer info, peerID is empty; err: %v", err)
+			c.log.Error(errMsg)
+			crep.Message = errMsg
+			return c.l.RenderJSON(request, &crep, http.StatusBadRequest)
+		}
 		if sendTokensRequest.InitiatorPeerInfo.PeerID != c.peerID {
 			sendTokensRequest.InitiatorPeerInfo.Local = false
 		} else {

--- a/core/transaction_builder.go
+++ b/core/transaction_builder.go
@@ -185,6 +185,7 @@ func BuildTransactionInfoFromRequest(
 					txTokens.FT = append(txTokens.FT, &models.TokenInfo{
 						TokenID:               tok.TokenID,
 						PreviousTransactionID: tok.TransactionID,
+						TokenValue:            tok.TokenValue,
 					})
 					allLockedIDs = append(allLockedIDs, tok.TokenID)
 					totalAmount = rubixmath.AddFloat(totalAmount, tok.TokenValue)

--- a/core/wallet/post_consensus_payload_builder.go
+++ b/core/wallet/post_consensus_payload_builder.go
@@ -123,6 +123,10 @@ func (w *Wallet) BuildPersistencePayload(ctx context.Context, transactionID stri
 			// Genesis (Deploy/Mint): Token is being created, initialize empty state
 			tokenValue := input.TokenValue
 			if tokenValue == 0 {
+				// cannot derive FT value and it cannot be 0, as the quorum needs to pledge the sum of FT values
+				if input.TokenTypeName == constants.TokenType_FT {
+					return nil, nil, nil, fmt.Errorf("FT value is 0 for token %s", input.TokenID)
+				}
 				// Try to derive from token ID
 				if derived, err := util.GetTokenValueFromTokenID(input.TokenID); err == nil && derived > 0 {
 					tokenValue = derived
@@ -149,6 +153,10 @@ func (w *Wallet) BuildPersistencePayload(ctx context.Context, transactionID stri
 			tokenValue := input.TokenValue
 
 			if tokenValue == 0 {
+				// cannot derive FT value and it cannot be 0, as the quorum needs to pledge the sum of FT values
+				if input.TokenTypeName == constants.TokenType_FT {
+					return nil, nil, nil, fmt.Errorf("FT value is 0 for token %s", input.TokenID)
+				}
 				if derived, err := util.GetTokenValueFromTokenID(input.TokenID); err == nil && derived > 0 {
 					tokenValue = derived
 				}

--- a/core/wallet/post_consensus_persistence.go
+++ b/core/wallet/post_consensus_persistence.go
@@ -151,7 +151,14 @@ func (pc *PostConsensusPersistenceCoordinator) Persist(ctx context.Context, req 
 		}
 	}
 	if len(req.TransactionInfo.Tokens.FT) != 0 {
-		if err := pc.upsertFTInfo(ctx, tx, req.TokenStates, req.ExecutionRole, isLocalTransfer); err != nil {
+		// extract FTs out of all tokens
+		ftStates := make([]models.Token, 0)
+		for _, tokenInfo := range req.TokenStates {
+			if tokenInfo.TokenType == int16(models.GetTokenTypeID(constants.TokenType_FT)) {
+				ftStates = append(ftStates, tokenInfo)
+			}
+		}
+		if err := pc.upsertFTInfo(ctx, tx, ftStates, req.ExecutionRole, isLocalTransfer); err != nil {
 			return err
 		}
 	}

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -419,6 +419,21 @@ func (w *Wallet) ReleaseAllLockedRBTTokensForDID(ctx context.Context, ownerDID s
 	return err
 }
 
+// ReleaseAllLockedFTTokensForDID resets all Locked FTs for a DID back to Free.
+// Called on transaction failure after LockTokensForSplit to prevent tokens from staying
+// permanently locked when the transaction does not complete.
+func (w *Wallet) ReleaseAllLockedFTTokensForDID(ctx context.Context, ownerDID string, referenceId string) error {
+	_, err := w.db.Pool().Exec(ctx,
+		`UPDATE tokens SET token_status=$1, updated_at=$2, lock_reference_id=NULL
+		 WHERE did=$4
+		   AND token_status=$5
+		   AND lock_reference_id=$3
+		   AND token_type=(SELECT id FROM token_type WHERE name=$6)`,
+		constants.TokenStatus_Free, time.Now(), referenceId, ownerDID, constants.TokenStatus_Locked, constants.TokenType_FT,
+	)
+	return err
+}
+
 // ReleaseAllLockedNFTAndSCTokensForDID resets all Locked NFT and SmartContract tokens for a DID
 // back to their correct executable status. Unlike RBT tokens (which return to Free), NFT/SC
 // tokens must return to Deployed or Executed depending on their latest role:


### PR DESCRIPTION
### Problems

1. **Token Value:** Currently, when a Receiver receives some FTs, it does not receive it's token value (in RBT). So, when the Receiver tries to send the FTs further, it cannot determine the required pledge value.
2. **Peer Info:** When a peer's PeerID is not found, in localnet, the node is trying to fetch it from mainnet explorer, which would not have localnet peer information.

### Solution

1. **Token Value:** This PR is adding token value of FT in the Transaction Info, while sending Tokens to Receiver
2. **Peer Info:** This PR is skipping peer info fetch from explorer in case of local net