### PR TITLE
Fix API : /rubix/v1/tx/{txn_id}

### DIFF
--- a/core/transaction.go
+++ b/core/transaction.go
@@ -863,7 +863,7 @@ func (c *Core) GetTransactionByID(txId string) (*models.TransactionInfo, error) 
 		return nil, fmt.Errorf("failed to get transactions details for tx: %v, err: %v", txId, err)
 	}
 
-	var txInfo *models.TransactionInfo
+	txInfo := &models.TransactionInfo{}
 	if err := json.Unmarshal(transactionDetail.Info, txInfo); err != nil {
 		return nil, fmt.Errorf("failed to unmarshal transaction info, err: %v", err)
 	}


### PR DESCRIPTION
### Problem
The API `/rubix/v1/tx/{txn_id}` had unmarshal error : 
```
json: Unmarshal(nil *models.TransactionInfo)
```
The error was due to passing nil pointer into Unmarshal() to write into.

### Solution
Passing an allocated object of type `models.TransactionInfo` into Unmarshal() to write into