### PR TITLE
update macos and windows test cases support

### DIFF
--- a/.github/workflows/native-integration.yml
+++ b/.github/workflows/native-integration.yml
@@ -37,17 +37,17 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.22'
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.11'
 
@@ -108,11 +108,11 @@ jobs:
 
       - name: Upload run artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: native-logs-${{ matrix.os }}
           path: |
             test/docker/data/stress/logs/**
-            test/native/data/**/node.log
+            test/native/data/**/*.log
             test/native/data/**/pgdata/server.log
           if-no-files-found: warn

--- a/.github/workflows/native-integration.yml
+++ b/.github/workflows/native-integration.yml
@@ -1,0 +1,118 @@
+name: Native Integration Tests
+
+# Behavioral end-to-end suite running WITHOUT Docker: native Postgres + native
+# rubixgoplatform processes (see test/integration/env/native_env.py). This is the
+# cross-OS counterpart to docker-integration.yml (Linux/Docker only) — it proves
+# the same suite passes on macOS and Windows, where GitHub-hosted runners can't
+# run the Linux node containers.
+#
+# Each OS: install Postgres, build the node binary natively (CGO), then run the
+# --native runner against config.native.json (node_index-derived ports).
+
+on:
+  pull_request:
+    branches:
+      - release-v1
+  workflow_dispatch:
+
+concurrency:
+  group: native-integration-${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  native:
+    name: Native suite (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false   # let macOS finish even if Windows breaks, and vice-versa
+      matrix:
+        include:
+          - os: ubuntu-latest
+            bin_path: linux/rubixgoplatform
+          - os: macos-latest
+            bin_path: mac/rubixgoplatform
+          - os: windows-latest
+            bin_path: windows/rubixgoplatform.exe
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: pip install -r test/integration/requirements.txt
+
+      # ---- Postgres provisioning (per-OS) -------------------------------- #
+      # The harness manages its own 3 instances; we only need initdb/pg_ctl on
+      # PATH. Ubuntu and the Windows runner ship Postgres; macOS gets it via brew.
+      - name: Install/locate Postgres (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          # postgresql client+server are preinstalled on ubuntu-latest under
+          # /usr/lib/postgresql/<ver>/bin — add it to PATH for initdb/pg_ctl.
+          PGBIN=$(ls -d /usr/lib/postgresql/*/bin | sort -V | tail -1)
+          echo "$PGBIN" >> "$GITHUB_PATH"
+
+      - name: Install Postgres (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install postgresql@16 || true
+          echo "$(brew --prefix postgresql@16)/bin" >> "$GITHUB_PATH"
+
+      - name: Locate Postgres (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          # windows-latest ships PostgreSQL under $env:PGBIN; fall back to the
+          # standard install dir. Append to PATH so initdb/pg_ctl resolve.
+          $pgbin = $env:PGBIN
+          if (-not $pgbin) {
+            $pgbin = (Get-ChildItem 'C:\Program Files\PostgreSQL\*\bin' | Sort-Object Name -Descending | Select-Object -First 1).FullName
+          }
+          Write-Host "Postgres bin: $pgbin"
+          Add-Content -Path $env:GITHUB_PATH -Value $pgbin
+
+      # ---- Build the node binary natively (CGO, no cross-compile) --------- #
+      - name: Build rubixgoplatform (Unix)
+        if: runner.os != 'Windows'
+        env:
+          CGO_ENABLED: '1'
+        run: go build -o ${{ matrix.bin_path }}
+
+      - name: Build rubixgoplatform (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        env:
+          CGO_ENABLED: '1'
+        run: go build -o ${{ matrix.bin_path }}
+
+      # ---- Run the native suite ------------------------------------------ #
+      - name: Run native integration suite (all subsystems + negatives)
+        run: >
+          python -m test.integration.runner
+          --native
+          --config test/integration/config.native.json
+          --small-test --run-all-tests
+
+      - name: Upload run artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: native-logs-${{ matrix.os }}
+          path: |
+            test/docker/data/stress/logs/**
+            test/native/data/**/node.log
+            test/native/data/**/pgdata/server.log
+          if-no-files-found: warn

--- a/.gitignore
+++ b/.gitignore
@@ -69,6 +69,9 @@ core/storage/.migration
 # Re-ignore runtime/generated state under the harness (must come AFTER the
 # negations above so it wins).
 test/docker/data/
+# Native (no-Docker) harness runtime state: per-node data dirs, Postgres data,
+# rendered configs, and the on-demand kubo download cache (test/native/.kubo).
+test/native/
 *.log
 
 # Release notes consumed by GoReleaser (make release passes --release-notes when

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -52,6 +52,38 @@ python3 -m test.integration.runner --no-docker --run-all-tests
 Requires Docker (with compose) for the default path. The runner builds the node
 image from `test/docker/rubix/Dockerfile` and uses `test/docker/docker-compose.stress.yml`.
 
+## Native mode (no Docker — macOS / Windows)
+
+`--native` runs the same suites against a cluster of **native host processes**
+instead of containers: three local PostgreSQL instances plus three
+`rubixgoplatform` processes. This is for platforms where GitHub-hosted runners
+can't run the Linux node containers (macOS has no Docker; Windows can't run Linux
+containers). Test logic is unchanged — only the cluster lifecycle (`env/`) differs.
+
+```bash
+# Build the node binary for your OS first (repo root):
+make compile-mac        # macOS  (or compile-linux / compile-windows)
+
+# Run natively (no Docker):
+python3 -m test.integration.runner --native \
+    --config test/integration/config.native.json --small-test --run-all-tests
+```
+
+Prerequisites:
+- **PostgreSQL** installed and on PATH (e.g. `brew install postgresql@16` on
+  macOS). The harness finds `initdb`/`pg_ctl` on PATH or in common install
+  locations and manages three throwaway instances itself.
+- The **`rubixgoplatform` binary** built via `make compile-<os>` (auto-detected:
+  `mac/`, `linux/`, or `windows/`).
+- Network access on first run to fetch the pinned **kubo** (IPFS) build for your
+  OS/arch; it's cached under `test/native/.kubo/` thereafter.
+
+Native mode uses the binary's own `node_index`-derived ports (no Docker
+remapping): API **20000/20001/20002**, Postgres **5433/5434/5435** — which is why
+it needs `--config test/integration/config.native.json` (the default
+`config.json` targets the Docker-mapped ports). All runtime state lives under
+`test/native/` (gitignored). `--native` is mutually exclusive with `--no-docker`.
+
 ## Exit code
 
 The runner exits non-zero when **any** verification check fails or the run

--- a/test/integration/config.native.json
+++ b/test/integration/config.native.json
@@ -1,0 +1,64 @@
+{
+  "_comment": "Native (no-Docker) E2E config. Ports point at the node_index-derived values the rubixgoplatform binary uses when run natively (no Docker port remapping). node_index 0/1/2 => API 20000/20001/20002 (constants.RubixServerPort+idx) and Postgres 5433/5434/5435 (constants.PostgresBasePort+idx). See core/config/config.go:141-152. Used via: python3 -m test.integration.runner --native --config test/integration/config.native.json",
+
+  "node_a_port": 20000,
+  "node_b_port": 20001,
+  "quorum_port": 20002,
+  "db_a_port": 5433,
+  "db_b_port": 5434,
+  "db_q_port": 5435,
+  "password": "mypassword",
+  "output_dir": "test/docker/data/stress/logs",
+
+  "_comment_callback": "Native nodes are host processes, so the SC callback receiver is reachable at 127.0.0.1 (not host.docker.internal).",
+  "callback_url_mode": "host",
+
+  "node_a_mint": {
+    "start_index": 140000,
+    "end_index": 142000,
+    "batch_size": 2000
+  },
+  "quorum_mint": {
+    "start_index": 180000,
+    "end_index": 182000,
+    "batch_size": 2000
+  },
+
+  "_comment_buffer": "min_balance_buffer reserves RBT that the shuttle phase will NOT spend, so the later asset phases (NFT/SC/FT/bundled/all-in-one/intra-node) have funds. Must exceed the asset phases' total RBT need (~50) or those phases starve even when plenty was minted.",
+  "min_balance_buffer": 200,
+  "quorum_free_threshold": 50,
+  "max_transactions": 40,
+
+  "phases": [
+    {"name": "sequential_warmup", "concurrency": 1,  "tx_count": 20},
+    {"name": "parallel_5",        "concurrency": 5,  "tx_count": 500},
+    {"name": "parallel_10",       "concurrency": 10, "tx_count": 1000},
+    {"name": "parallel_20",       "concurrency": 20, "tx_count": 1400}
+  ],
+
+  "_comment_small": "small_test: sized so the FULL --run-all-tests matrix completes every transaction (used by CI). It's localnet, so minting is free/instant — we mint generously rather than risk starvation. Index ranges kept far apart so token-number ranges can never overlap across nodes.",
+  "small_test_overrides": {
+    "node_a_mint": {"start_index": 300000, "end_index": 300500, "batch_size": 100},
+    "quorum_mint": {"start_index": 400000, "end_index": 401000, "batch_size": 100},
+    "min_balance_buffer": 200,
+    "quorum_free_threshold": 5,
+    "max_transactions": 40,
+    "phases": [
+      {"name": "sequential_warmup", "concurrency": 1, "tx_count": 10},
+      {"name": "parallel_5",        "concurrency": 5, "tx_count": 20},
+      {"name": "parallel_10",       "concurrency": 10, "tx_count": 10}
+    ]
+  },
+
+  "_comment_micro": "micro_test: minimal budget for fast RBT-chain tracing / debugging. NOT sized for the full --run-all-tests matrix (it will starve in later phases by design). Use --small-test for a complete run-all.",
+  "micro_test_overrides": {
+    "node_a_mint": {"start_index": 600100, "end_index": 600150, "batch_size": 25},
+    "quorum_mint": {"start_index": 700100, "end_index": 700300, "batch_size": 25},
+    "min_balance_buffer": 5,
+    "quorum_free_threshold": 1,
+    "max_transactions": 5,
+    "phases": [
+      {"name": "sequential_warmup", "concurrency": 1, "tx_count": 5}
+    ]
+  }
+}

--- a/test/integration/engines/intra_node_engine.py
+++ b/test/integration/engines/intra_node_engine.py
@@ -352,12 +352,20 @@ class IntraNodeEngine:
         fund_count: int = 2,
         rounds: int = 2,
         per_round: int = 1,
+        pre_fund_settle: int = 15,
     ) -> None:
         """Fund did_a2 with ``fund_count`` FTs and bounce ``per_round`` tokens
         back-and-forth for ``rounds`` rounds.
 
         ``ft_batch`` is a dict from :class:`FTEngine._minted_fts` — needs
         ``ft_name`` and ``creator_did``.
+
+        ``pre_fund_settle`` waits before the first A->A2 fund so the quorum's
+        synced copy of the FT token chain catches up to the initiator's head.
+        Without it, on slow runners the fund transfer fails with
+        ``TokenChainIntegrityCheck: ... chain mismatch after sync`` because the
+        FT was minted/transferred in the preceding FT phase and the quorum's
+        chain head lags. Fast dev machines don't hit this; CI does.
         """
         assert self.secondary_did, "call setup_secondary_did() first"
         if not ft_batch:
@@ -377,6 +385,16 @@ class IntraNodeEngine:
             "=== INTRA-NODE FT: batch=%s  fund=%d  rounds=%d  per_round=%d ===",
             ft_name, fund_count, rounds, per_round,
         )
