### PR TITLE
adding validateMinterAllowlist check for the fullnode;

### DIFF
--- a/core/consensus/checks.go
+++ b/core/consensus/checks.go
@@ -792,7 +792,17 @@ func TokenChainIntegrityCheck(
 	}
 	for tokenType, tokens := range tokenLists {
 		for _, t := range tokens {
+			//If the previous transaction id is empty, then it is the genesis transaction.
+			//In that case, first check whether the same token details are present in the tokenchain table or not,
+			//If it is present, then check whether its transactionId is same as the current transactionID or not.
+			//If it is not same, it should through an error, it it is same,just continue.
 			if t.PreviousTransactionID == "" {
+				//get the token details from the tokenchain table
+				latestTransactionID, err := w.GetLatestTransactionIdByTokenId(t.TokenID, isFullnode)
+				if err == nil && latestTransactionID != currentTxID {
+					return fmt.Errorf("TokenChainIntigrityCheck: token details already exist in the tokenchain table, so once again genesis transaction is not allowed, for token %s: latestTransactionID %s != currentTxID %s", t.TokenID, latestTransactionID, currentTxID)
+				}
+				//If there is no token with the same tokenID, then it is the first transaction of the token, so skip the check.
 				continue
 			}
 			allTokens = append(allTokens, tokenCheck{
@@ -1002,6 +1012,7 @@ func ValidateTransaction(
 		return false, fmt.Errorf("ValidateTransaction: %w", err)
 	}
 
+	//If transaction is a genesis transaction fullnode should do the below check addordingly
 	if err := ValidateMinterAllowlist(&txnInfo, isFullnode, w, log, syncTxChains, testnet, mainnet); err != nil {
 		return false, fmt.Errorf("ValidateTransaction: %w", err)
 	}

--- a/core/consensus/minter_allowlist.go
+++ b/core/consensus/minter_allowlist.go
@@ -18,7 +18,8 @@ type genesisInitiatorLookup interface {
 
 // ValidateMinterAllowlist checks that every RBT in the transaction — both
 // transferred and committed (split parents / SC-committed RBT) — was minted
-// by an allowed DID. For part tokens, it checks the whole-token ancestor.
+// by an allowed DID. On fullnodes, pledged quorum tokens are checked too.
+// For part tokens, it checks the whole-token ancestor.
 //
 // Enforced only on mainnet (uses AllowedMinters). Testnet enforcement is
 // wired but disabled — see the switch below.
@@ -60,20 +61,29 @@ func validateMinterAllowlist(
 		expectedLevel = 1
 	// Testnet enforcement is currently disabled. Re-enable by uncommenting
 	// the case below; TestnetAllowedMinters is still defined and tested.
-	// case testnet:
-	// 	table = minterallowlist.TestnetAllowedMinters
-	// 	expectedLevel = 50001
+	case testnet:
+		table = minterallowlist.TestnetAllowedMinters
+		expectedLevel = 50001
 	default:
 		// Testnet and localnet: skip the check.
 		_ = testnet
 		return nil
 	}
 
-	var rbtTokens []*models.TokenInfo
+	tokensToCheck := make([]*models.TokenInfo, 0)
 	if txnInfo.Tokens != nil {
-		rbtTokens = txnInfo.Tokens.RBT
+		tokensToCheck = append(tokensToCheck, txnInfo.Tokens.RBT...)
 	}
-	for _, t := range append(rbtTokens, txnInfo.CommittedTokens...) {
+	tokensToCheck = append(tokensToCheck, txnInfo.CommittedTokens...)
+	if isFullnode {
+		for _, q := range txnInfo.Quorums {
+			if q == nil {
+				continue
+			}
+			tokensToCheck = append(tokensToCheck, q.Tokens...)
+		}
+	}
+	for _, t := range tokensToCheck {
 		if t == nil || t.TokenID == "" {
 			continue
 		}
@@ -104,6 +114,21 @@ func validateMinterAllowlist(
 					t.TokenID, wholeID, syncErr)
 			}
 			minter, lookupErr = w.GetGenesisInitiatorDID(wholeID, isFullnode)
+		}
+		// Fallback: if local genesis lookup still fails and the current
+		// transaction declares itself as the mint for this whole token
+		// (PartIndex == 0 and PreviousTransactionID is empty), then the
+		// transaction we are about to persist IS the genesis. In that case
+		// the minter is the transaction initiator — no DB row exists yet
+		// because the genesis chain row is created by this very transaction.
+		if lookupErr != nil && elems.PartIndex == 0 && t.PreviousTransactionID == "" {
+			if txnInfo.Initiator == "" {
+				return fmt.Errorf("ValidateMinterAllowlist: genesis transaction for token %s has empty initiator", t.TokenID)
+			}
+			log.Debug("ValidateMinterAllowlist: local genesis missing; current transaction is the genesis, using initiator as minter",
+				"tokenID", t.TokenID, "wholeID", wholeID, "initiator", txnInfo.Initiator)
+			minter = txnInfo.Initiator
+			lookupErr = nil
 		}
 		if lookupErr != nil {
 			log.Error("ValidateMinterAllowlist: cannot resolve genesis initiator",

--- a/core/wallet/fullnode_persistence.go
+++ b/core/wallet/fullnode_persistence.go
@@ -76,7 +76,6 @@ func (w *Wallet) PersistFullNodeTransaction(ctx context.Context, req *FullNodePe
 	if ctx == nil {
 		ctx = w.Ctx
 	}
-	w.log.Debug("PersistFullNodeTransaction: previous txnID is: ***", req.TransactionInfo.Tokens.SmartContract[0].PreviousTransactionID)
 
 	inputs, affectedTokenIDs, err := collectFullNodeTokenInputs(req.TransactionInfo)
 	if err != nil {

--- a/core/wallet/transaction.go
+++ b/core/wallet/transaction.go
@@ -106,12 +106,11 @@ func (w *Wallet) GetLatestTransaction(tokenId string, isFullNode bool) (*models.
 	return w.GetTransactionByID(latestTxnId, isFullNode)
 }
 
-// get latest transaction id of the given token id
+// GetGenesisTransactionIdByTokenId returns the mint (position-0) transaction id for a token.
 func (w *Wallet) GetGenesisTransactionIdByTokenId(tokenID string, isFullNode bool) (string, error) {
 	var row pgx.Row
-	var err error
 	if isFullNode {
-		row, err = w.db.Pool().Query(w.Ctx,
+		row = w.db.Pool().QueryRow(w.Ctx,
 			`SELECT transaction_id 
      		FROM fullnode_tokenchain 
      		WHERE id = (
@@ -122,7 +121,7 @@ func (w *Wallet) GetGenesisTransactionIdByTokenId(tokenID string, isFullNode boo
 			tokenID,
 		)
 	} else {
-		row, err = w.db.Pool().Query(w.Ctx,
+		row = w.db.Pool().QueryRow(w.Ctx,
 			`SELECT transaction_id 
      		FROM tokenchain 
      		WHERE id = (
@@ -133,15 +132,12 @@ func (w *Wallet) GetGenesisTransactionIdByTokenId(tokenID string, isFullNode boo
 			tokenID,
 		)
 	}
-	if err != nil {
-		return "", fmt.Errorf("GetGenesisTransactionIdByTokenId: %w", err)
-	}
 	var genesisTxnId string
 	if err := row.Scan(&genesisTxnId); err != nil {
 		if err == pgx.ErrNoRows {
-			return "", fmt.Errorf("genesis transaction id not found for the token %s", tokenID)
+			return "", fmt.Errorf("genesis transaction id not found for the token %s, genesisTransactionId: %s", tokenID, genesisTxnId)
 		}
-		return "", fmt.Errorf("GetTransactionIdByIndex scan: %w", err)
+		return "", fmt.Errorf("GetGenesisTransactionIdByTokenId scan: %w", err)
 	}
 	return genesisTxnId, nil
 }
@@ -159,7 +155,7 @@ func (w *Wallet) ReturnLatestTransactionIdByTokenId(tokenID string) (string, err
 		)`,
 		tokenID,
 	)
-	
+
 	var latestTxnId string
 	if err := row.Scan(&latestTxnId); err != nil {
 		if err == pgx.ErrNoRows {
@@ -169,7 +165,6 @@ func (w *Wallet) ReturnLatestTransactionIdByTokenId(tokenID string) (string, err
 	}
 	return latestTxnId, nil
 }
-
 
 // get latest transaction id of the given token id
 func (w *Wallet) GetLatestTransactionIdByTokenId(tokenID string, isFullNode bool) (string, error) {
@@ -231,7 +226,7 @@ func (w *Wallet) GetTransactionIdByIndex(index int16, isFullNode bool) (string, 
 	return txnId, nil
 }
 
-// GetTransactionsByDIDAndTokenType returns transaction history of a given DID and token_type, 
+// GetTransactionsByDIDAndTokenType returns transaction history of a given DID and token_type,
 // and in case of RBT it does not return split/burnt transactions where initiator=owner
 func (w *Wallet) GetTransactionsByDIDAndTokenType(did, tokenType string) ([]models.Transactions, error) {
 	rows, err := w.db.Pool().Query(w.Ctx,


### PR DESCRIPTION
1. Other than the quorum, Fullnode will do the validateMinterAllowlist check if,in case of genesis token creation transaction itself, but in case of quorum, quorum will do validateMinterAllowlist check when a token gets transferred(because quorum is not involved in case generating a token). 
2. Fullnode will do the validateMinterAllowlist check in case of pledged tokens as well where as quorums will do the validateMinterAllowlist check only in case of committed tokens and transaction tokens.
