### PR TITLE
Sai/fixing token status in case of syncing

### DIFF
--- a/core/consensus/checks.go
+++ b/core/consensus/checks.go
@@ -209,6 +209,19 @@ func ValidateTokenOwnershipByPrevTxn(txnInfo *models.TransactionInfo, isFullnode
 				if !getTransactionTokens(&pledgedTxnInfo, &prevTxnInfo) {
 					return fmt.Errorf("no common transaction tokens found between pledged transaction %s and previous transaction %s", *previousTransactionID, prevTxnID)
 				}
+
+				//If above 2 checks pass, we are sure that, the token is a unpledged token, which previously got pledged.
+				//now ensure that initiator is same as the guy who has pledged this token previously.
+				//we have to get the quorum DID which has pledged this token from the list of quorumDIDs.
+				//check whether that quorumDID is same as the initiatorDID or not
+				quorumDID, err := wallet.FindDIDByTokenID(txnInfo.Quorums, tokenID)
+				if err != nil {
+					return fmt.Errorf("failed to get quorum DID for token %s: %w", tokenID, err)
+				}
+				if quorumDID != txnInfo.Initiator {
+					return fmt.Errorf("ownership mismatch: initiator %s does not match quorum %s of token %s", txnInfo.Initiator, quorumDID, tokenID)
+				}
+
 			} else {
 				//If previous txn details are not there in the fullnode side, sync those transaction details from the initiator.
 				//In general, Previous transaction won't be nil, because we are calling this function after the sync in the  TokenChainIntigretyCheck function.
@@ -288,6 +301,18 @@ func ValidateTokenOwnershipByPrevTxn(txnInfo *models.TransactionInfo, isFullnode
 					if !getTransactionTokens(&pledgedTxnInfo, &prevTxnInfo) {
 						return fmt.Errorf("no common transaction tokens found between pledged transaction %s and previous transaction %s", *previousTransactionID, prevTx.ID)
 					}
+					//If above 2 checks pass, we are sure that, the token is a unpledged token, which previously got pledged.
+					//now ensure that initiator is same as the guy who has pledged this token previously.
+					//we have to get the quorum DID which has pledged this token from the list of quorumDIDs.
+					//check whether that quorumDID is same as the quorumDID or not
+					quorumDID, err := wallet.FindDIDByTokenID(txnInfo.Quorums, t.TokenID)
+					if err != nil {
+						return fmt.Errorf("failed to get quorum DID for token %s: %w", t.TokenID, err)
+					}
+					if quorumDID != quorum.Did {
+						return fmt.Errorf("ownership mismatch: initiator %s does not match quorum %s of token %s", txnInfo.Initiator, quorumDID, t.TokenID)
+					}
+
 				} else {
 					//If previous txn details are not there in the fullnode side, sync those transaction details from the initiator.
 					//In general, Previous transaction won't be nil, because we are calling this function after the sync in the  TokenChainIntigretyCheck function.

--- a/core/wallet/fullnode_persistence.go
+++ b/core/wallet/fullnode_persistence.go
@@ -102,7 +102,9 @@ func (w *Wallet) PersistFullNodeTransaction(ctx context.Context, req *FullNodePe
 		if roleName == constants.TokenRole_Transfer && input.tokenInfo.PreviousTransactionID == "" {
 			roleName = constants.TokenRole_Mint
 		}
+		w.log.Debug("PersistFullNodeTransaction:PreviousTransactionID1 is :", input.tokenInfo.PreviousTransactionID)
 		if roleName == constants.TokenRole_Execute && input.tokenInfo.PreviousTransactionID == "" {
+			w.log.Debug("PersistFullNodeTransaction:PreviousTransactionID2 is :", input.tokenInfo.PreviousTransactionID)
 			roleName = constants.TokenRole_Deploy
 		}
 

--- a/core/wallet/fullnode_persistence.go
+++ b/core/wallet/fullnode_persistence.go
@@ -204,7 +204,7 @@ func collectFullNodeTokenInputs(txInfo *models.TransactionInfo) ([]fullNodeToken
 		if err := appendInputs(txInfo.Tokens.FT, constants.TokenType_FT, constants.TokenRole_Transfer); err != nil {
 			return nil, nil, err
 		}
-		if err := appendInputs(txInfo.Tokens.NFT, constants.TokenType_NFT, constants.TokenRole_Deploy); err != nil {
+		if err := appendInputs(txInfo.Tokens.NFT, constants.TokenType_NFT, constants.TokenRole_Execute); err != nil {
 			return nil, nil, err
 		}
 		if err := appendInputs(txInfo.Tokens.SmartContract, constants.TokenType_SmartContract, constants.TokenRole_Execute); err != nil {

--- a/core/wallet/fullnode_persistence.go
+++ b/core/wallet/fullnode_persistence.go
@@ -37,6 +37,32 @@ type fullNodeTokenState struct {
 	exists         bool
 }
 
+// This function returns the quorumDID corresponding the tokenID from the pledged tokens
+func FindDIDByTokenID(quorums []*models.QuorumInfo, tokenID string) (string, error) {
+	if tokenID == "" {
+		return "", fmt.Errorf("tokenID is empty")
+	}
+
+	for _, q := range quorums {
+		if q == nil {
+			continue
+		}
+		for _, t := range q.Tokens {
+			if t == nil {
+				continue
+			}
+			if t.TokenID == tokenID {
+				if q.Did == "" {
+					return "", fmt.Errorf("did is empty for tokenID %q", tokenID)
+				}
+				return q.Did, nil
+			}
+		}
+	}
+
+	return "", fmt.Errorf("tokenID %q not found in quorum tokens", tokenID)
+}
+
 func (w *Wallet) PersistFullNodeTransaction(ctx context.Context, req *FullNodePersistenceRequest) error {
 	if w == nil {
 		return fmt.Errorf("fullnode persistence: wallet is nil")
@@ -322,6 +348,15 @@ func deriveFullNodeTokenState(existing fullNodeTokenState, txInfo *models.Transa
 	if txInfo.Owner != "" {
 		state.did = txInfo.Owner
 	}
+	//If it is a pledged token, did should be updated as the quorumDID.
+	if input.roleName == constants.TokenRole_Pledge {
+		quorumDID, err := FindDIDByTokenID(txInfo.Quorums, input.tokenInfo.TokenID)
+		if err != nil {
+			return fullNodeTokenState{}
+		}
+		state.did = quorumDID
+	}
+
 	// Keep status aligned with role-derived transitions.
 	switch input.roleName {
 	case constants.TokenRole_Burn:
@@ -775,10 +810,35 @@ func (w *Wallet) PersistFullNodeSyncedTokenChain(
 	if err != nil {
 		return err
 	}
+	//whether the token is already present in the database or not, derive the token_status from the transactionInfo or tokenchain
 	if !tokenState.exists {
 		tokenState.tokenID = tokenID
+		// tokenState.tokenStatus = int16(constants.TokenStatus_Free)
+	}
+	//we have to derive the token_status depending on the role of the token in the transaction.
+	switch lastRole {
+	case int16(models.GetTokenRoleID(constants.TokenRole_Mint)):
+		tokenState.tokenStatus = int16(constants.TokenStatus_Generated)
+	case int16(models.GetTokenRoleID(constants.TokenRole_Transfer)):
+		tokenState.tokenStatus = int16(constants.TokenStatus_Transferred)
+	case int16(models.GetTokenRoleID(constants.TokenRole_Commit)):
+		tokenState.tokenStatus = int16(constants.TokenStatus_Committed)
+	case int16(models.GetTokenRoleID(constants.TokenRole_Pledge)):
+		tokenState.tokenStatus = int16(constants.TokenStatus_Pledged)
+	case int16(models.GetTokenRoleID(constants.TokenRole_Unpledge)):
+		tokenState.tokenStatus = int16(constants.TokenStatus_Free)
+	case int16(models.GetTokenRoleID(constants.TokenRole_Burn)):
+		tokenState.tokenStatus = int16(constants.TokenStatus_Burnt)
+	case int16(models.GetTokenRoleID(constants.TokenRole_Uncommit)):
+		tokenState.tokenStatus = int16(constants.TokenStatus_Free)
+	case int16(models.GetTokenRoleID(constants.TokenRole_Execute)):
+		tokenState.tokenStatus = int16(constants.TokenStatus_Executed)
+	case int16(models.GetTokenRoleID(constants.TokenRole_Deploy)):
+		tokenState.tokenStatus = int16(constants.TokenStatus_Deployed)
+	default:
 		tokenState.tokenStatus = int16(constants.TokenStatus_Free)
 	}
+
 	if tokenValue > 0 {
 		tokenState.tokenValue = tokenValue
 	}


### PR DESCRIPTION
1. fixes wrong updation of token role in case of NFT execution in fullnode token chain table .
2.  added previous ownership check in case of pledge token gets transferred or once again pledge; 
3.  token status was also not getting updated in fullnode_rbt table when token gets synced from other node
These 3 issues have been solved in this PR.