+
+        # Let the quorum's synced FT token chain catch up to the initiator's
+        # head before funding, so the fund transfer's TokenChainIntegrityCheck
+        # doesn't fail on a stale chain head (see docstring).
+        if pre_fund_settle > 0:
+            log.info(
+                "Settling %ds for FT '%s' token chain to sync on quorum before fund…",
+                pre_fund_settle, ft_name,
+            )
+            time.sleep(pre_fund_settle)
 
         # Initial fund — A -> A2
         self._fire_ft(

--- a/test/integration/env/native_cluster.py
+++ b/test/integration/env/native_cluster.py
@@ -1,0 +1,306 @@
+"""
+native_cluster.py — launch the 3-node Rubix cluster as native host processes.
+
+This is the no-Docker counterpart to StressDockerManager (docker_env.py). Instead
+of `docker compose up`, it runs three `rubixgoplatform` processes directly on the
+host, each in its own working directory, so the suite can run on macOS / Windows
+where Linux containers aren't available on CI.
+
+Per node it reproduces what test/docker/rubix/entrypoint.sh does in bash, but in
+cross-platform Python:
+  1. create a working dir (the node's CWD — Rubix shells out to ./ipfs relative
+     to CWD, see core/ipfs.go:41),
+  2. drop the OS-correct kubo binary (ipfs / ipfs.exe) and localnetswarm.key into
+     that dir,
+  3. render config.toml with this node's node_index (0/1/2) and DB coordinates —
+     every port (API/IPFS/swarm/DB) is derived from node_index in
+     core/config/config.go:141-152, so distinct indices give non-colliding ports,
+  4. `rubixgoplatform init -p <dir>` then `rubixgoplatform run -p <dir>` as a
+     background process,
+  5. health-check the node's HTTP API port until it answers.
+
+teardown() terminates the processes cross-platform via the Popen handle (no
+pkill / taskkill).
+
+Port derivation (core/config/config.go + constants/ipfs.go), per node_index i:
+    RubixServerPort = 20000 + i      (HTTP API the tests hit)
+    SwarmPort       = 4002  + i      (IPFS swarm — distinct per node on one host)
+    IPFSAPIPort     = 8081  + i
+    IPFSPort        = 5002  + i
+    Postgres        = 5433  + i      (matches native_postgres.py)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import shutil
+import socket
+import subprocess
+import sys
+import tarfile
+import time
+import urllib.request
+import zipfile
+from dataclasses import dataclass
+from typing import List, Optional
+
+log = logging.getLogger(__name__)
+
+_IS_WINDOWS = os.name == "nt"
+
+# Kubo version vendored for Docker (test/docker/rubix/kubo_v0.19.1_linux-amd64.tar.gz).
+# Native mode fetches the matching host build on demand.
+_KUBO_VERSION = "v0.19.1"
+_KUBO_DIST = "https://dist.ipfs.tech/kubo/{ver}/kubo_{ver}_{plat}.{ext}"
+
+# Swarm key shared by all localnet nodes (same file the Docker swarm mount uses).
+_SWARM_KEY_SRC = os.path.join("test", "docker", "swarm", "localnetswarm.key")
+
+
+@dataclass(frozen=True)
+class NativeNode:
+    """One node in the native cluster."""
+
+    name: str        # nodeA / nodeB / quorum
+    node_index: int  # 0 / 1 / 2 — drives ALL derived ports
+    db_name: str     # rubix_a / rubix_b / rubix_q
+    db_port: int     # 5433 / 5434 / 5435
+    work_dir: str    # the node's CWD / -p data dir
+
+    @property
+    def api_port(self) -> int:
+        return 20000 + self.node_index
+
+
+class NativeClusterManager:
+    """Build (config + assets), launch, health-check, and stop native nodes."""
+
+    def __init__(
+        self,
+        nodes: List[NativeNode],
+        binary: str,
+        network_mode: str = "localnet",
+        startup_timeout: int = 120,
+    ) -> None:
+        self._nodes = nodes
+        self._binary = os.path.abspath(binary)
+        self._network = network_mode
+        self._startup_timeout = startup_timeout
+        self._procs: dict[str, subprocess.Popen] = {}
+        self._ipfs_bin: Optional[str] = None  # resolved lazily in up()
+
+    # ----- lifecycle ------------------------------------------------------ #
+
+    def up(self) -> None:
+        if not os.path.isfile(self._binary):
+            raise FileNotFoundError(
+                f"rubixgoplatform binary not found at {self._binary}. "
+                f"Build it first (e.g. `make compile-mac`)."
+            )
+        self._ipfs_bin = self._resolve_kubo_binary()
+
+        for node in self._nodes:
+            self._prepare_node_dir(node)
+            self._init_node(node)
+            self._render_config(node)
+            self._launch_node(node)
+
+        for node in self._nodes:
+            self._wait_healthy(node)
+        log.info("All %d native node(s) healthy.", len(self._nodes))
+
+    def down(self) -> None:
+        for name, proc in list(self._procs.items()):
+            if proc.poll() is not None:
+                continue
+            log.info("[%s] terminating node process (pid %s)…", name, proc.pid)
+            try:
+                proc.terminate()
+                try:
+                    proc.wait(timeout=15)
+                except subprocess.TimeoutExpired:
+                    log.warning("[%s] did not exit on terminate; killing.", name)
+                    proc.kill()
+                    proc.wait(timeout=10)
+            except Exception as exc:  # noqa: BLE001
+                log.warning("[%s] teardown error: %s", name, exc)
+        self._procs.clear()
+
+    # ----- per-node setup ------------------------------------------------- #
+
+    def _prepare_node_dir(self, node: NativeNode) -> None:
+        # Fresh dir every run — no stale .ipfs/, config.toml, or DB pointers.
+        if os.path.isdir(node.work_dir):
+            shutil.rmtree(node.work_dir, ignore_errors=True)
+        os.makedirs(node.work_dir, exist_ok=True)
+
+        # Place the kubo binary as ./ipfs (or ./ipfs.exe) in the node's CWD —
+        # Rubix invokes it by relative path (core/ipfs.go:41-45).
+        ipfs_name = "ipfs.exe" if _IS_WINDOWS else "ipfs"
+        dest_ipfs = os.path.join(node.work_dir, ipfs_name)
+        shutil.copy2(self._ipfs_bin, dest_ipfs)
+        if not _IS_WINDOWS:
+            os.chmod(dest_ipfs, 0o755)
+
+        # Place the localnet swarm key in CWD — initIPFS copies it from there
+        # (core/ipfs.go:89, entrypoint.sh:72).
+        if not os.path.isfile(_SWARM_KEY_SRC):
+            raise FileNotFoundError(f"swarm key not found at {_SWARM_KEY_SRC}")
+        shutil.copy2(_SWARM_KEY_SRC, os.path.join(node.work_dir, "localnetswarm.key"))
+
+    def _init_node(self, node: NativeNode) -> None:
+        # `init` writes a default config.toml template into -p; we overwrite it
+        # with the rendered per-node config next (mirrors the Docker entrypoint:
+        # init, then envsubst the real config over the top).
+        #
+        # -p MUST be absolute: the node joins -p onto its CWD, and we set CWD to
+        # work_dir (Rubix needs ./ipfs relative to CWD). A relative -p would
+        # resolve to work_dir/work_dir and the node would read the wrong config.
+        abs_dir = os.path.abspath(node.work_dir)
+        log.info("[%s] rubixgoplatform init -p %s", node.name, abs_dir)
+        subprocess.run(
+            [self._binary, "init", "-p", abs_dir],
+            check=True, cwd=node.work_dir, capture_output=True, text=True,
+        )
+
+    def _render_config(self, node: NativeNode) -> None:
+        """Write config.toml with this node's node_index / network / DB coords.
+
+        Python replacement for envsubst — works on Windows (no gettext). The
+        node derives every port from node_index, so we only need to vary the
+        index, network mode, and DB connection per node.
+        """
+        config = _NODE_CONFIG_TEMPLATE.format(
+            node_index=node.node_index,
+            network_mode=self._network,
+            db_host="127.0.0.1",
+            db_port=node.db_port,
+            db_name=node.db_name,
+        )
+        # Write to the SAME absolute path the node reads (-p is absolute, see
+        # _init_node), so this render — not init's template — is what `run` parses.
+        cfg_path = os.path.join(os.path.abspath(node.work_dir), "config.toml")
+        with open(cfg_path, "w", encoding="utf-8") as fh:
+            fh.write(config)
+
+    def _launch_node(self, node: NativeNode) -> None:
+        log.info(
+            "[%s] starting node (index=%d, api=%d, db=%d)…",
+            node.name, node.node_index, node.api_port, node.db_port,
+        )
+        abs_dir = os.path.abspath(node.work_dir)
+        logf = open(os.path.join(abs_dir, "node.log"), "w", encoding="utf-8")
+        # CWD = work_dir is REQUIRED: Rubix runs ./ipfs and reads ./localnetswarm.key
+        # relative to CWD (entrypoint.sh:6 comment). -p is absolute so the node
+        # reads our rendered config, not a work_dir/work_dir duplicate.
+        proc = subprocess.Popen(
+            [self._binary, "run", "-p", abs_dir],
+            cwd=abs_dir,
+            stdout=logf,
+            stderr=subprocess.STDOUT,
+        )
+        self._procs[node.name] = proc
+
+    # ----- health --------------------------------------------------------- #
+
+    def _wait_healthy(self, node: NativeNode) -> None:
+        deadline = time.time() + self._startup_timeout
+        while time.time() < deadline:
+            proc = self._procs.get(node.name)
+            if proc is not None and proc.poll() is not None:
+                raise RuntimeError(
+                    f"[{node.name}] node exited early (code {proc.returncode}). "
+                    f"See {os.path.join(node.work_dir, 'node.log')}."
+                )
+            if self._tcp_open("127.0.0.1", node.api_port):
+                log.info("[%s] API reachable on :%d", node.name, node.api_port)
+                return
+            time.sleep(1.0)
+        raise TimeoutError(
+            f"[{node.name}] API port {node.api_port} not reachable within "
+            f"{self._startup_timeout}s. See {os.path.join(node.work_dir, 'node.log')}."
+        )
+
+    @staticmethod
+    def _tcp_open(host: str, port: int) -> bool:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return True
+        except OSError:
+            return False
+
+    # ----- kubo (ipfs) binary resolution ---------------------------------- #
+
+    def _resolve_kubo_binary(self) -> str:
+        """Return a path to a host-native kubo `ipfs` binary, downloading the
+        pinned version into test/native/.kubo/ if not already cached."""
+        plat = self._kubo_platform()
+        ext = "zip" if _IS_WINDOWS else "tar.gz"
+        cache_dir = os.path.join("test", "native", ".kubo", f"{_KUBO_VERSION}_{plat}")
+        ipfs_name = "ipfs.exe" if _IS_WINDOWS else "ipfs"
+        cached = os.path.join(cache_dir, ipfs_name)
+        if os.path.isfile(cached):
+            return cached
+
+        os.makedirs(cache_dir, exist_ok=True)
+        url = _KUBO_DIST.format(ver=_KUBO_VERSION, plat=plat, ext=ext)
+        archive = os.path.join(cache_dir, f"kubo.{ext}")
+        log.info("Downloading kubo %s (%s) …", _KUBO_VERSION, plat)
+        urllib.request.urlretrieve(url, archive)  # noqa: S310 (pinned dist URL)
+
+        if ext == "zip":
+            with zipfile.ZipFile(archive) as zf:
+                zf.extractall(cache_dir)
+        else:
+            with tarfile.open(archive) as tf:
+                tf.extractall(cache_dir)  # noqa: S202 (trusted dist archive)
+        extracted = os.path.join(cache_dir, "kubo", ipfs_name)
+        if not os.path.isfile(extracted):
+            raise FileNotFoundError(f"kubo archive did not contain {ipfs_name}")
+        shutil.move(extracted, cached)
+        if not _IS_WINDOWS:
+            os.chmod(cached, 0o755)
+        return cached
+
+    @staticmethod
+    def _kubo_platform() -> str:
+        """Map the host to a kubo dist platform string (e.g. darwin-arm64)."""
+        sysname = {"Darwin": "darwin", "Windows": "windows", "Linux": "linux"}.get(
+            platform.system()
+        )
+        machine = platform.machine().lower()
+        arch = "arm64" if machine in ("arm64", "aarch64") else "amd64"
+        if sysname is None:
+            raise RuntimeError(f"unsupported OS for native mode: {platform.system()}")
+        return f"{sysname}-{arch}"
+
+
+# config.toml the node parses from -p (mirrors test/docker/rubix/config.template.toml,
+# but rendered in Python). Only node_index / network_mode / db coords vary per node;
+# every port is derived from node_index by the node itself.
+_NODE_CONFIG_TEMPLATE = """\
+[core]
+node_index = {node_index}
+network_mode = "{network_mode}"
+
+[db]
+host = "{db_host}"
+port = {db_port}
+username = "rubix"
+password = "rubixpass"
+db_name = "{db_name}"
+
+[db.config]
+max_connections = 50
+min_connections = 10
+max_connection_lifetime_seconds = 60
+max_connection_idletime_seconds = 30
+statement_timeout_seconds = 20
+
+[ipfs]
+mainnet_bootstrap_nodes = []
+testnet_bootstrap_nodes = []
+localnet_bootstrap_nodes = []
+"""

--- a/test/integration/env/native_cluster.py
+++ b/test/integration/env/native_cluster.py
@@ -32,6 +32,7 @@ Port derivation (core/config/config.go + constants/ipfs.go), per node_index i:
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 import platform
@@ -73,6 +74,17 @@ class NativeNode:
     def api_port(self) -> int:
         return 20000 + self.node_index
 
+    @property
+    def swarm_port(self) -> int:
+        # constants.SwarmPort (4002) + node_index — the IPFS swarm listen port.
+        return 4002 + self.node_index
+
+    @property
+    def ipfs_api_port(self) -> int:
+        # constants.IPFSPort (5002) + node_index — the kubo HTTP API port
+        # (`ipfs --api` talks to this; see core/ipfs.go:66).
+        return 5002 + self.node_index
+
 
 class NativeClusterManager:
     """Build (config + assets), launch, health-check, and stop native nodes."""
@@ -110,6 +122,16 @@ class NativeClusterManager:
         for node in self._nodes:
             self._wait_healthy(node)
         log.info("All %d native node(s) healthy.", len(self._nodes))
+
+        # Explicitly mesh the nodes' IPFS swarms. On localnet the node dials
+        # peers by bare peerID (core/ipfsport/peer.go:114), which needs the
+        # address already in the peerstore. The only discovery mechanism is
+        # kubo's mDNS — which works between local processes on a dev machine but
+        # is blocked in sandboxed CI runners (no multicast), and the DHT is off
+        # (private swarm) with no bootstrap nodes. So we hand each node the
+        # others' explicit loopback multiaddrs; once connected, the peerstore
+        # caches them and per-transaction SwarmConnect(peerID) succeeds.
+        self._mesh_connect()
 
     def down(self) -> None:
         for name, proc in list(self._procs.items()):
@@ -230,6 +252,67 @@ class NativeClusterManager:
                 return True
         except OSError:
             return False
+
+    # ----- IPFS swarm meshing --------------------------------------------- #
+
+    def _mesh_connect(self) -> None:
+        """Explicitly connect every node's IPFS swarm to every other node via
+        loopback multiaddrs, so peering doesn't depend on mDNS/DHT discovery.
+
+        Resolves each node's peerID via `ipfs id`, then for every ordered pair
+        runs `ipfs swarm connect /ip4/127.0.0.1/tcp/<swarm>/p2p/<peerID>`.
+        """
+        # Resolve peerIDs (may need a brief retry — the kubo daemon starts a
+        # moment after the node's HTTP API is reachable).
+        peer_ids: dict[str, str] = {}
+        for node in self._nodes:
+            peer_ids[node.name] = self._wait_ipfs_id(node)
+
+        connected = 0
+        for src in self._nodes:
+            for dst in self._nodes:
+                if src.name == dst.name:
+                    continue
+                maddr = (f"/ip4/127.0.0.1/tcp/{dst.swarm_port}"
+                         f"/p2p/{peer_ids[dst.name]}")
+                rc, out, err = self._ipfs(src, "swarm", "connect", maddr)
+                if rc == 0:
+                    connected += 1
+                else:
+                    # Non-fatal per-pair: log and continue. A genuinely broken
+                    # mesh surfaces as transaction failures the suite catches.
+                    log.warning("[%s -> %s] swarm connect failed: %s",
+                                src.name, dst.name, (err or out))
+        log.info("IPFS swarm mesh: %d/%d peer connections established.",
+                 connected, len(self._nodes) * (len(self._nodes) - 1))
+
+    def _wait_ipfs_id(self, node: NativeNode, timeout: int = 30) -> str:
+        """Return node's IPFS peerID, retrying until the kubo API answers."""
+        deadline = time.time() + timeout
+        last = ""
+        while time.time() < deadline:
+            rc, out, err = self._ipfs(node, "id")
+            if rc == 0 and out:
+                try:
+                    return json.loads(out)["ID"]
+                except (ValueError, KeyError):
+                    last = out
+            else:
+                last = err or out
+            time.sleep(1.0)
+        raise RuntimeError(
+            f"[{node.name}] could not read IPFS peerID within {timeout}s "
+            f"(last: {last})"
+        )
+
+    def _ipfs(self, node: NativeNode, *args: str):
+        """Run the node's kubo binary against its HTTP API. Returns
+        (returncode, stdout, stderr)."""
+        ipfs = os.path.join(os.path.abspath(node.work_dir),
+                            "ipfs.exe" if _IS_WINDOWS else "ipfs")
+        cmd = [ipfs, "--api", f"/ip4/127.0.0.1/tcp/{node.ipfs_api_port}", *args]
+        p = subprocess.run(cmd, cwd=node.work_dir, capture_output=True, text=True)
+        return p.returncode, p.stdout.strip(), p.stderr.strip()
 
     # ----- kubo (ipfs) binary resolution ---------------------------------- #
 

--- a/test/integration/env/native_env.py
+++ b/test/integration/env/native_env.py
@@ -1,0 +1,115 @@
+"""
+native_env.py — Environment backed by native (no-Docker) host processes.
+
+The no-Docker counterpart to DockerEnvironment. Instead of a compose stack, it
+stands up three local Postgres instances (NativePostgresManager) and three native
+rubixgoplatform processes (NativeClusterManager), then exposes the same
+Environment contract (setup/teardown/node_ports) so the test suites run unchanged.
+
+Used on macOS / Windows where GitHub-hosted runners can't run Linux node
+containers. Selected via `runner.py --native`.
+
+Ports are the node_index-derived defaults the binary uses natively (no Docker
+port remapping):
+    nodeA  index 0 -> API 20000, DB 5433, db rubix_a
+    nodeB  index 1 -> API 20001, DB 5434, db rubix_b
+    quorum index 2 -> API 20002, DB 5435, db rubix_q
+These match test/integration/config.native.json — pass it with
+`--config test/integration/config.native.json`.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import List, Optional
+
+from test.integration.env.base import Environment
+from test.integration.env.native_cluster import NativeClusterManager, NativeNode
+from test.integration.env.native_postgres import NativePostgresManager, PgInstance
+
+log = logging.getLogger(__name__)
+
+# Native node API ports (constants.RubixServerPort + node_index). These override
+# the Docker NODE_PORTS (20010/11/12) because native mode does no port remapping.
+NODE_PORTS = [20000, 20001, 20002]
+
+# Workspace for native node data dirs + Postgres data dirs (gitignored, like
+# test/docker/data/stress). Relative to repo root (where the runner runs).
+_NATIVE_ROOT = os.path.join("test", "native", "data")
+
+# (name, node_index, db_name, db_port) for the 3-node localnet cluster.
+_NODE_SPECS = [
+    ("nodeA", 0, "rubix_a", 5433),
+    ("nodeB", 1, "rubix_b", 5434),
+    ("quorum", 2, "rubix_q", 5435),
+]
+
+
+class NativeEnvironment(Environment):
+    """Environment backed by native Postgres + rubixgoplatform processes.
+
+    Args:
+        binary: path to the rubixgoplatform binary. Defaults to the make
+                compile output for the host OS (mac/ on darwin, linux/ elsewhere,
+                windows/ on Windows).
+        network_mode: rubix network (localnet for the integration suite).
+    """
+
+    NODE_PORTS: List[int] = NODE_PORTS
+
+    def __init__(
+        self,
+        binary: Optional[str] = None,
+        network_mode: str = "localnet",
+    ) -> None:
+        self._binary = binary or self._default_binary()
+
+        nodes = [
+            NativeNode(
+                name=name,
+                node_index=idx,
+                db_name=db_name,
+                db_port=db_port,
+                work_dir=os.path.join(_NATIVE_ROOT, name, "app"),
+            )
+            for (name, idx, db_name, db_port) in _NODE_SPECS
+        ]
+        pg_instances = [
+            PgInstance(
+                name=name,
+                port=db_port,
+                db_name=db_name,
+                data_dir=os.path.join(_NATIVE_ROOT, name, "pgdata"),
+            )
+            for (name, _idx, db_name, db_port) in _NODE_SPECS
+        ]
+
+        self._pg = NativePostgresManager(pg_instances)
+        self._cluster = NativeClusterManager(
+            nodes, binary=self._binary, network_mode=network_mode
+        )
+
+    def setup(self) -> None:
+        # Postgres first — nodes fail to start without their DB reachable.
+        self._pg.up()
+        self._cluster.up()
+
+    def teardown(self) -> None:
+        # Stop nodes before Postgres so a node doesn't error on a vanishing DB.
+        # Best-effort: both swallow their own errors so one failure doesn't
+        # leak the other's resources.
+        try:
+            self._cluster.down()
+        finally:
+            self._pg.down()
+
+    @staticmethod
+    def _default_binary() -> str:
+        """Path to the host's `make compile-*` binary output."""
+        if os.name == "nt":
+            return os.path.join("windows", "rubixgoplatform.exe")
+        import platform
+        if platform.system() == "Darwin":
+            return os.path.join("mac", "rubixgoplatform")
+        return os.path.join("linux", "rubixgoplatform")

--- a/test/integration/env/native_postgres.py
+++ b/test/integration/env/native_postgres.py
@@ -138,7 +138,12 @@ class NativePostgresManager:
         # Fresh data dir every run — no stale rubix_* state across runs.
         if os.path.isdir(inst.data_dir):
             shutil.rmtree(inst.data_dir, ignore_errors=True)
-        os.makedirs(inst.data_dir, exist_ok=True)
+        # Create only the PARENT; let initdb create the leaf data dir itself.
+        # initdb locks the data dir to 0700, and on Windows it can't change
+        # permissions on a pre-existing directory ("could not change permissions
+        # of directory: Permission denied"). When initdb creates the dir, it sets
+        # the right perms at creation. Harmless on Unix too.
+        os.makedirs(os.path.dirname(inst.data_dir), exist_ok=True)
 
         # Trust local connections so we can create the rubix role without a
         # bootstrap password dance; this is a throwaway test instance on loopback.

--- a/test/integration/env/native_postgres.py
+++ b/test/integration/env/native_postgres.py
@@ -143,22 +143,60 @@ class NativePostgresManager:
         # Trust local connections so we can create the rubix role without a
         # bootstrap password dance; this is a throwaway test instance on loopback.
         log.info("[%s] initdb -> %s", inst.name, inst.data_dir)
-        subprocess.run(
+        proc = subprocess.run(
             [self._initdb, "-D", inst.data_dir, "-U", "postgres",
              "--auth=trust", "--encoding=UTF8"],
-            check=True, capture_output=True, text=True,
+            capture_output=True, text=True,
         )
+        if proc.returncode != 0:
+            # initdb's reason is in its stdout/stderr; capture_output hides it
+            # unless we surface it. Persist alongside the data dir too so it
+            # lands in the CI artifact.
+            try:
+                with open(os.path.join(os.path.dirname(inst.data_dir), "initdb.log"),
+                          "w", encoding="utf-8") as fh:
+                    fh.write((proc.stdout or "") + "\n--- stderr ---\n" + (proc.stderr or ""))
+            except OSError:
+                pass
+            log.error(
+                "[%s] initdb failed (rc=%s).\nstdout:\n%s\nstderr:\n%s",
+                inst.name, proc.returncode, proc.stdout, proc.stderr,
+            )
+            raise subprocess.CalledProcessError(
+                proc.returncode, proc.args, proc.stdout, proc.stderr
+            )
 
     def _start_instance(self, inst: PgInstance) -> None:
         logfile = os.path.join(inst.data_dir, "server.log")
         # Bind loopback only; set the port via -o so each instance is isolated.
         opts = f"-p {inst.port} -h 127.0.0.1"
+        # On Unix, override the unix-socket dir to the (writable) data dir. The
+        # default (/var/run/postgresql) is NOT writable by the non-root CI runner
+        # user, so `pg_ctl start` fails there. Use an absolute path — pg requires
+        # it for -k. Windows has no unix sockets, so skip.
+        if not _IS_WINDOWS:
+            opts += f" -k {os.path.abspath(inst.data_dir)}"
         log.info("[%s] starting Postgres on 127.0.0.1:%d", inst.name, inst.port)
-        subprocess.run(
-            [self._pg_ctl, "-D", inst.data_dir, "-l", logfile,
-             "-o", opts, "-w", "-t", str(self._startup_timeout), "start"],
-            check=True, capture_output=True, text=True,
-        )
+        try:
+            subprocess.run(
+                [self._pg_ctl, "-D", inst.data_dir, "-l", logfile,
+                 "-o", opts, "-w", "-t", str(self._startup_timeout), "start"],
+                check=True, capture_output=True, text=True,
+            )
+        except subprocess.CalledProcessError as exc:
+            # pg_ctl's own stderr rarely says why; the reason is in server.log.
+            # Surface both so a CI failure is diagnosable without the artifact.
+            server_log = ""
+            try:
+                with open(logfile, encoding="utf-8") as fh:
+                    server_log = fh.read()[-2000:]
+            except OSError:
+                pass
+            log.error(
+                "[%s] pg_ctl start failed (rc=%s).\nstdout:%s\nstderr:%s\nserver.log:\n%s",
+                inst.name, exc.returncode, exc.stdout, exc.stderr, server_log,
+            )
+            raise
 
     def _stop_instance(self, inst: PgInstance) -> None:
         if not os.path.isdir(inst.data_dir):

--- a/test/integration/env/native_postgres.py
+++ b/test/integration/env/native_postgres.py
@@ -1,0 +1,239 @@
+"""
+native_postgres.py — manage local PostgreSQL instances for native (no-Docker) mode.
+
+The Docker harness runs each node's Postgres as a `postgres:16` container. Native
+mode instead stands up real Postgres instances on the host, one per node, on the
+ports the rubixgoplatform binary expects (constants.PostgresBasePort + node_index
+=> 5433 / 5434 / 5435). Each instance has its own data dir, a `rubix` superuser
+with password `rubixpass`, and a single database (rubix_a / rubix_b / rubix_q) —
+matching test/docker/docker-compose.stress.yml and the node's config.template.toml.
+
+Cross-platform by design (macOS / Windows / Linux):
+  - locates initdb/pg_ctl from PATH or common install locations (Homebrew, EDB),
+  - drives them via subprocess (no pg_isready / shell tools),
+  - readiness is a TCP connect + a psycopg `SELECT 1`, not pg_isready.
+
+NativePostgresManager owns the lifecycle; NativeEnvironment composes it with the
+node-cluster manager.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import platform
+import shutil
+import socket
+import subprocess
+import time
+from dataclasses import dataclass
+from typing import List, Optional
+
+log = logging.getLogger(__name__)
+
+_IS_WINDOWS = os.name == "nt"
+
+# Superuser created in each instance — must match config.template.toml [db].
+_DB_USER = "rubix"
+_DB_PASSWORD = "rubixpass"
+
+
+@dataclass(frozen=True)
+class PgInstance:
+    """One Postgres instance: a data dir on a port, hosting one database."""
+
+    name: str          # nodeA / nodeB / quorum (for logs)
+    port: int          # 5433 / 5434 / 5435
+    db_name: str       # rubix_a / rubix_b / rubix_q
+    data_dir: str      # per-instance PGDATA
+
+
+def _find_binary(name: str) -> str:
+    """Locate a Postgres CLI binary (initdb / pg_ctl / postgres).
+
+    Checks PATH first, then common per-OS install locations. Raises with an
+    actionable message if not found, since native mode can't proceed without it.
+    """
+    exe = name + (".exe" if _IS_WINDOWS else "")
+    found = shutil.which(exe)
+    if found:
+        return found
+
+    candidates: List[str] = []
+    system = platform.system()
+    if system == "Darwin":
+        # Homebrew (Apple Silicon + Intel) and the Postgres.app bundle.
+        candidates += [
+            f"/opt/homebrew/bin/{exe}",
+            f"/usr/local/bin/{exe}",
+        ]
+        # Homebrew versioned kegs: /opt/homebrew/opt/postgresql@16/bin
+        for base in ("/opt/homebrew/opt", "/usr/local/opt"):
+            if os.path.isdir(base):
+                for entry in sorted(os.listdir(base), reverse=True):
+                    if entry.startswith("postgresql"):
+                        candidates.append(os.path.join(base, entry, "bin", exe))
+        candidates.append(
+            f"/Applications/Postgres.app/Contents/Versions/latest/bin/{exe}"
+        )
+    elif system == "Windows":
+        for base in (
+            r"C:\Program Files\PostgreSQL",
+            r"C:\Program Files (x86)\PostgreSQL",
+        ):
+            if os.path.isdir(base):
+                for entry in sorted(os.listdir(base), reverse=True):  # newest major first
+                    candidates.append(os.path.join(base, entry, "bin", exe))
+    else:  # Linux
+        candidates += [f"/usr/bin/{exe}", f"/usr/lib/postgresql/16/bin/{exe}"]
+        base = "/usr/lib/postgresql"
+        if os.path.isdir(base):
+            for entry in sorted(os.listdir(base), reverse=True):
+                candidates.append(os.path.join(base, entry, "bin", exe))
+
+    for c in candidates:
+        if os.path.isfile(c):
+            return c
+
+    raise FileNotFoundError(
+        f"Could not find '{name}' on PATH or in common install locations. "
+        f"Install PostgreSQL (e.g. `brew install postgresql@16` on macOS) and "
+        f"ensure its bin/ is on PATH."
+    )
+
+
+class NativePostgresManager:
+    """Stand up / tear down N local Postgres instances for the native cluster."""
+
+    def __init__(self, instances: List[PgInstance], startup_timeout: int = 60) -> None:
+        self._instances = instances
+        self._startup_timeout = startup_timeout
+        self._initdb = _find_binary("initdb")
+        self._pg_ctl = _find_binary("pg_ctl")
+
+    # ----- lifecycle ------------------------------------------------------ #
+
+    def up(self) -> None:
+        """initdb + start + create role/db for every instance, then block until
+        each accepts a real query. Idempotent per run: data dirs are wiped first
+        so state never leaks between runs (mirrors DockerEnvironment._clean_state)."""
+        for inst in self._instances:
+            self._init_instance(inst)
+            self._start_instance(inst)
+            self._wait_ready(inst)
+            self._ensure_role_and_db(inst)
+        log.info("All %d native Postgres instance(s) ready.", len(self._instances))
+
+    def down(self) -> None:
+        """Best-effort stop of every instance (safe to call on failure)."""
+        for inst in self._instances:
+            try:
+                self._stop_instance(inst)
+            except Exception as exc:  # noqa: BLE001
+                log.warning("[%s] Postgres stop failed: %s", inst.name, exc)
+
+    # ----- per-instance steps --------------------------------------------- #
+
+    def _init_instance(self, inst: PgInstance) -> None:
+        # Fresh data dir every run — no stale rubix_* state across runs.
+        if os.path.isdir(inst.data_dir):
+            shutil.rmtree(inst.data_dir, ignore_errors=True)
+        os.makedirs(inst.data_dir, exist_ok=True)
+
+        # Trust local connections so we can create the rubix role without a
+        # bootstrap password dance; this is a throwaway test instance on loopback.
+        log.info("[%s] initdb -> %s", inst.name, inst.data_dir)
+        subprocess.run(
+            [self._initdb, "-D", inst.data_dir, "-U", "postgres",
+             "--auth=trust", "--encoding=UTF8"],
+            check=True, capture_output=True, text=True,
+        )
+
+    def _start_instance(self, inst: PgInstance) -> None:
+        logfile = os.path.join(inst.data_dir, "server.log")
+        # Bind loopback only; set the port via -o so each instance is isolated.
+        opts = f"-p {inst.port} -h 127.0.0.1"
+        log.info("[%s] starting Postgres on 127.0.0.1:%d", inst.name, inst.port)
+        subprocess.run(
+            [self._pg_ctl, "-D", inst.data_dir, "-l", logfile,
+             "-o", opts, "-w", "-t", str(self._startup_timeout), "start"],
+            check=True, capture_output=True, text=True,
+        )
+
+    def _stop_instance(self, inst: PgInstance) -> None:
+        if not os.path.isdir(inst.data_dir):
+            return
+        log.info("[%s] stopping Postgres (port %d)", inst.name, inst.port)
+        subprocess.run(
+            [self._pg_ctl, "-D", inst.data_dir, "-m", "fast", "-w", "stop"],
+            check=False, capture_output=True, text=True,
+        )
+
+    # ----- readiness + provisioning --------------------------------------- #
+
+    def _wait_ready(self, inst: PgInstance) -> None:
+        deadline = time.time() + self._startup_timeout
+        last_err: Optional[Exception] = None
+        while time.time() < deadline:
+            if self._tcp_open("127.0.0.1", inst.port) and self._query_ok(inst, "postgres"):
+                return
+            time.sleep(0.5)
+        raise TimeoutError(
+            f"[{inst.name}] Postgres on port {inst.port} not ready within "
+            f"{self._startup_timeout}s (last error: {last_err})"
+        )
+
+    def _ensure_role_and_db(self, inst: PgInstance) -> None:
+        """Create the rubix superuser and the node's database (idempotent)."""
+        import psycopg2  # local import: only needed in native mode
+
+        conn = psycopg2.connect(
+            host="127.0.0.1", port=inst.port, user="postgres", dbname="postgres"
+        )
+        try:
+            conn.autocommit = True
+            with conn.cursor() as cur:
+                cur.execute("SELECT 1 FROM pg_roles WHERE rolname = %s", (_DB_USER,))
+                if not cur.fetchone():
+                    cur.execute(
+                        f"CREATE ROLE {_DB_USER} LOGIN SUPERUSER PASSWORD %s",
+                        (_DB_PASSWORD,),
+                    )
+                cur.execute(
+                    "SELECT 1 FROM pg_database WHERE datname = %s", (inst.db_name,)
+                )
+                if not cur.fetchone():
+                    # CREATE DATABASE can't run in a parameterized/transactional
+                    # form; identifier is internal (rubix_a/b/q), not user input.
+                    cur.execute(f"CREATE DATABASE {inst.db_name} OWNER {_DB_USER}")
+            log.info("[%s] role '%s' + db '%s' ready.", inst.name, _DB_USER, inst.db_name)
+        finally:
+            conn.close()
+
+    # ----- low-level probes ----------------------------------------------- #
+
+    @staticmethod
+    def _tcp_open(host: str, port: int) -> bool:
+        try:
+            with socket.create_connection((host, port), timeout=1):
+                return True
+        except OSError:
+            return False
+
+    @staticmethod
+    def _query_ok(inst: PgInstance, dbname: str) -> bool:
+        try:
+            import psycopg2
+            conn = psycopg2.connect(
+                host="127.0.0.1", port=inst.port, user="postgres",
+                dbname=dbname, connect_timeout=2,
+            )
+            try:
+                with conn.cursor() as cur:
+                    cur.execute("SELECT 1")
+                    cur.fetchone()
+                return True
+            finally:
+                conn.close()
+        except Exception:  # noqa: BLE001
+            return False

--- a/test/integration/env/native_postgres.py
+++ b/test/integration/env/native_postgres.py
@@ -182,35 +182,62 @@ class NativePostgresManager:
         if not _IS_WINDOWS:
             opts += f" -k {os.path.abspath(inst.data_dir)}"
         log.info("[%s] starting Postgres on 127.0.0.1:%d", inst.name, inst.port)
+        # IMPORTANT: do NOT use capture_output here. pg_ctl launches the postgres
+        # server as a detached child that inherits the stdout/stderr pipes; on
+        # Windows that server keeps the pipe open after pg_ctl exits, so a
+        # capture_output read would block forever (the whole job hangs at
+        # "starting Postgres" with no error). Send pg_ctl's own output to a file
+        # and add a Python-side timeout as a hard backstop so a misbehaving
+        # pg_ctl can never hang CI — it raises instead.
+        pgctl_log = os.path.join(inst.data_dir, "pg_ctl.out")
         try:
-            subprocess.run(
-                [self._pg_ctl, "-D", inst.data_dir, "-l", logfile,
-                 "-o", opts, "-w", "-t", str(self._startup_timeout), "start"],
-                check=True, capture_output=True, text=True,
-            )
-        except subprocess.CalledProcessError as exc:
-            # pg_ctl's own stderr rarely says why; the reason is in server.log.
-            # Surface both so a CI failure is diagnosable without the artifact.
-            server_log = ""
-            try:
-                with open(logfile, encoding="utf-8") as fh:
-                    server_log = fh.read()[-2000:]
-            except OSError:
-                pass
+            with open(pgctl_log, "w", encoding="utf-8") as out:
+                subprocess.run(
+                    [self._pg_ctl, "-D", inst.data_dir, "-l", logfile,
+                     "-o", opts, "-w", "-t", str(self._startup_timeout), "start"],
+                    check=True, stdout=out, stderr=subprocess.STDOUT,
+                    timeout=self._startup_timeout + 30,
+                )
+        except subprocess.TimeoutExpired:
+            server_log = self._read_tail(logfile)
+            pgctl_out = self._read_tail(pgctl_log)
             log.error(
-                "[%s] pg_ctl start failed (rc=%s).\nstdout:%s\nstderr:%s\nserver.log:\n%s",
-                inst.name, exc.returncode, exc.stdout, exc.stderr, server_log,
+                "[%s] pg_ctl start TIMED OUT after %ss.\npg_ctl.out:\n%s\nserver.log:\n%s",
+                inst.name, self._startup_timeout + 30, pgctl_out, server_log,
             )
             raise
+        except subprocess.CalledProcessError as exc:
+            # pg_ctl's own output is in pg_ctl.out; the real reason is in
+            # server.log. Surface both so a CI failure is diagnosable.
+            log.error(
+                "[%s] pg_ctl start failed (rc=%s).\npg_ctl.out:\n%s\nserver.log:\n%s",
+                inst.name, exc.returncode,
+                self._read_tail(pgctl_log), self._read_tail(logfile),
+            )
+            raise
+
+    @staticmethod
+    def _read_tail(path: str, n: int = 2000) -> str:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                return fh.read()[-n:]
+        except OSError:
+            return "(unavailable)"
 
     def _stop_instance(self, inst: PgInstance) -> None:
         if not os.path.isdir(inst.data_dir):
             return
         log.info("[%s] stopping Postgres (port %d)", inst.name, inst.port)
-        subprocess.run(
-            [self._pg_ctl, "-D", inst.data_dir, "-m", "fast", "-w", "stop"],
-            check=False, capture_output=True, text=True,
-        )
+        # No capture_output (same Windows pipe-inheritance hang risk as start);
+        # bounded timeout so teardown can't hang the job either.
+        try:
+            subprocess.run(
+                [self._pg_ctl, "-D", inst.data_dir, "-m", "fast", "-w", "stop"],
+                check=False, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+                timeout=60,
+            )
+        except subprocess.TimeoutExpired:
+            log.warning("[%s] pg_ctl stop timed out; leaving server to OS cleanup.", inst.name)
 
     # ----- readiness + provisioning --------------------------------------- #
 

--- a/test/integration/runner.py
+++ b/test/integration/runner.py
@@ -62,6 +62,13 @@ def _build_arg_parser() -> argparse.ArgumentParser:
         help="Skip docker up/down (nodes already running — e.g. external environment)",
     )
     p.add_argument(
+        "--native",
+        action="store_true",
+        help="Run the cluster as native host processes (no Docker): local Postgres "
+             "+ rubixgoplatform binaries. For macOS/Windows. Use with "
+             "--config test/integration/config.native.json. Mutually exclusive with --no-docker.",
+    )
+    p.add_argument(
         "--max-transactions",
         type=int,
         default=None,
@@ -461,10 +468,20 @@ def main() -> None:
 
     runner = StressRunner(cfg)
 
-    # Environment owns cluster lifecycle. --no-docker => caller provides nodes
-    # (external environment, e.g. a future non-Docker workflow). Otherwise spin
-    # up a fresh compose stack and tear it down on the way out.
-    env = None if args.no_docker else DockerEnvironment()
+    # Environment owns cluster lifecycle:
+    #   --native    => stand up native Postgres + rubixgoplatform processes (no Docker)
+    #   --no-docker => caller provides already-running nodes (external environment)
+    #   default     => spin up a fresh compose stack and tear it down on the way out
+    if args.native and args.no_docker:
+        log.error("--native and --no-docker are mutually exclusive.")
+        sys.exit(2)
+    if args.native:
+        from test.integration.env.native_env import NativeEnvironment
+        env = NativeEnvironment()
+    elif args.no_docker:
+        env = None
+    else:
+        env = DockerEnvironment()
 
     try:
         if env is not None:


### PR DESCRIPTION
Adds a no-Docker mode for the integration suite so the same test cases run on
macOS and Windows CI, where GitHub runners can't run the Linux node containers.

- New NativeEnvironment: local Postgres + native rubixgoplatform processes,
  selected via `--native` (alongside the existing Docker path, which is unchanged).
  
  No change to test logic or the Docker harness — only the env/ lifecycle seam.