### PR TITLE
fix: Skip publishing transactions on localnet

### DIFF
--- a/util/transaction.go
+++ b/util/transaction.go
@@ -60,6 +60,11 @@ func VerifySignature(dc types.DIDCrypto, txInfo *models.TransactionInfo, signatu
 }
 
 func PublishTransaction(pubsub *types.PubSub, tx *models.TransactionInfo, signature *models.Signature, isTxSuccess bool, message string) (*models.Transactions, error) {
+	// Skip publishing transactions on localnet
+	if tx.Network == constants.NetworkMode_Localnet {
+		return nil, nil
+	}
+
 	txID, err := GetTransactionID(tx)
 	if err != nil {
 		return nil, fmt.Errorf("PublishTransaction: failed to get transaction ID: %v", err)


### PR DESCRIPTION
Skip pubsub transaction publishing when the network is localnet.

Added an early return in util.PublishTransaction using tx.Network — no call-site changes needed since every caller already passes TransactionInfo.