### PR TITLE
Add minter-allowlist check on the quorum side

### DIFF
--- a/core/consensus/checks.go
+++ b/core/consensus/checks.go
@@ -937,6 +937,10 @@ func ValidateTransaction(
 		return false, fmt.Errorf("ValidateTransaction: %w", err)
 	}
 
+	if err := ValidateMinterAllowlist(&txnInfo, isFullnode, w, log, syncTxChains, testnet, mainnet); err != nil {
+		return false, fmt.Errorf("ValidateTransaction: %w", err)
+	}
+
 	// 7. ValidateTokenIDRelatedChecks for each RBT token in Tokens and CommittedTokens and pledged tokens
 	if txnInfo.Tokens.RBT != nil {
 		for _, token := range txnInfo.Tokens.RBT {

--- a/core/consensus/minter_allowlist.go
+++ b/core/consensus/minter_allowlist.go
@@ -1,0 +1,116 @@
+package consensus
+
+import (
+	"fmt"
+
+	"github.com/rubixchain/rubixgoplatform/core/minterallowlist"
+	"github.com/rubixchain/rubixgoplatform/core/wallet"
+	"github.com/rubixchain/rubixgoplatform/types/models"
+	"github.com/rubixchain/rubixgoplatform/util"
+	"github.com/rubixchain/rubixgoplatform/wrapper/logger"
+)
+
+// genesisInitiatorLookup is the wallet method this gate uses. An interface so
+// tests can swap in a fake.
+type genesisInitiatorLookup interface {
+	GetGenesisInitiatorDID(tokenID string, isFullNode bool) (string, error)
+}
+
+// ValidateMinterAllowlist checks that every RBT in the transaction was minted
+// by an allowed DID. For part tokens, it checks the whole-token ancestor.
+//
+// The list used depends on the network: AllowedMinters on mainnet,
+// TestnetAllowedMinters on testnet. On localnet the check is skipped.
+//
+// Must run after TokenChainIntegrityCheck so the local chain is up to date.
+// NFT, FT, and SmartContract entries are skipped.
+func ValidateMinterAllowlist(
+	txnInfo *models.TransactionInfo,
+	isFullnode bool,
+	w *wallet.Wallet,
+	log logger.Logger,
+	syncTxChains func(peerDID string, tokenIDs []string, prevTxIDs map[string]string, excludeTxIDs []string) error,
+	testnet, mainnet bool,
+) error {
+	return validateMinterAllowlist(txnInfo, isFullnode, w, log, syncTxChains, testnet, mainnet)
+}
+
+// validateMinterAllowlist is the test-friendly entry that takes an interface
+// for the wallet lookup.
+func validateMinterAllowlist(
+	txnInfo *models.TransactionInfo,
+	isFullnode bool,
+	w genesisInitiatorLookup,
+	log logger.Logger,
+	syncTxChains func(peerDID string, tokenIDs []string, prevTxIDs map[string]string, excludeTxIDs []string) error,
+	testnet, mainnet bool,
+) error {
+	if txnInfo == nil || txnInfo.Tokens == nil {
+		return nil
+	}
+
+	var (
+		table         []minterallowlist.MintAccessRange
+		expectedLevel int
+	)
+	switch {
+	case mainnet:
+		table = minterallowlist.AllowedMinters
+		expectedLevel = 1
+	case testnet:
+		table = minterallowlist.TestnetAllowedMinters
+		expectedLevel = 50001
+	default:
+		// Localnet: skip the check.
+		return nil
+	}
+
+	for _, t := range txnInfo.Tokens.RBT {
+		if t == nil || t.TokenID == "" {
+			continue
+		}
+		elems, err := util.GetRbtIDElements(t.TokenID)
+		if err != nil {
+			return fmt.Errorf("ValidateMinterAllowlist: %w", err)
+		}
+		level, number := elems.TokenLevel, elems.TokenNumber
+		if level != expectedLevel {
+			return fmt.Errorf("ValidateMinterAllowlist: token %s has level %d; expected level %d for this network",
+				t.TokenID, level, expectedLevel)
+		}
+		wholeID := fmt.Sprintf("%d_%d", level, number)
+
+		minter, lookupErr := w.GetGenesisInitiatorDID(wholeID, isFullnode)
+		if lookupErr != nil && elems.PartIndex != 0 && syncTxChains != nil {
+			// Part-token transfer: the whole-token chain may not be local yet.
+			// Pull it from the initiator and try the lookup again.
+			log.Debug("ValidateMinterAllowlist: whole-token chain missing locally for part transfer, syncing from initiator",
+				"partTokenID", t.TokenID, "wholeID", wholeID, "peerDID", txnInfo.Initiator)
+			if syncErr := syncTxChains(
+				txnInfo.Initiator,
+				[]string{wholeID},
+				map[string]string{wholeID: ""},
+				nil,
+			); syncErr != nil {
+				return fmt.Errorf("ValidateMinterAllowlist: whole-token sync failed for %s (whole %s): %w",
+					t.TokenID, wholeID, syncErr)
+			}
+			minter, lookupErr = w.GetGenesisInitiatorDID(wholeID, isFullnode)
+		}
+		if lookupErr != nil {
+			log.Error("ValidateMinterAllowlist: cannot resolve genesis initiator",
+				"tokenID", t.TokenID, "wholeID", wholeID, "err", lookupErr)
+			return fmt.Errorf("ValidateMinterAllowlist: minter unverifiable for token %s (whole %s): %w",
+				t.TokenID, wholeID, lookupErr)
+		}
+
+		if !minterallowlist.ValidateMinterAuthorization(table, minter, level, number) {
+			log.Error("ValidateMinterAllowlist: rejection",
+				"tokenID", t.TokenID, "wholeID", wholeID,
+				"minter", minter, "level", level, "tokenNumber", number)
+			return fmt.Errorf("ValidateMinterAllowlist: token %s minter %s not authorised for level %d number %d",
+				t.TokenID, minter, level, number)
+		}
+	}
+	return nil
+}

--- a/core/consensus/minter_allowlist.go
+++ b/core/consensus/minter_allowlist.go
@@ -16,7 +16,8 @@ type genesisInitiatorLookup interface {
 	GetGenesisInitiatorDID(tokenID string, isFullNode bool) (string, error)
 }
 
-// ValidateMinterAllowlist checks that every RBT in the transaction was minted
+// ValidateMinterAllowlist checks that every RBT in the transaction — both
+// transferred and committed (split parents / SC-committed RBT) — was minted
 // by an allowed DID. For part tokens, it checks the whole-token ancestor.
 //
 // Enforced only on mainnet (uses AllowedMinters). Testnet enforcement is
@@ -45,7 +46,7 @@ func validateMinterAllowlist(
 	syncTxChains func(peerDID string, tokenIDs []string, prevTxIDs map[string]string, excludeTxIDs []string) error,
 	testnet, mainnet bool,
 ) error {
-	if txnInfo == nil || txnInfo.Tokens == nil {
+	if txnInfo == nil {
 		return nil
 	}
 
@@ -68,7 +69,11 @@ func validateMinterAllowlist(
 		return nil
 	}
 
-	for _, t := range txnInfo.Tokens.RBT {
+	var rbtTokens []*models.TokenInfo
+	if txnInfo.Tokens != nil {
+		rbtTokens = txnInfo.Tokens.RBT
+	}
+	for _, t := range append(rbtTokens, txnInfo.CommittedTokens...) {
 		if t == nil || t.TokenID == "" {
 			continue
 		}

--- a/core/consensus/minter_allowlist.go
+++ b/core/consensus/minter_allowlist.go
@@ -19,8 +19,8 @@ type genesisInitiatorLookup interface {
 // ValidateMinterAllowlist checks that every RBT in the transaction was minted
 // by an allowed DID. For part tokens, it checks the whole-token ancestor.
 //
-// The list used depends on the network: AllowedMinters on mainnet,
-// TestnetAllowedMinters on testnet. On localnet the check is skipped.
+// Enforced only on mainnet (uses AllowedMinters). Testnet enforcement is
+// wired but disabled — see the switch below.
 //
 // Must run after TokenChainIntegrityCheck so the local chain is up to date.
 // NFT, FT, and SmartContract entries are skipped.
@@ -57,11 +57,14 @@ func validateMinterAllowlist(
 	case mainnet:
 		table = minterallowlist.AllowedMinters
 		expectedLevel = 1
-	case testnet:
-		table = minterallowlist.TestnetAllowedMinters
-		expectedLevel = 50001
+	// Testnet enforcement is currently disabled. Re-enable by uncommenting
+	// the case below; TestnetAllowedMinters is still defined and tested.
+	// case testnet:
+	// 	table = minterallowlist.TestnetAllowedMinters
+	// 	expectedLevel = 50001
 	default:
-		// Localnet: skip the check.
+		// Testnet and localnet: skip the check.
+		_ = testnet
 		return nil
 	}
 

--- a/core/minterallowlist/mint_access_control.go
+++ b/core/minterallowlist/mint_access_control.go
@@ -1,0 +1,45 @@
+// Package minterallowlist holds the list of DIDs allowed to mint tokens, used
+// to check transfers.
+package minterallowlist
+
+// MintAccessRange is one minter's allowed token-number range at a given level.
+type MintAccessRange struct {
+	DID              string
+	Level            int
+	StartTokenNumber int
+	EndTokenNumber   int
+}
+
+// AllowedMinters lists the DIDs that minted mainnet tokens, and which token
+// numbers each one owns.
+var AllowedMinters = []MintAccessRange{
+	{DID: "bafybmid35wgktknwpaddfxkgdrouq5z2cmcdz27gf2u4xvrh4pswmrnvpe", Level: 1, StartTokenNumber: 1, EndTokenNumber: 400000},
+	{DID: "bafybmifogacbfyny7wahapjuk7jpjl3ffylsakmtbrcqmdwckofnsg6rbu", Level: 1, StartTokenNumber: 400001, EndTokenNumber: 800000},
+	{DID: "bafybmielnukpgfknvyrsocrvxshplwecjv3bqapt6my3juy4fa6gez4zmy", Level: 1, StartTokenNumber: 800001, EndTokenNumber: 1200000},
+	{DID: "bafybmie6vd43nyvzesubkfddpydja6rwlxijsgkcjfsthovlbujclm3td4", Level: 1, StartTokenNumber: 1200001, EndTokenNumber: 1600000},
+	{DID: "bafybmieybmtvh22j2kzjr5w4yzptbeax3musw7rcqwz6vkaejemn53qsvi", Level: 1, StartTokenNumber: 1600001, EndTokenNumber: 2000000},
+	{DID: "bafybmighj3g2ip7c5wmfzulcfkdo6t4734oekbpeb7mh73nyp4sv4mvyqu", Level: 1, StartTokenNumber: 2000001, EndTokenNumber: 2400000},
+	{DID: "bafybmifty4w2ccl3zcclaehgong5vhuocr3pnabccfnn27z2e6knxx7aye", Level: 1, StartTokenNumber: 2400001, EndTokenNumber: 2800000},
+	{DID: "bafybmifk4dzbmjl434kdn32u4m4rzr6qgyvu7t4jtql2muqn7lx5fyj6aa", Level: 1, StartTokenNumber: 2800001, EndTokenNumber: 3200000},
+	{DID: "bafybmihm6nutigowauas3232pgxhm3sk4xr4o7t7q7j4ejklh4hkmrrjna", Level: 1, StartTokenNumber: 3200001, EndTokenNumber: 3600000},
+	{DID: "bafybmibw2b7hokbfvcdqb6u53gbve276oc2x2svaalklgzv4mzgfadw7cm", Level: 1, StartTokenNumber: 3600001, EndTokenNumber: 4000000},
+	{DID: "bafybmifmwqhlscye636ui5ajybavpvyfb6gf25m3kkxhm7pewc6slh3yue", Level: 1, StartTokenNumber: 4000001, EndTokenNumber: 4300000},
+}
+
+// TestnetAllowedMinters lists the testnet faucet DID and its token-number
+// range.
+var TestnetAllowedMinters = []MintAccessRange{
+	{DID: "bafybmiairxfiplfpwvzzgslubbx3dwqrutwhrgtypnzyb752rrjbthgrwm", Level: 50001, StartTokenNumber: 1, EndTokenNumber: 4300000},
+}
+
+// ValidateMinterAuthorization returns true if (did, level, number) is in the
+// list.
+func ValidateMinterAuthorization(table []MintAccessRange, did string, level, number int) bool {
+	for _, m := range table {
+		if m.DID == did && m.Level == level {
+			return number >= m.StartTokenNumber && number <= m.EndTokenNumber
+		}
+	}
+	return false
+}
+

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -257,7 +257,11 @@ func (c *Core) initiateConsensusHandler(request *ensweb.Request) *ensweb.Result 
 	isTransactionInfoValidated, err := consensus.ValidateTransaction(txn, c.fullNode, c.w, c.log, initiatorDIDCrypto, nil, c.testnet, c.mainnet, c.localnet, c.checkTokenStateHashPinned, syncTxChains)
 	if err != nil || !isTransactionInfoValidated {
 		c.log.Error("initiateConsensusHandler: transaction info validation failed", "err", err)
-		response.Message = "initiateConsensusHandler: transaction info validation failed"
+		if err != nil {
+			response.Message = fmt.Sprintf("initiateConsensusHandler: transaction info validation failed: %v", err)
+		} else {
+			response.Message = "initiateConsensusHandler: transaction info validation failed"
+		}
 		return c.l.RenderJSON(request, response, http.StatusBadRequest)
 	}
 

--- a/core/wallet/token_chain.go
+++ b/core/wallet/token_chain.go
@@ -259,6 +259,24 @@ func (w *Wallet) GetTokenChainByTokenID(tokenID string, isFullNode bool) ([]mode
 	return result, nil
 }
 
+// GetGenesisInitiatorDID returns the DID that minted the token.
+func (w *Wallet) GetGenesisInitiatorDID(tokenID string, isFullNode bool) (string, error) {
+	genesisTx, err := w.GetGenesisTransaction(tokenID, isFullNode)
+	if err != nil {
+		return "", fmt.Errorf("GetGenesisInitiatorDID: %w", err)
+	}
+	var parsed struct {
+		Initiator string `json:"initiator"`
+	}
+	if err := json.Unmarshal(genesisTx.Info, &parsed); err != nil {
+		return "", fmt.Errorf("GetGenesisInitiatorDID: unmarshal info for token %s: %w", tokenID, err)
+	}
+	if parsed.Initiator == "" {
+		return "", fmt.Errorf("GetGenesisInitiatorDID: empty initiator in genesis info for token %s", tokenID)
+	}
+	return parsed.Initiator, nil
+}
+
 // GetTokenChainByTokenIDAndPrevTxnId fetches up to 100 tokenchain rows for a token
 // starting from the row whose previous_transaction_id matches txnID.
 // Pass txnID = "" to fetch from genesis (position = 0) — handles the first-sync case


### PR DESCRIPTION
# RBT Transfer Minter Validation Enforcement

Quorums now reject any RBT transfer whose token (or part-token ancestor) was **not minted by an approved DID within that DID's authorised level-1 range**.

The validation check runs inside `ValidateTransaction` **after** `TokenChainIntegrityCheck`.

## Behaviour

- **Mainnet:** Enforced against `AllowedMinters`
- **Testnet:** Wired but currently disabled (table and switch case retained for future re-enable)
- **Localnet:** Skipped
- **NFT / FT / SmartContract:** Not affected

## Part-Token Handling

For part-tokens, the validation gate looks up the **whole-token ancestor**.

If the whole-token chain is not available locally (e.g. first-time part-token receive), it is fetched from the initiator on demand before validation proceeds.

---

# Approved Minters (Mainnet - Level 1)

| #  | DID | Authorised Token Range |
|----|-----|------------------------|
| 1  | `bafybmid35wgktknwpaddfxkgdrouq5z2cmcdz27gf2u4xvrh4pswmrnvpe` | 1 – 400,000 |
| 2  | `bafybmifogacbfyny7wahapjuk7jpjl3ffylsakmtbrcqmdwckofnsg6rbu` | 400,001 – 800,000 |
| 3  | `bafybmielnukpgfknvyrsocrvxshplwecjv3bqapt6my3juy4fa6gez4zmy` | 800,001 – 1,200,000 |
| 4  | `bafybmie6vd43nyvzesubkfddpydja6rwlxijsgkcjfsthovlbujclm3td4` | 1,200,001 – 1,600,000 |
| 5  | `bafybmieybmtvh22j2kzjr5w4yzptbeax3musw7rcqwz6vkaejemn53qsvi` | 1,600,001 – 2,000,000 |
| 6  | `bafybmighj3g2ip7c5wmfzulcfkdo6t4734oekbpeb7mh73nyp4sv4mvyqu` | 2,000,001 – 2,400,000 |
| 7  | `bafybmifty4w2ccl3zcclaehgong5vhuocr3pnabccfnn27z2e6knxx7aye` | 2,400,001 – 2,800,000 |
| 8  | `bafybmifk4dzbmjl434kdn32u4m4rzr6qgyvu7t4jtql2muqn7lx5fyj6aa` | 2,800,001 – 3,200,000 |
| 9  | `bafybmihm6nutigowauas3232pgxhm3sk4xr4o7t7q7j4ejklh4hkmrrjna` | 3,200,001 – 3,600,000 |
| 10 | `bafybmibw2b7hokbfvcdqb6u53gbve276oc2x2svaalklgzv4mzgfadw7cm` | 3,600,001 – 4,000,000 |
| 11 | `bafybmifmwqhlscye636ui5ajybavpvyfb6gf25m3kkxhm7pewc6slh3yue` | 4,000,001 – 4,300,000 |

---

## Summary

**Total authorised supply:** `4,300,000 RBT tokens`

## Validation Rule Summary

An RBT transfer is considered valid only if:

1. The token (or its whole-token ancestor in case of part-tokens) was minted by an approved DID.
2. The minted token number falls within that DID’s authorised level-1 range.
3. `TokenChainIntegrityCheck` passes before this validation executes.

Otherwise, the quorum rejects the transaction.