### PR TITLE
Support zero-value NFTs, preserve owner on subscriber execute, restrict value changes to the owner

### DIFF
--- a/core/sync.go
+++ b/core/sync.go
@@ -474,12 +474,31 @@ func (c *Core) applyTokenChainFromSync(tokenID string, remoteTxs []types.Transac
 	case int16(models.GetTokenRoleID(constants.TokenRole_Execute)):
 		lastStatus = int16(constants.TokenStatus_Executed)
 	}
-	tokenForUpdate.DID = lastOwnerDID
+	// For NFT executions, ownership doesn't change
+	// in sync with the chain head when a non-owner subscriber executes an NFT.
+	if lastEntry.Role == int16(models.GetTokenRoleID(constants.TokenRole_Execute)) &&
+		tokenForUpdate.TokenType != int16(models.GetTokenTypeID(constants.TokenType_SmartContract)) {
+		// Leave tokenForUpdate.DID at its existing value.
+	} else {
+		tokenForUpdate.DID = lastOwnerDID
+	}
 	tokenForUpdate.TransactionID = newTxs[len(newTxs)-1].tx.ID
 	tokenForUpdate.LatestPosition = lastEntry.Position
 	tokenForUpdate.LatestRole = lastEntry.Role
 	tokenForUpdate.TokenStatus = lastStatus
 	tokenForUpdate.UpdatedAt = time.Now()
+
+	// NFT value is mutable per execution and per transfer.
+	// RBT/FT/SC values are immutable across the chain and stay as set at creation.
+	if tokenForUpdate.TokenType == int16(models.GetTokenTypeID(constants.TokenType_NFT)) && lastTxInfo.Tokens != nil {
+		for _, t := range lastTxInfo.Tokens.NFT {
+			if t != nil && t.TokenID == tokenID {
+				tokenForUpdate.TokenValue = t.TokenValue
+				break
+			}
+		}
+	}
+
 	if updateErr := c.w.UpdateToken(tokenForUpdate); updateErr != nil {
 		return fmt.Errorf("applyTokenChainFromSync: UpdateToken for %s: %w", tokenID, updateErr)
 	}

