### PR TITLE
updating the network check, checks whether network mode which is ther…

### DIFF
--- a/core/consensus/checks.go
+++ b/core/consensus/checks.go
@@ -45,7 +45,7 @@ func validateDID(did string, label string) error {
 	return nil
 }
 
-func ValidateTransactionInfoFields(txnInfo *models.TransactionInfo) error {
+func ValidateTransactionInfoFields(txnInfo *models.TransactionInfo, configuredNetworkMode string) error {
 	if err := validateDID(txnInfo.Initiator, "initiator"); err != nil {
 		return err
 	}
@@ -68,6 +68,20 @@ func ValidateTransactionInfoFields(txnInfo *models.TransactionInfo) error {
 		return fmt.Errorf("invalid network %q: must be one of the supported networks", txnInfo.Network)
 	}
 
+	//Here we are validing that, the network mode which is presented in the transaction info is valid and matches the configured network mode(validators network mode).
+	if configuredNetworkMode != "" {fmt.Println("ValidateTransactionInfoFields: transaction network mismatch", txnInfo.Network, configuredNetworkMode)
+		if _, ok := validNetworks[configuredNetworkMode]; !ok {
+			return fmt.Errorf("invalid configured network mode %q", configuredNetworkMode)
+		}
+		if txnInfo.Network != configuredNetworkMode {
+			return fmt.Errorf(
+				"transaction network mismatch: txnInfo.Network=%q, configured network_mode=%q",
+				txnInfo.Network, configuredNetworkMode,
+			)
+
+		}
+	}
+
 	if txnInfo.Tokens == nil ||
 		(len(txnInfo.Tokens.RBT) == 0 && len(txnInfo.Tokens.NFT) == 0 &&
 			len(txnInfo.Tokens.FT) == 0 && len(txnInfo.Tokens.SmartContract) == 0) {
@@ -75,6 +89,29 @@ func ValidateTransactionInfoFields(txnInfo *models.TransactionInfo) error {
 	}
 
 	return nil
+}
+
+func configuredNetworkModeFromFlags(testnet, mainnet, localnet bool) (string, error) {
+	modeCount := 0
+	if testnet {
+		modeCount++
+	}
+	if mainnet {
+		modeCount++
+	}
+	if localnet {
+		modeCount++
+	}
+	if modeCount != 1 {
+		return "", fmt.Errorf("invalid node network configuration: expected exactly one of mainnet/testnet/localnet to be true")
+	}
+	if mainnet {
+		return constants.NetworkMode_Mainnet, nil
+	}
+	if testnet {
+		return constants.NetworkMode_Testnet, nil
+	}
+	return constants.NetworkMode_Localnet, nil
 }
 
 func TransactionIDIntegrityCheck(transactionID string, transactionInfo *models.TransactionInfo) error {
@@ -889,7 +926,12 @@ func ValidateTransaction(
 		return false, fmt.Errorf("ValidateTransaction: failed to unmarshal transaction info: %w", err)
 	}
 
-	if err := ValidateTransactionInfoFields(&txnInfo); err != nil {
+	configuredNetworkMode, err := configuredNetworkModeFromFlags(testnet, mainnet, localnet)
+	if err != nil {
+		return false, fmt.Errorf("ValidateTransaction: %w", err)
+	}
+
+	if err := ValidateTransactionInfoFields(&txnInfo, configuredNetworkMode); err != nil {
 		return false, fmt.Errorf("ValidateTransaction: %w", err)
 	}
 

--- a/core/consensus/checks.go
+++ b/core/consensus/checks.go
@@ -91,29 +91,6 @@ func ValidateTransactionInfoFields(txnInfo *models.TransactionInfo, configuredNe
 	return nil
 }
 
-func configuredNetworkModeFromFlags(testnet, mainnet, localnet bool) (string, error) {
-	modeCount := 0
-	if testnet {
-		modeCount++
-	}
-	if mainnet {
-		modeCount++
-	}
-	if localnet {
-		modeCount++
-	}
-	if modeCount != 1 {
-		return "", fmt.Errorf("invalid node network configuration: expected exactly one of mainnet/testnet/localnet to be true")
-	}
-	if mainnet {
-		return constants.NetworkMode_Mainnet, nil
-	}
-	if testnet {
-		return constants.NetworkMode_Testnet, nil
-	}
-	return constants.NetworkMode_Localnet, nil
-}
-
 func TransactionIDIntegrityCheck(transactionID string, transactionInfo *models.TransactionInfo) error {
 	computedTransactionID, err := util.GetTransactionID(transactionInfo)
 	if err != nil {
@@ -926,7 +903,7 @@ func ValidateTransaction(
 		return false, fmt.Errorf("ValidateTransaction: failed to unmarshal transaction info: %w", err)
 	}
 
-	configuredNetworkMode, err := configuredNetworkModeFromFlags(testnet, mainnet, localnet)
+	configuredNetworkMode, err := util.GetNetworkMode(testnet, mainnet, localnet)
 	if err != nil {
 		return false, fmt.Errorf("ValidateTransaction: %w", err)
 	}

--- a/core/consensus/checks_test.go
+++ b/core/consensus/checks_test.go
@@ -76,71 +76,77 @@ func TestValidateTransactionInfoFields(t *testing.T) {
 	now := int(time.Now().Unix())
 
 	tests := []struct {
-		name      string
-		mutate    func(*models.TransactionInfo)
-		wantErr   bool
-		wantMatch string // substring expected in the error (optional)
+		name              string
+		mutate            func(*models.TransactionInfo)
+		configuredNetwork string
+		wantErr           bool
+		wantMatch         string // substring expected in the error (optional)
 	}{
 		// ---- happy path ----
-		{name: "valid input", mutate: func(*models.TransactionInfo) {}, wantErr: false},
+		{name: "valid input", mutate: func(*models.TransactionInfo) {}, configuredNetwork: constants.NetworkMode_Mainnet, wantErr: false},
 
 		// ---- Initiator DID ----
 		{name: "initiator empty", mutate: func(tx *models.TransactionInfo) { tx.Initiator = "" },
-			wantErr: true, wantMatch: "initiator"},
+			configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "initiator"},
 		{name: "initiator with non-alphanumeric", mutate: func(tx *models.TransactionInfo) { tx.Initiator = "bafybmi!!!" },
-			wantErr: true, wantMatch: "alphanumeric"},
+			configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "alphanumeric"},
 		{name: "initiator wrong prefix", mutate: func(tx *models.TransactionInfo) {
 			tx.Initiator = "xxxxxxx" + strings.Repeat("a", constants.DidLength-7)
-		}, wantErr: true, wantMatch: "must start with"},
+		}, configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "must start with"},
 		{name: "initiator wrong length (short)", mutate: func(tx *models.TransactionInfo) {
 			tx.Initiator = constants.DidPrefix + "a"
-		}, wantErr: true, wantMatch: "length"},
+		}, configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "length"},
 		{name: "initiator wrong length (long)", mutate: func(tx *models.TransactionInfo) {
 			tx.Initiator = constants.DidPrefix + strings.Repeat("a", constants.DidLength) // too long
-		}, wantErr: true, wantMatch: "length"},
+		}, configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "length"},
 
 		// ---- Owner DID ----
 		{name: "owner empty is allowed (deployment txns)", mutate: func(tx *models.TransactionInfo) { tx.Owner = "" },
-			wantErr: false},
+			configuredNetwork: constants.NetworkMode_Mainnet, wantErr: false},
 		{name: "owner has space", mutate: func(tx *models.TransactionInfo) { tx.Owner = "bafybmi abc" },
-			wantErr: true, wantMatch: "alphanumeric"},
+			configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "alphanumeric"},
 
 		// ---- Epoch ----
 		{name: "epoch zero", mutate: func(tx *models.TransactionInfo) { tx.Epoch = 0 },
-			wantErr: true, wantMatch: "epoch"},
+			configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "epoch"},
 		{name: "epoch negative", mutate: func(tx *models.TransactionInfo) { tx.Epoch = -1 },
-			wantErr: true, wantMatch: "epoch"},
+			configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "epoch"},
 		{name: "epoch before April-1-2026", mutate: func(tx *models.TransactionInfo) {
 			tx.Epoch = constants.MinTransactionEpochUnix - 1
-		}, wantErr: true, wantMatch: "epoch"},
+		}, configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "epoch"},
 		{name: "epoch in the future", mutate: func(tx *models.TransactionInfo) { tx.Epoch = now + 3600 },
-			wantErr: true, wantMatch: "epoch"},
+			configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "epoch"},
 
 		// ---- Network ----
 		{name: "network empty", mutate: func(tx *models.TransactionInfo) { tx.Network = "" },
-			wantErr: true, wantMatch: "network"},
+			configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "network"},
 		{name: "network unknown", mutate: func(tx *models.TransactionInfo) { tx.Network = "devnet" },
-			wantErr: true, wantMatch: "network"},
+			configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "network"},
 		{name: "network wrong case", mutate: func(tx *models.TransactionInfo) { tx.Network = "MAINNET" },
-			wantErr: true, wantMatch: "network"},
+			configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "network"},
 		{name: "network testnet OK", mutate: func(tx *models.TransactionInfo) {
 			tx.Network = constants.NetworkMode_Testnet
-		}, wantErr: false},
+		}, configuredNetwork: constants.NetworkMode_Testnet, wantErr: false},
 		{name: "network localnet OK", mutate: func(tx *models.TransactionInfo) {
 			tx.Network = constants.NetworkMode_Localnet
-		}, wantErr: false},
+		}, configuredNetwork: constants.NetworkMode_Localnet, wantErr: false},
+		{name: "network mismatch with configured mainnet", mutate: func(tx *models.TransactionInfo) {
+			tx.Network = constants.NetworkMode_Testnet
+		}, configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "network mismatch"},
+		{name: "invalid configured network mode", mutate: func(*models.TransactionInfo) {},
+			configuredNetwork: "devnet", wantErr: true, wantMatch: "configured network mode"},
 
 		// ---- Tokens ----
 		{name: "tokens pointer is nil", mutate: func(tx *models.TransactionInfo) { tx.Tokens = nil },
-			wantErr: true, wantMatch: "transfer token"},
+			configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "transfer token"},
 		{name: "tokens pointer set but all lists empty",
-			mutate:  func(tx *models.TransactionInfo) { tx.Tokens = &models.TransactionTokens{} },
-			wantErr: true, wantMatch: "transfer token"},
+			mutate:            func(tx *models.TransactionInfo) { tx.Tokens = &models.TransactionTokens{} },
+			configuredNetwork: constants.NetworkMode_Mainnet, wantErr: true, wantMatch: "transfer token"},
 		{name: "only NFT populated is OK",
 			mutate: func(tx *models.TransactionInfo) {
 				tx.Tokens = &models.TransactionTokens{NFT: []*models.TokenInfo{{TokenID: "nft1"}}}
 			},
-			wantErr: false},
+			configuredNetwork: constants.NetworkMode_Mainnet, wantErr: false},
 	}
 
 	for _, tc := range tests {
@@ -148,7 +154,7 @@ func TestValidateTransactionInfoFields(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			tx := baseValidTxnInfo()
 			tc.mutate(&tx)
-			err := ValidateTransactionInfoFields(&tx)
+			err := ValidateTransactionInfoFields(&tx, tc.configuredNetwork)
 			if tc.wantErr && err == nil {
 				t.Fatalf("expected error, got nil")
 			}
@@ -363,8 +369,6 @@ func TestValidateTransactionValueAndPledge(t *testing.T) {
 // Pure helper tests (no DB needed).
 // -----------------------------------------------------------------------------
 
-
-
 // -----------------------------------------------------------------------------
 // Orchestrator-level (ValidateTransaction) sanity tests.
 //
@@ -397,7 +401,7 @@ func TestValidateTransaction_FailsOnInvalidInfoFields(t *testing.T) {
 		nil,   // logger – never touched in this failure path
 		&stubDIDCrypto{Verify: true},
 		map[string]types.DIDCrypto{},
-		false, false, false,
+		false, true, false,
 		func(string, string) error { return nil },
 		func(string, []string, map[string]string, []string) error { return nil },
 		false, // transferNFTOwnership
@@ -425,7 +429,7 @@ func TestValidateTransaction_FailsOnTxIDMismatch(t *testing.T) {
 		storedTx, false, nil, nil,
 		&stubDIDCrypto{Verify: true},
 		map[string]types.DIDCrypto{},
-		false, false, false,
+		false, true, false,
 		func(string, string) error { return nil },
 		func(string, []string, map[string]string, []string) error { return nil },
 		false, // transferNFTOwnership
@@ -498,9 +502,6 @@ func (f *fakeTxnStore) GetGenesisTransactionIdByTokenId(tokenID string, isFullNo
 // testLogger returns a real logger suitable for use inside tests. It writes
 // nowhere meaningful (go test captures stdout), which is fine for our needs.
 func testLogger() logger.Logger { return logger.New(nil) }
-
-
-
 
 // =============================================================================
 // Section 3 — TokenID-related checks for RBTs (ValidateNewTokenContent)


### PR DESCRIPTION
In this check, we are updating the network check while validating transaction Info fields, This check ensures that when quorum or fullnode gets a transaction to validate, it will check whether the network mode in the transaction is same as the network mode which is there in its config.toml file. Previously it used to check that whether network mode which is there in the transaction Info is one among the mainnet, testnet or localnet or not.

Test cases:
1. while quorum is running in testnet, initiator initiated a transaction with network mode as mainnet, quorum rejected the transaction.
2. while fullnode is running in testnet, initiator has published a transaction with network mode as mainnet, fullnode rejected the transaction.