### PR TITLE
Remove synchronous receiver sync path

### DIFF
--- a/core/consensus/checks.go
+++ b/core/consensus/checks.go
@@ -792,7 +792,17 @@ func TokenChainIntegrityCheck(
 	}
 	for tokenType, tokens := range tokenLists {
 		for _, t := range tokens {
+			//If the previous transaction id is empty, then it is the genesis transaction.
+			//In that case, first check whether the same token details are present in the tokenchain table or not,
+			//If it is present, then check whether its transactionId is same as the current transactionID or not.
+			//If it is not same, it should through an error, it it is same,just continue.
 			if t.PreviousTransactionID == "" {
+				//get the token details from the tokenchain table
+				latestTransactionID, err := w.GetLatestTransactionIdByTokenId(t.TokenID, isFullnode)
+				if err == nil && latestTransactionID != currentTxID {
+					return fmt.Errorf("TokenChainIntigrityCheck: token details already exist in the tokenchain table, so once again genesis transaction is not allowed, for token %s: latestTransactionID %s != currentTxID %s", t.TokenID, latestTransactionID, currentTxID)
+				}
+				//If there is no token with the same tokenID, then it is the first transaction of the token, so skip the check.
 				continue
 			}
 			allTokens = append(allTokens, tokenCheck{
@@ -1002,6 +1012,7 @@ func ValidateTransaction(
 		return false, fmt.Errorf("ValidateTransaction: %w", err)
 	}
 
+	//If transaction is a genesis transaction fullnode should do the below check addordingly
 	if err := ValidateMinterAllowlist(&txnInfo, isFullnode, w, log, syncTxChains, testnet, mainnet); err != nil {
 		return false, fmt.Errorf("ValidateTransaction: %w", err)
 	}

--- a/core/consensus/minter_allowlist.go
+++ b/core/consensus/minter_allowlist.go
@@ -18,7 +18,8 @@ type genesisInitiatorLookup interface {
 
 // ValidateMinterAllowlist checks that every RBT in the transaction — both
 // transferred and committed (split parents / SC-committed RBT) — was minted
-// by an allowed DID. For part tokens, it checks the whole-token ancestor.
+// by an allowed DID. On fullnodes, pledged quorum tokens are checked too.
+// For part tokens, it checks the whole-token ancestor.
 //
 // Enforced only on mainnet (uses AllowedMinters). Testnet enforcement is
 // wired but disabled — see the switch below.
@@ -60,20 +61,29 @@ func validateMinterAllowlist(
 		expectedLevel = 1
 	// Testnet enforcement is currently disabled. Re-enable by uncommenting
 	// the case below; TestnetAllowedMinters is still defined and tested.
-	// case testnet:
-	// 	table = minterallowlist.TestnetAllowedMinters
-	// 	expectedLevel = 50001
+	case testnet:
+		table = minterallowlist.TestnetAllowedMinters
+		expectedLevel = 50001
 	default:
 		// Testnet and localnet: skip the check.
 		_ = testnet
 		return nil
 	}
 
-	var rbtTokens []*models.TokenInfo
+	tokensToCheck := make([]*models.TokenInfo, 0)
 	if txnInfo.Tokens != nil {
-		rbtTokens = txnInfo.Tokens.RBT
+		tokensToCheck = append(tokensToCheck, txnInfo.Tokens.RBT...)
 	}
-	for _, t := range append(rbtTokens, txnInfo.CommittedTokens...) {
+	tokensToCheck = append(tokensToCheck, txnInfo.CommittedTokens...)
+	if isFullnode {
+		for _, q := range txnInfo.Quorums {
+			if q == nil {
+				continue
+			}
+			tokensToCheck = append(tokensToCheck, q.Tokens...)
+		}
+	}
+	for _, t := range tokensToCheck {
 		if t == nil || t.TokenID == "" {
 			continue
 		}
@@ -104,6 +114,21 @@ func validateMinterAllowlist(
 					t.TokenID, wholeID, syncErr)
 			}
 			minter, lookupErr = w.GetGenesisInitiatorDID(wholeID, isFullnode)
+		}
+		// Fallback: if local genesis lookup still fails and the current
+		// transaction declares itself as the mint for this whole token
+		// (PartIndex == 0 and PreviousTransactionID is empty), then the
+		// transaction we are about to persist IS the genesis. In that case
+		// the minter is the transaction initiator — no DB row exists yet
+		// because the genesis chain row is created by this very transaction.
+		if lookupErr != nil && elems.PartIndex == 0 && t.PreviousTransactionID == "" {
+			if txnInfo.Initiator == "" {
+				return fmt.Errorf("ValidateMinterAllowlist: genesis transaction for token %s has empty initiator", t.TokenID)
+			}
+			log.Debug("ValidateMinterAllowlist: local genesis missing; current transaction is the genesis, using initiator as minter",
+				"tokenID", t.TokenID, "wholeID", wholeID, "initiator", txnInfo.Initiator)
+			minter = txnInfo.Initiator
+			lookupErr = nil
 		}
 		if lookupErr != nil {
 			log.Error("ValidateMinterAllowlist: cannot resolve genesis initiator",

--- a/core/nft.go
+++ b/core/nft.go
@@ -7,6 +7,7 @@ package core
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"path"
@@ -105,16 +106,22 @@ func (c *Core) ensureNFTArtifactAndSubscription(nftID string) error {
 
 		nft, err := c.fetchContractInfo(nftID)
 		if err != nil {
-			c.log.Error("ensureNFTArtifactAndSubscription: failed to fetch NFT metadata", "nft_token", nftID, "err", err)
-			return fmt.Errorf("ensureNFTArtifactAndSubscription: failed to fetch NFT metadata for %s: %w", nftID, err)
-		}
+			// Child NFTs have no metadata/artifact, so skip the fetch and
+			// rely on chain sync. Other errors are still fatal.
+			if errors.Is(err, ErrContractMetadataInvalid) {
+				c.log.Info("ensureNFTArtifactAndSubscription: NFT has no contract metadata (child NFT), skipping artifact fetch", "nft_token", nftID)
+			} else {
+				c.log.Error("ensureNFTArtifactAndSubscription: failed to fetch NFT metadata", "nft_token", nftID, "err", err)
+				return fmt.Errorf("ensureNFTArtifactAndSubscription: failed to fetch NFT metadata for %s: %w", nftID, err)
+			}
+		} else {
+			if err := c.GetNFTFromIpfs(nftID, nft.ArtifactHash); err != nil {
+				c.log.Error("ensureNFTArtifactAndSubscription: failed to fetch NFT artifact from IPFS", "nft_token", nftID, "artifact_hash", nft.ArtifactHash, "err", err)
+				return fmt.Errorf("ensureNFTArtifactAndSubscription: failed to fetch NFT artifact for %s: %w", nftID, err)
+			}
 
-		if err := c.GetNFTFromIpfs(nftID, nft.ArtifactHash); err != nil {
-			c.log.Error("ensureNFTArtifactAndSubscription: failed to fetch NFT artifact from IPFS", "nft_token", nftID, "artifact_hash", nft.ArtifactHash, "err", err)
-			return fmt.Errorf("ensureNFTArtifactAndSubscription: failed to fetch NFT artifact for %s: %w", nftID, err)
+			c.log.Info("ensureNFTArtifactAndSubscription: NFT fetched successfully", "nft_token", nftID)
 		}
-
-		c.log.Info("ensureNFTArtifactAndSubscription: NFT fetched successfully", "nft_token", nftID)
 	} else {
 		c.log.Debug("ensureNFTArtifactAndSubscription: NFT folder already exists, skipping fetch", "nft_token", nftID, "path", nftFolderPath)
 	}

--- a/core/smart_contract.go
+++ b/core/smart_contract.go
@@ -24,6 +24,10 @@ const (
 	ExecuteType int = 2
 )
 
+// ErrContractMetadataInvalid means the content at a token hash isn't valid
+// contract metadata JSON. Expected for child NFTs, which have no metadata.
+var ErrContractMetadataInvalid = errors.New("contract metadata is not valid IPFSContractInfo JSON")
+
 type NewState struct {
 	ConOwnerDID string `json:"contract_ownwer_did"`
 	ConHash     string `json:"contract_hash"`
@@ -506,7 +510,7 @@ func (c *Core) fetchContractInfo(tokenHash string) (*models.IPFSContractInfo, er
 	// Parse into unified struct
 	var contractInfo models.IPFSContractInfo
 	if err := json.Unmarshal(metadataBytes, &contractInfo); err != nil {
-		return nil, fmt.Errorf("fetchContractInfo: failed to parse contract metadata JSON: %w", err)
+		return nil, fmt.Errorf("fetchContractInfo: %w: %v", ErrContractMetadataInvalid, err)
 	}
 
 	return &contractInfo, nil

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -519,18 +519,9 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 		}
 
 		if !isOwnerDIDLocal {
-			c.log.Info("InitiateTransaction: Sending tokens to receiver (synchronous)", "receiver", nextOwnerDID, "transactionID", transactionId)
-			asyncMode := false
-			if asyncMode {
-				go c.sendTokensToReceiver(nextOwnerDID, transactionId, transactionInfo, signatureTobePublished, request)
-			} else {
-				if err := c.sendTokensToReceiverSync(nextOwnerDID, transactionId, transactionInfo, signatureTobePublished, request); err != nil {
-					c.log.Error("InitiateTransaction: receiver sync failed", "err", err)
-					resp.Status = false
-					resp.Message = "Transaction failed: receiver sync failed: " + err.Error()
-					return resp
-				}
-			}
+			// Best-effort push to the receiver. Failure does not fail the transaction.
+			c.log.Info("InitiateTransaction: Notifying receiver asynchronously", "receiver", nextOwnerDID, "transactionID", transactionId)
+			go c.sendTokensToReceiver(nextOwnerDID, transactionId, transactionInfo, signatureTobePublished, request)
 		} else {
 			c.log.Info("InitiateTransaction: Owner DID is local — receiver state handled by initiator persistence", "receiver", nextOwnerDID, "transactionID", transactionId)
 		}
@@ -649,103 +640,23 @@ func (c *Core) sendTokensToReceiver(
 	)
 
 	if err != nil {
-		c.log.Warn("sendTokensToReceiver: Failed to sync tokens to receiver (will retry later)",
+		c.log.Warn("sendTokensToReceiver: Failed to sync tokens with the receiver",
 			"receiver", receiverDID,
 			"transactionID", transactionID,
 			"err", err)
+		return
+	}
+	if !sendTokensResponse.Status {
+		c.log.Warn("sendTokensToReceiver: Receiver rejected the tokens",
+			"receiver", receiverDID,
+			"transactionID", transactionID,
+			"message", sendTokensResponse.Message)
 		return
 	}
 
 	c.log.Info("sendTokensToReceiver: Receiver sync completed successfully",
 		"receiver", receiverDID,
 		"transactionID", transactionID)
-}
-
-// sendTokensToReceiver sends transaction tokens to the receiver synchronously.
-// This function is designed avoid running as a goroutine and handles all errors externally.
-// It will block or fail the main transaction flow.
-func (c *Core) sendTokensToReceiverSync(
-	receiverDID string,
-	transactionID string,
-	txInfo *models.TransactionInfo,
-	signature *models.Signature,
-	request *models.TransactionRequest,
-) error {
-	c.log.Debug("sendTokensToReceiver: Starting async receiver sync",
-		"receiver", receiverDID,
-		"transactionID", transactionID)
-
-	// Get receiver peer connection
-	receiverPeer, err := c.getPeer(receiverDID)
-	if err != nil {
-		c.log.Warn("sendTokensToReceiver: Receiver offline, will sync later",
-			"receiver", receiverDID,
-			"transactionID", transactionID,
-			"err", err)
-		return fmt.Errorf("sendTokensToReceiver: Receiver offline, will sync later ",
-			" receiver: ", receiverDID,
-			" transactionID: ", transactionID,
-			" err: ", err)
-	}
-	defer receiverPeer.Close()
-
-	// Prepare sync request
-	// For smartcontracts we need not send the token information to the receiver, we just need to publish it.
-	// For NFTs we need to check the particular boolean in the request for sending.
-	// For RBTs we need to send the entire token information.
-	var sendTokensRequest models.SendTokensRequest
-	var sendTokensResponse model.BasicResponse
-	sendTokensRequest.Tokens = txInfo.Tokens
-	sendTokensRequest.TransactionInfo = txInfo
-	sendTokensRequest.Signature = signature
-	if request.HasNFT() {
-		sendTokensRequest.NFTOwnershipTransfer = request.Tokens.TransferNFTOwnership
-	}
-
-	// prepare did info to share with receiver
-	algoID, err := c.w.GetDidAlgoIDByName(constants.DidAlgo_SECP256K1)
-	if err != nil {
-		errMsg := fmt.Sprintf("sendTokensToReceiver: failed to get algo ID of Initiator, will sync later; receiver: %s, transactionID: %s, err: %s", receiverDID, transactionID, err)
-		c.log.Warn(errMsg)
-		return fmt.Errorf(errMsg)
-	}
-	sendTokensRequest.InitiatorPeerInfo = &models.DID{
-		DID:    txInfo.Initiator,
-		PeerID: c.peerID,
-		AlgoID: algoID,
-	}
-
-	// Send tokens to receiver with 2-minute timeout
-	// SendJSONRequest has built-in retry logic (3 attempts with exponential backoff)
-	err = receiverPeer.SendJSONRequest(
-		"POST",
-		APISendTokens,
-		nil,
-		&sendTokensRequest,
-		&sendTokensResponse,
-		true,
-		2*time.Minute, // Timeout for the entire operation
-	)
-
-	if err != nil {
-		c.log.Warn("sendTokensToReceiver: Failed to sync tokens to receiver (will retry later)",
-			"receiver", receiverDID,
-			"transactionID", transactionID,
-			"err", err)
-		return fmt.Errorf("sendTokensToReceiver: Failed to sync tokens to receiver (will retry later)",
-			" receiver: ", receiverDID,
-			" transactionID: ", transactionID,
-			" err: ", err)
-	}
-	if !sendTokensResponse.Status {
-		return fmt.Errorf("receiver rejected: %s", sendTokensResponse.Message)
-	}
-
-	c.log.Info("sendTokensToReceiver: Receiver sync completed successfully",
-		"receiver", receiverDID,
-		"transactionID", transactionID)
-
-	return nil
 }
 
 // This has been added here since this is part of the transaction flow.

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -510,13 +510,8 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 		// Receiver sync needed — but skip network round-trip if receiver is on this node.
 		// In that case, the initiator persistence (with isLocalTransfer=true) has already
 		// recorded receiver-side token state via BuildPersistencePayload.
-		var isOwnerDIDLocal bool
-		isOwnerDIDLocal, err = c.w.IsLocalDID(nextOwnerDID)
-		if err != nil {
-			c.log.Error("InitiateTransaction: Failed to check if owner DID is local", "ownerDID", nextOwnerDID, "err", err)
-			resp.Message = "InitiateTransaction: Failed to check if owner DID is local: " + err.Error()
-			return resp
-		}
+		// Unknown owner DID returns ErrNoRows; treat as not-local and proceed to async sync.
+		isOwnerDIDLocal, _ := c.w.IsLocalDID(nextOwnerDID)
 
 		if !isOwnerDIDLocal {
 			// Best-effort push to the receiver. Failure does not fail the transaction.

--- a/core/wallet/fullnode_persistence.go
+++ b/core/wallet/fullnode_persistence.go
@@ -76,7 +76,6 @@ func (w *Wallet) PersistFullNodeTransaction(ctx context.Context, req *FullNodePe
 	if ctx == nil {
 		ctx = w.Ctx
 	}
-	w.log.Debug("PersistFullNodeTransaction: previous txnID is: ***", req.TransactionInfo.Tokens.SmartContract[0].PreviousTransactionID)
 
 	inputs, affectedTokenIDs, err := collectFullNodeTokenInputs(req.TransactionInfo)
 	if err != nil {

--- a/core/wallet/post_consensus_persistence.go
+++ b/core/wallet/post_consensus_persistence.go
@@ -76,10 +76,7 @@ func (pc *PostConsensusPersistenceCoordinator) Persist(ctx context.Context, req 
 	}
 
 	// Check if the transaction is local
-	isLocalTransfer, err := pc.wallet.IsLocalDID(req.TransactionInfo.Owner)
-	if err != nil {
-		return fmt.Errorf("post-consensus persistence: failed to check if owner DID is local: %w", err)
-	}
+	isLocalTransfer, _ := pc.wallet.IsLocalDID(req.TransactionInfo.Owner)
 
 	// Ideally local transfer will only happen on the initiator side.
 	// The following prevents any invariant state where a non-initiator node mistakenly

--- a/core/wallet/transaction.go
+++ b/core/wallet/transaction.go
@@ -106,12 +106,11 @@ func (w *Wallet) GetLatestTransaction(tokenId string, isFullNode bool) (*models.
 	return w.GetTransactionByID(latestTxnId, isFullNode)
 }
 
-// get latest transaction id of the given token id
+// GetGenesisTransactionIdByTokenId returns the mint (position-0) transaction id for a token.
 func (w *Wallet) GetGenesisTransactionIdByTokenId(tokenID string, isFullNode bool) (string, error) {
 	var row pgx.Row
-	var err error
 	if isFullNode {
-		row, err = w.db.Pool().Query(w.Ctx,
+		row = w.db.Pool().QueryRow(w.Ctx,
 			`SELECT transaction_id 
      		FROM fullnode_tokenchain 
      		WHERE id = (
@@ -122,7 +121,7 @@ func (w *Wallet) GetGenesisTransactionIdByTokenId(tokenID string, isFullNode boo
 			tokenID,
 		)
 	} else {
-		row, err = w.db.Pool().Query(w.Ctx,
+		row = w.db.Pool().QueryRow(w.Ctx,
 			`SELECT transaction_id 
      		FROM tokenchain 
      		WHERE id = (
@@ -133,15 +132,12 @@ func (w *Wallet) GetGenesisTransactionIdByTokenId(tokenID string, isFullNode boo
 			tokenID,
 		)
 	}
-	if err != nil {
-		return "", fmt.Errorf("GetGenesisTransactionIdByTokenId: %w", err)
-	}
 	var genesisTxnId string
 	if err := row.Scan(&genesisTxnId); err != nil {
 		if err == pgx.ErrNoRows {
-			return "", fmt.Errorf("genesis transaction id not found for the token %s", tokenID)
+			return "", fmt.Errorf("genesis transaction id not found for the token %s, genesisTransactionId: %s", tokenID, genesisTxnId)
 		}
-		return "", fmt.Errorf("GetTransactionIdByIndex scan: %w", err)
+		return "", fmt.Errorf("GetGenesisTransactionIdByTokenId scan: %w", err)
 	}
 	return genesisTxnId, nil
 }
@@ -159,7 +155,7 @@ func (w *Wallet) ReturnLatestTransactionIdByTokenId(tokenID string) (string, err
 		)`,
 		tokenID,
 	)
-	
+
 	var latestTxnId string
 	if err := row.Scan(&latestTxnId); err != nil {
 		if err == pgx.ErrNoRows {
@@ -169,7 +165,6 @@ func (w *Wallet) ReturnLatestTransactionIdByTokenId(tokenID string) (string, err
 	}
 	return latestTxnId, nil
 }
-
 
 // get latest transaction id of the given token id
 func (w *Wallet) GetLatestTransactionIdByTokenId(tokenID string, isFullNode bool) (string, error) {
@@ -231,7 +226,7 @@ func (w *Wallet) GetTransactionIdByIndex(index int16, isFullNode bool) (string, 
 	return txnId, nil
 }
 
-// GetTransactionsByDIDAndTokenType returns transaction history of a given DID and token_type, 
+// GetTransactionsByDIDAndTokenType returns transaction history of a given DID and token_type,
 // and in case of RBT it does not return split/burnt transactions where initiator=owner
 func (w *Wallet) GetTransactionsByDIDAndTokenType(did, tokenType string) ([]models.Transactions, error) {
 	rows, err := w.db.Pool().Query(w.Ctx,


### PR DESCRIPTION
Makes receiver sync a fire-and-forget goroutine. Failure to reach the receiver no longer fails the transaction — once the quorum commits, the tx is considered successful.