--- a/core/sync/transaction_chain.go
+++ b/core/sync/transaction_chain.go
@@ -9,7 +9,6 @@ import (
 	"github.com/rubixchain/rubixgoplatform/constants"
 	"github.com/rubixchain/rubixgoplatform/core/ipfsport"
 	"github.com/rubixchain/rubixgoplatform/core/wallet"
-	"github.com/rubixchain/rubixgoplatform/math"
 	"github.com/rubixchain/rubixgoplatform/types/models"
 	"github.com/rubixchain/rubixgoplatform/util"
 	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
@@ -102,8 +101,6 @@ func FindTokenRoleInTxn(tokenID string, txInfo *models.TransactionInfo, transfer
 }
 
 // findTokenValue returns the TokenValue for tokenID from any token list in txInfo.
-// For NFT tokens with a TokenValue of 0, MinTransferAmount() is pledged so that
-// the splitting logic always has a non-zero amount to work with.
 // Returns 0 if not found.
 func findTokenValue(tokenID string, txInfo *models.TransactionInfo) float64 {
 	if txInfo.Tokens != nil {
@@ -114,9 +111,6 @@ func findTokenValue(tokenID string, txInfo *models.TransactionInfo) float64 {
 		}
 		for _, t := range txInfo.Tokens.NFT {
 			if t.TokenID == tokenID {
-				if t.TokenValue == 0 {
-					return math.MinTransferAmount()
-				}
 				return t.TokenValue
 			}
 		}

--- a/core/sync/transaction_chain.go
+++ b/core/sync/transaction_chain.go
@@ -9,6 +9,7 @@ import (
 	"github.com/rubixchain/rubixgoplatform/constants"
 	"github.com/rubixchain/rubixgoplatform/core/ipfsport"
 	"github.com/rubixchain/rubixgoplatform/core/wallet"
+	"github.com/rubixchain/rubixgoplatform/math"
 	"github.com/rubixchain/rubixgoplatform/types/models"
 	"github.com/rubixchain/rubixgoplatform/util"
 	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
@@ -101,7 +102,8 @@ func FindTokenRoleInTxn(tokenID string, txInfo *models.TransactionInfo, transfer
 }
 
 // findTokenValue returns the TokenValue for tokenID from any token list in txInfo.
-// For NFT tokens, a minimum value of 1.0 is enforced (1 RBT must always be pledged).
+// For NFT tokens with a TokenValue of 0, MinTransferAmount() is pledged so that
+// the splitting logic always has a non-zero amount to work with.
 // Returns 0 if not found.
 func findTokenValue(tokenID string, txInfo *models.TransactionInfo) float64 {
 	if txInfo.Tokens != nil {
@@ -112,8 +114,8 @@ func findTokenValue(tokenID string, txInfo *models.TransactionInfo) float64 {
 		}
 		for _, t := range txInfo.Tokens.NFT {
 			if t.TokenID == tokenID {
-				if t.TokenValue < 1.0 {
-					return 1.0
+				if t.TokenValue == 0 {
+					return math.MinTransferAmount()
 				}
 				return t.TokenValue
 			}

--- a/core/transaction_builder.go
+++ b/core/transaction_builder.go
@@ -51,6 +51,13 @@ func BuildTransactionInfoFromRequest(
 	var totalAmount float64
 	var allCommittedTokens []*models.TokenInfo
 
+	// nftCurrentOwner is captured from the wallet's tokens row when an existing
+	// NFT is locked for execution. It is used below to pin txInfo.Owner for
+	// NFT-only execute transactions so the chain payload accurately reflects the
+	// current owner. Stays empty for deploys and for
+	// non-NFT flows.
+	var nftCurrentOwner string
+
 	// --- RBT path (separate — CollectRBTTokens manages its own locking) ---
 	if req.HasRBT() {
 		var genTX *models.Transactions = nil
@@ -221,11 +228,19 @@ func BuildTransactionInfoFromRequest(
 					tok := locked[0]
 					log.Info("BuildTransactionInfoFromRequest: NFT locked for execution", "nftID", tok.TokenID, "prevTxID", tok.TransactionID)
 
-					// A non-zero request value overrides the wallet's stored value
-					// (NFT value is mutable per execution). Zero/omitted falls back
-					// to the wallet's stored value.
+					// Capture the chain owner cached in the wallet row. Used below to
+					// pin txInfo.Owner for NFT-only execute transactions so the chain
+					// payload reflects the actual on-chain owner instead of the
+					// initiator default.
+					nftCurrentOwner = tok.DID
+
+					// only the current owner is allowed to update the value
+					// subscriber the request value is silently ignored and the wallet's
+					// stored value is used unchanged.
+					//
+					// Data can still be set by any executor.
 					chosenValue := nftInfo.Value
-					if chosenValue == 0 {
+					if chosenValue == 0 || req.Initiator != tok.DID {
 						chosenValue = tok.TokenValue
 					}
 
@@ -378,6 +393,26 @@ func BuildTransactionInfoFromRequest(
 	txInfoOwner := req.Owner
 	if txInfoOwner == "" {
 		txInfoOwner = req.Initiator
+	}
+
+	// For an NFT-only single-NFT execute (transferNFTOwnership=false), set
+	// txInfoOwner to the NFT's current chain owner so the transaction record
+	// shows who actually owns the NFT, even when a non-owner is executing it.
+	// Persistence and sync already keep ownership correct on every node — this
+	// just makes the chain payload easier to read directly.
+	//
+	// Skipped when:
+	//   - Deploy: no existing owner yet.
+	//   - Transfer (transferNFTOwnership=true): req.Owner is the new owner.
+	//   - Mixed-asset: Owner carries the RBT/FT receiver; NFT side handled by persistence.
+	//   - Multi-NFT: a single Owner field can't represent multiple owners.
+	if !req.Tokens.TransferNFTOwnership &&
+		nftCurrentOwner != "" &&
+		len(req.Tokens.NFT) == 1 &&
+		req.Tokens.RBT == 0 &&
+		len(req.Tokens.FT) == 0 &&
+		len(req.Tokens.SmartContract) == 0 {
+		txInfoOwner = nftCurrentOwner
 	}
 
 	txInfo := &models.TransactionInfo{

--- a/core/transaction_builder.go
+++ b/core/transaction_builder.go
@@ -220,14 +220,30 @@ func BuildTransactionInfoFromRequest(
 					}
 					tok := locked[0]
 					log.Info("BuildTransactionInfoFromRequest: NFT locked for execution", "nftID", tok.TokenID, "prevTxID", tok.TransactionID)
+
+					// A non-zero request value overrides the wallet's stored value
+					// (NFT value is mutable per execution). Zero/omitted falls back
+					// to the wallet's stored value.
+					chosenValue := nftInfo.Value
+					if chosenValue == 0 {
+						chosenValue = tok.TokenValue
+					}
+
 					txTokens.NFT = append(txTokens.NFT, &models.TokenInfo{
 						TokenID:               tok.TokenID,
 						PreviousTransactionID: tok.TransactionID,
 						Data:                  nftInfo.Data,
-						TokenValue:            tok.TokenValue,
+						TokenValue:            chosenValue,
 					})
 					allLockedIDs = append(allLockedIDs, tok.TokenID)
-					totalAmount += tok.TokenValue
+
+					// Pledge contribution is floored to MinDecimalUnit so the quorum
+					// always locks a non-zero amount even for zero-value NFTs.
+					pledgeContribution := chosenValue
+					if pledgeContribution < rubixmath.MinDecimalUnit() {
+						pledgeContribution = rubixmath.MinDecimalUnit()
+					}
+					totalAmount = rubixmath.AddFloat(totalAmount, pledgeContribution)
 				} else {
 					// DEPLOYMENT MODE: Token doesn't exist, prepare for deployment
 					log.Info("BuildTransactionInfoFromRequest: NFT does not exist - DEPLOYMENT MODE", "nftID", nftInfo.NFTId, "value", nftInfo.Value)
@@ -238,7 +254,12 @@ func BuildTransactionInfoFromRequest(
 						Data:                  nftInfo.Data,
 						TokenValue:            nftInfo.Value,
 					})
-					totalAmount += nftInfo.Value
+
+					pledgeContribution := nftInfo.Value
+					if pledgeContribution < rubixmath.MinDecimalUnit() {
+						pledgeContribution = rubixmath.MinDecimalUnit()
+					}
+					totalAmount = rubixmath.AddFloat(totalAmount, pledgeContribution)
 				}
 			}
 		}

--- a/core/wallet/post_consensus_payload_builder.go
+++ b/core/wallet/post_consensus_payload_builder.go
@@ -145,10 +145,21 @@ func (w *Wallet) BuildPersistencePayload(ctx context.Context, transactionID stri
 		}
 
 		state := currentToken
-		if state.TokenValue == 0 {
+		if input.TokenTypeName == constants.TokenType_NFT {
+			// NFT value is mutable per execution and per transfer. input.TokenValue
+			// carries the resolved value from BuildTransactionInfoFromRequest
+			// (either a non-zero request override or the wallet's fallback value),
+			// so we always mirror it into the wallet record. Zero is permitted.
+			state.TokenValue = input.TokenValue
+		} else if state.TokenValue == 0 {
+			// RBT / FT / SmartContract: only resolve a value when the wallet has
+			// none yet (genesis / receiver-first-time path). Existing non-zero
+			// values are preserved across transfers.
 			tokenValue := input.TokenValue
 
 			if tokenValue == 0 {
+				// GetTokenValueFromTokenID parses RBT-style IDs; it cleanly fails
+				// for FT/SC IDs and we skip the assignment in that case.
 				if derived, err := util.GetTokenValueFromTokenID(input.TokenID); err == nil && derived > 0 {
 					tokenValue = derived
 				}

--- a/core/wallet/post_consensus_payload_builder.go
+++ b/core/wallet/post_consensus_payload_builder.go
@@ -194,8 +194,11 @@ func (w *Wallet) BuildPersistencePayload(ctx context.Context, transactionID stri
 			}
 			state.TokenStatus = int16(constants.TokenStatus_Deployed)
 		case input.RoleName == constants.TokenRole_Execute:
-			// SC/NFT Execution - token stays with initiator in Executed status
-			if txInfo.Initiator != "" {
+			// SmartContract execute: ownership moves to the executor (initiator).
+			// NFT (and anything else) execute: keep the existing owner — state.DID stays
+			// at currentToken.DID (fetched from the chain head), so non-owner subscribers
+			// can execute without overwriting the chain's owner.
+			if input.TokenTypeName == constants.TokenType_SmartContract && txInfo.Initiator != "" {
 				state.DID = txInfo.Initiator
 			}
 			state.TokenStatus = int16(constants.TokenStatus_Executed)

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -285,11 +285,11 @@ func (w *Wallet) GetTokensFromDenomMap(denomMap map[types.DenomValue]types.Denom
 func (w *Wallet) UpdateToken(token models.Token) error {
 	if _, err := w.db.Pool().Exec(w.Ctx,
 		`UPDATE tokens SET did=$1, transaction_id=$2, token_state_hash=$3,
-		 token_status=$4, latest_position=$5, latest_role=$6, updated_at=NOW()
-		 WHERE token_id=$7`,
+		 token_status=$4, latest_position=$5, latest_role=$6, token_value=$7, updated_at=NOW()
+		 WHERE token_id=$8`,
 		token.DID, token.TransactionID, token.TokenStateHash,
 		token.TokenStatus, token.LatestPosition, token.LatestRole,
-		token.TokenID,
+		token.TokenValue, token.TokenID,
 	); err != nil {
 		return fmt.Errorf("failed to update token %v: %w", token.TokenID, err)
 	}

--- a/math/math.go
+++ b/math/math.go
@@ -18,6 +18,18 @@ func FloatPrecision(f float64) float64 {
 	return float64(round(f*output)) / output
 }
 
+// MaxSupportedDecimalPlaces returns the maximum number of decimal places
+// allowed for a Rubix transfer amount.
+func MaxSupportedDecimalPlaces() int {
+	return constants.MaxSupportedDecimalPlaces
+}
+
+// MinTransferAmount returns the smallest amount that can be transferred in
+// Rubix, i.e. 10^-MaxSupportedDecimalPlaces (0.001 at 3 decimal places).
+func MinTransferAmount() float64 {
+	return FloatPrecision(math.Pow10(-constants.MaxSupportedDecimalPlaces))
+}
+
 func ZeroFloat() float64 {
 	return FloatPrecision(0.0)
 }

--- a/math/math.go
+++ b/math/math.go
@@ -24,9 +24,9 @@ func MaxSupportedDecimalPlaces() int {
 	return constants.MaxSupportedDecimalPlaces
 }
 
-// MinTransferAmount returns the smallest amount that can be transferred in
-// Rubix, i.e. 10^-MaxSupportedDecimalPlaces (0.001 at 3 decimal places).
-func MinTransferAmount() float64 {
+// MinDecimalUnit returns the smallest representable value at the configured
+// decimal precision, i.e. 10^-MaxSupportedDecimalPlaces (0.001 at 3 decimal places).
+func MinDecimalUnit() float64 {
 	return FloatPrecision(math.Pow10(-constants.MaxSupportedDecimalPlaces))
 }
 


### PR DESCRIPTION
## Summary
  
  - Zero-value NFTs can now be deployed and executed.
  - Subscribers can execute an NFT without changing the owner.
  - Only the owner can change the NFT's value; the `data` field stays freely settable.
  - Multi-asset transactions (RBT transfer + NFT execute) work correctly.