### PR TITLE
fix: reject replayed RBT-split double-spend at consensus + related pledge/DID fixes

### DIFF
--- a/core/consensus/checks.go
+++ b/core/consensus/checks.go
@@ -817,6 +817,258 @@ func TokenChainIntegrityCheck(
 	return nil
 }
 
+// ValidateSplitParentsAgainstFullnode rejects a replayed RBT split (a
+// double-mint) by verifying, against an authoritative full node, the DERIVED
+// ancestor tokens of each freshly-split child — not the parent list the
+// initiator authored in the genesis's CommittedTokens.
+//
+// Why derived, not declared: a rolled-back initiator controls every field of a
+// split genesis's CommittedTokens (which parents it lists AND their claimed
+// prior tip). It can present a genuinely double-spent parent as an empty-prev
+// "fresh mint" and evade any check that trusts that list. Token IDs, by
+// contrast, are hierarchical and deterministic: from a transferred child C we
+// can DERIVE its full ancestor chain up to the whole token (util TokenID
+// GetHierarchy) with no initiator input.
+//
+// The invariant: a token is legitimately burnt exactly once, by the split that
+// consumes it. We check the tokens genTX BURNS (its CommittedTokens) intersected
+// with the DERIVED ancestors of its freshly-minted children — i.e. exactly the
+// ancestors this split actually consumes. For each such token A, the
+// authoritative full node's burn transaction must be either (a) absent (A still
+// free — this split is A's first consume) or (b) genTX itself. If the full node
+// says A was burnt by a DIFFERENT, earlier transaction, this split is
+// re-consuming an already-spent token — a replay — and is rejected.
+//
+// The intersection is essential: the derived hierarchy alone over-rejects a
+// legitimate split of a low part (whose higher ancestors were legitimately burnt
+// by earlier splits and which genTX does not touch); CommittedTokens alone is
+// initiator-authored. Intersecting checks only what genTX both derivably has as
+// an ancestor AND declares it burns.
+//
+// "Freshly-split child" = a transferred RBT token whose PreviousTransactionID
+// resolves (getTxByID) to a genesis carrying CommittedTokens. A plain transfer
+// of a pre-existing part has an ordinary (non-genesis) prev and is skipped.
+//
+// Tiering: the ancestor's burn tx is first read locally (getParentBurnTx). A
+// local "burnt by a different tx" is a provable replay (applyTokenChainFromSync
+// fork detection prevents a stale initiator sync from overwriting a genuine
+// local burn). Ancestors not locally confirmable are pulled once from an
+// authoritative full node (syncAuthoritative) and re-checked.
+//
+// Fallback: if the authoritative sync is unavailable or fails, this logs a
+// warning and returns nil (no rejection) so transactions keep flowing when no
+// full node is reachable, at the cost of no replay protection in that case.
+func ValidateSplitParentsAgainstFullnode(
+	txnInfo *models.TransactionInfo,
+	log logger.Logger,
+	getTxByID func(txID string) (*models.TransactionInfo, error),
+	getParentBurnTx func(parentID string) (burnTxID string, found bool, err error),
+	syncAuthoritative func(tokenIDs []string) (map[string]string, error),
+) error {
+	if getParentBurnTx == nil {
+		return nil
+	}
+
+	// ancestorGenesis maps a tokenID that a split genesis BURNS → that genesis
+	// (genTX). If the full node's burn tx for such a token differs from genTX,
+	// the token was already consumed by an earlier split → replay.
+	//
+	// The set to check is: the tokens genTX declares it burns (its
+	// CommittedTokens) INTERSECTED WITH the derived ancestors of the freshly-
+	// minted children. Why the intersection:
+	//   - Derived hierarchy alone over-rejects: a legitimate split of a low part
+	//     (e.g. a free 0.05) has higher ancestors (0.5, whole) that were burnt by
+	//     EARLIER legitimate splits — genTX does not touch them, so they must not
+	//     be checked.
+	//   - CommittedTokens alone is initiator-authored (which parents + their prev
+	//     are forgeable). But a genesis can only HARM by HIDING a burn (omitting
+	//     or empty-prev), never by adding a burn it isn't performing; and omission
+	//     breaks the minted children's derived parent linkage caught elsewhere.
+	// Intersecting the two: we check exactly the ancestors genTX both derivably
+	// has AND claims to burn — the tokens this split actually consumes.
+	ancestorGenesis := make(map[string]string)
+
+	// registerBurns records genTX's burnt tokens that are genuine ancestors of at
+	// least one freshly-minted child (derived), so we ignore forged/irrelevant IDs.
+	registerBurns := func(genTX string, childIDs []string, committed []*models.TokenInfo) {
+		if len(committed) == 0 {
+			return
+		}
+		// Derived ancestor set across all this genesis's minted children.
+		derived := make(map[string]struct{})
+		for _, childID := range childIDs {
+			ancestors, err := util.TokenID(childID).GetHierarchy()
+			if err != nil {
+				log.Debug("ValidateSplitParentsAgainstFullnode: could not derive hierarchy",
+					"tokenID", childID, "err", err)
+				continue
+			}
+			for _, a := range ancestors {
+				derived[a] = struct{}{}
+			}
+		}
+		for _, ct := range committed {
+			if ct == nil || ct.TokenID == "" {
+				continue
+			}
+			if _, ok := derived[ct.TokenID]; !ok {
+				continue // burnt token is not a derived ancestor of any minted child
+			}
+			if _, seen := ancestorGenesis[ct.TokenID]; !seen {
+				ancestorGenesis[ct.TokenID] = genTX
+			}
+		}
+	}
+
+	// Source 1: the transaction being validated is ITSELF a split genesis (the
+	// full node ingestion path) — its minted children are the RBT tokens it
+	// carries, and its own tx ID is genTX.
+	if len(txnInfo.CommittedTokens) > 0 && txnInfo.Tokens != nil {
+		if selfTxID, idErr := util.GetTransactionID(txnInfo); idErr == nil {
+			childIDs := make([]string, 0, len(txnInfo.Tokens.RBT))
+			for _, t := range txnInfo.Tokens.RBT {
+				if t != nil && t.TokenID != "" {
+					childIDs = append(childIDs, t.TokenID)
+				}
+			}
+			registerBurns(selfTxID, childIDs, txnInfo.CommittedTokens)
+		} else {
+			log.Warn("ValidateSplitParentsAgainstFullnode: could not compute self tx ID", "err", idErr)
+		}
+	}
+
+	// Source 2: the quorum consensus path — the transfer lists freshly-minted
+	// children whose PreviousTransactionID is the split genesis. Resolve genTX,
+	// and only if it is a split genesis (has CommittedTokens), register its burns.
+	if txnInfo.Tokens != nil && getTxByID != nil {
+		childrenByGenesis := make(map[string][]string)
+		for _, t := range txnInfo.Tokens.RBT {
+			if t == nil || t.TokenID == "" || t.PreviousTransactionID == "" {
+				continue
+			}
+			childrenByGenesis[t.PreviousTransactionID] = append(childrenByGenesis[t.PreviousTransactionID], t.TokenID)
+		}
+		for genTX, childIDs := range childrenByGenesis {
+			genInfo, err := getTxByID(genTX)
+			if err != nil || genInfo == nil || len(genInfo.CommittedTokens) == 0 {
+				// Not a resolvable split genesis (e.g. plain part transfer).
+				log.Debug("ValidateSplitParentsAgainstFullnode: genesis not a resolvable split (skipping)",
+					"genesis", genTX, "children", childIDs, "resolveErr", err, "committedTokens", func() int {
+						if genInfo == nil {
+							return -1
+						}
+						return len(genInfo.CommittedTokens)
+					}())
+				continue
+			}
+			log.Debug("ValidateSplitParentsAgainstFullnode: resolved split genesis for transferred children",
+				"genesis", genTX, "children", childIDs, "committedTokenCount", len(genInfo.CommittedTokens))
+			registerBurns(genTX, childIDs, genInfo.CommittedTokens)
+		}
+	}
+
+	if len(ancestorGenesis) == 0 {
+		log.Debug("ValidateSplitParentsAgainstFullnode: no split-genesis ancestors to check; nothing to do")
+		return nil
+	}
+
+	log.Debug("ValidateSplitParentsAgainstFullnode: checking split-genesis ancestors",
+		"ancestorCount", len(ancestorGenesis), "ancestorGenesis", ancestorGenesis)
+
+	// verifyAncestor checks one ancestor's burn tx against its expected genesis.
+	// Returns (rejectErr, confirmed). confirmed=false → not resolvable from this
+	// view; try the authoritative sync.
+	verifyAncestor := func(ancestorID, genTX string, tier string) (error, bool) {
+		burnTxID, found, err := getParentBurnTx(ancestorID)
+		if err != nil {
+			log.Warn("ValidateSplitParentsAgainstFullnode: getParentBurnTx errored; treating ancestor as unconfirmed",
+				"tier", tier, "ancestor", ancestorID, "expectedGenesis", genTX, "err", err)
+			return nil, false
+		}
+		if !found {
+			// Not burnt in this view: either genuinely free (legit first split of
+			// this ancestor) or the burn record just isn't here yet. Treated as
+			// unconfirmed so Tier 2 can fetch the authoritative record.
+			log.Debug("ValidateSplitParentsAgainstFullnode: ancestor not burnt in this view (unconfirmed)",
+				"tier", tier, "ancestor", ancestorID, "expectedGenesis", genTX)
+			return nil, false
+		}
+		if burnTxID != genTX {
+			log.Warn("ValidateSplitParentsAgainstFullnode: REPLAY DETECTED — ancestor burnt by a different tx than this split genesis",
+				"tier", tier, "ancestor", ancestorID, "burntBy", burnTxID, "thisSplitGenesis", genTX)
+			return fmt.Errorf("ValidateSplitParentsAgainstFullnode: ancestor %s already consumed (burnt by %s, not by this split genesis %s); double spend",
+				ancestorID, burnTxID, genTX), true
+		}
+		// Burnt by this split's genesis — part of the legitimate contiguous run.
+		log.Debug("ValidateSplitParentsAgainstFullnode: ancestor burnt by this split genesis (legit contiguous run)",
+			"tier", tier, "ancestor", ancestorID, "genesis", genTX)
+		return nil, true
+	}
+
+	// Tier 1 — LOCAL.
+	unconfirmed := make([]string, 0, len(ancestorGenesis))
+	for ancestorID, genTX := range ancestorGenesis {
+		rejectErr, confirmed := verifyAncestor(ancestorID, genTX, "local")
+		if rejectErr != nil {
+			return rejectErr
+		}
+		if !confirmed {
+			unconfirmed = append(unconfirmed, ancestorID)
+		}
+	}
+	log.Debug("ValidateSplitParentsAgainstFullnode: tier-1 (local) complete",
+		"confirmedLocally", len(ancestorGenesis)-len(unconfirmed), "unconfirmed", unconfirmed)
+
+	// Tier 2 — AUTHORITATIVE.
+	if len(unconfirmed) > 0 {
+		if syncAuthoritative == nil {
+			log.Warn("ValidateSplitParentsAgainstFullnode: no authoritative sync available; ACCEPTING (cannot verify)",
+				"tokens", unconfirmed)
+			return nil
+		}
+		log.Debug("ValidateSplitParentsAgainstFullnode: tier-2 syncing unconfirmed ancestors from authoritative fullnode",
+			"tokens", unconfirmed)
+		// syncAuthoritative returns the authoritative burn-tx per ancestor read
+		// straight from the fullnode's response (tokenID -> burnTxID; "" means
+		// the fullnode served the chain but it is not burnt; ABSENT means the
+		// fullnode had no chain for it). We compare that directly instead of
+		// re-reading a locally-persisted chain — the fullnode sync-info payload
+		// carries no signature, so it is never applied to this node's wallet.
+		authoritativeBurnTx, err := syncAuthoritative(unconfirmed)
+		if err != nil {
+			log.Warn("ValidateSplitParentsAgainstFullnode: authoritative fullnode sync failed; ACCEPTING (cannot verify)",
+				"tokens", unconfirmed, "err", err)
+			return nil
+		}
+		for _, ancestorID := range unconfirmed {
+			genTX := ancestorGenesis[ancestorID]
+			burnTxID, served := authoritativeBurnTx[ancestorID]
+			switch {
+			case !served || burnTxID == "":
+				// Fullnode has no burn for this ancestor (not served, or served
+				// but not burnt) → authoritatively not consumed → legitimate
+				// first-split. NOTE: a fullnode that simply lacks the record also
+				// lands here — this is fail-open, consistent with tier-1.
+				log.Warn("ValidateSplitParentsAgainstFullnode: ancestor not burnt on authoritative fullnode — ACCEPTING as legitimate first-split (NOTE: a fullnode missing the record also lands here)",
+					"ancestor", ancestorID, "expectedGenesis", genTX, "served", served)
+			case burnTxID != genTX:
+				log.Warn("ValidateSplitParentsAgainstFullnode: REPLAY DETECTED — ancestor burnt by a different tx than this split genesis",
+					"tier", "authoritative", "ancestor", ancestorID, "burntBy", burnTxID, "thisSplitGenesis", genTX)
+				return fmt.Errorf("ValidateSplitParentsAgainstFullnode: ancestor %s already consumed (burnt by %s, not by this split genesis %s); double spend",
+					ancestorID, burnTxID, genTX)
+			default:
+				// Burnt by this split's genesis — part of the legitimate run.
+				log.Debug("ValidateSplitParentsAgainstFullnode: ancestor burnt by this split genesis (legit contiguous run)",
+					"tier", "authoritative", "ancestor", ancestorID, "genesis", genTX)
+			}
+		}
+	}
+
+	log.Debug("ValidateSplitParentsAgainstFullnode: all ancestors verified; no replay detected (ACCEPT)",
+		"ancestorCount", len(ancestorGenesis))
+	return nil
+}
+
 // ValidateIPFSPinChecks validates IPFS pin status for all tokens.
 // checkPinned is a caller-supplied function that checks whether a given
 // token state hash is already pinned. It should return an error if pinned.
@@ -869,6 +1121,7 @@ func ValidateIPFSPinChecks(txnInfo *models.TransactionInfo, isFullnode bool, che
 //   - testnet, mainnet, localnet: network mode flags
 //   - checkPinned: function to check IPFS pin status (tokenID, prevTxnID) → error
 //   - syncTxChains: callback to sync transaction chains from peer (injected from core to avoid cyclic import)
+//   - syncAuthoritative: callback to sync tokens from an authoritative full node (for committed parent verification)
 //   - transferNFTOwnership: from ConsensusRequest envelope. Fullnode passes false.
 func ValidateTransaction(
 	tx *models.Transactions,
@@ -882,6 +1135,9 @@ func ValidateTransaction(
 	localnet bool,
 	checkPinned func(tokenID, previousTxnID string) error,
 	syncTxChains func(peerDID string, tokenIDs []string, prevTxIDs map[string]string, excludeTxIDs []string) error,
+	syncAuthoritative func(tokenIDs []string) (map[string]string, error),
+	getTxByID func(txID string) (*models.TransactionInfo, error),
+	getParentBurnTx func(parentID string) (burnTxID string, found bool, err error),
 	transferNFTOwnership bool,
 ) (bool, error) {
 	var txnInfo models.TransactionInfo
@@ -907,6 +1163,13 @@ func ValidateTransaction(
 	}
 
 	if err := TokenChainIntegrityCheck(&txnInfo, tx.ID, isFullnode, w, log, syncTxChains); err != nil {
+		return false, fmt.Errorf("ValidateTransaction: %w", err)
+	}
+
+	// Reject a replayed RBT split (double-mint) by verifying each freshly-split
+	// child's DERIVED ancestor tokens against an authoritative full node rather
+	// than trusting the (possibly rolled-back) initiator's declared parents.
+	if err := ValidateSplitParentsAgainstFullnode(&txnInfo, log, getTxByID, getParentBurnTx, syncAuthoritative); err != nil {
 		return false, fmt.Errorf("ValidateTransaction: %w", err)
 	}
 

--- a/core/consensus/checks_test.go
+++ b/core/consensus/checks_test.go
@@ -400,6 +400,9 @@ func TestValidateTransaction_FailsOnInvalidInfoFields(t *testing.T) {
 		false, false, false,
 		func(string, string) error { return nil },
 		func(string, []string, map[string]string, []string) error { return nil },
+		func([]string) (map[string]string, error) { return map[string]string{}, nil }, // syncAuthoritative
+		func(string) (*models.TransactionInfo, error) { return nil, nil }, // getTxByID
+		func(string) (string, bool, error) { return "", false, nil },      // getParentBurnTx
 		false, // transferNFTOwnership
 	)
 	if err == nil {
@@ -428,11 +431,228 @@ func TestValidateTransaction_FailsOnTxIDMismatch(t *testing.T) {
 		false, false, false,
 		func(string, string) error { return nil },
 		func(string, []string, map[string]string, []string) error { return nil },
+		func([]string) (map[string]string, error) { return map[string]string{}, nil }, // syncAuthoritative
+		func(string) (*models.TransactionInfo, error) { return nil, nil }, // getTxByID
+		func(string) (string, bool, error) { return "", false, nil },      // getParentBurnTx
 		false, // transferNFTOwnership
 	)
 	if err == nil || !strings.Contains(err.Error(), "transaction ID mismatch") {
 		t.Fatalf("expected tx ID mismatch error, got: %v", err)
 	}
+}
+
+// =============================================================================
+// ValidateSplitParentsAgainstFullnode — replayed-RBT-split double-spend.
+//
+// The check derives each freshly-split child's ancestors (util TokenID
+// GetHierarchy) and, for each, compares the authoritative burn tx against the
+// child's minting genesis. Tests use a real hierarchical child so the derivation
+// is genuine: 1_1_14 -> ancestors [1_1_3, 1_1_1, 1_1]. Driven purely through the
+// injected callbacks; the *wallet.Wallet arg is unused, passed nil.
+// =============================================================================
+
+func TestValidateSplitParentsAgainstFullnode(t *testing.T) {
+	const (
+		genTX   = "genesis-split-tx-1"   // the split that mints the child now
+		otherTX = "genesis-split-tx-old" // an earlier different split (the replay's true burn)
+		childID = "1_1_14"               // freshly-minted child; ancestors: 1_1_3, 1_1_1, 1_1
+	)
+	// ancestors of childID, deepest→whole (must match util GetHierarchy output).
+	ancImmediate := "1_1_3"
+	ancMid := "1_1_1"
+	ancWhole := "1_1"
+
+	// A transfer of a freshly-split child: RBT token whose prev is the split genesis.
+	transferInfo := func() *models.TransactionInfo {
+		return &models.TransactionInfo{
+			Tokens: &models.TransactionTokens{
+				RBT: []*models.TokenInfo{
+					{TokenID: childID, PreviousTransactionID: genTX, TokenValue: 0.001},
+				},
+			},
+		}
+	}
+	// genTX is a split genesis. Its CommittedTokens declares which ancestors it
+	// burns; the check intersects this with the derived ancestors. We list all
+	// three ancestors with EMPTY prev to prove the check does NOT depend on the
+	// prev field (the old evasion) — only on the fullnode's burn-by-whom.
+	genInfo := &models.TransactionInfo{
+		CommittedTokens: []*models.TokenInfo{
+			{TokenID: ancImmediate, PreviousTransactionID: ""},
+			{TokenID: ancMid, PreviousTransactionID: ""},
+			{TokenID: ancWhole, PreviousTransactionID: ""},
+		},
+	}
+
+	getTxByIDReturning := func(info *models.TransactionInfo) func(string) (*models.TransactionInfo, error) {
+		return func(id string) (*models.TransactionInfo, error) {
+			if id == genTX {
+				return info, nil
+			}
+			return nil, errors.New("not found")
+		}
+	}
+	// burnMap: ancestorID -> (burnTx, burnt?). Missing entry => not burnt.
+	burnFrom := func(m map[string]string) func(string) (string, bool, error) {
+		return func(id string) (string, bool, error) {
+			if tx, ok := m[id]; ok {
+				return tx, true, nil
+			}
+			return "", false, nil
+		}
+	}
+
+	t.Run("legit split: ancestors burnt by this genesis / free -> accept", func(t *testing.T) {
+		// Immediate parent burnt by genTX (this split), higher ancestors free.
+		err := ValidateSplitParentsAgainstFullnode(
+			transferInfo(), testLogger(),
+			getTxByIDReturning(genInfo),
+			burnFrom(map[string]string{ancImmediate: genTX}),
+			func([]string) (map[string]string, error) { return map[string]string{}, nil },
+		)
+		if err != nil {
+			t.Fatalf("expected accept, got: %v", err)
+		}
+	})
+
+	t.Run("DEEP replay: an ANCESTOR burnt by a different tx (empty-prev evasion) -> reject", func(t *testing.T) {
+		// This is the case the old committed-parents check MISSED: the immediate
+		// parent looks freshly minted (burnt by genTX), but a higher ancestor
+		// (the resurrected level) is already burnt by an earlier split.
+		burns := map[string]string{
+			ancImmediate: genTX,   // freshly minted by this split
+			ancMid:       genTX,   // part of this split's run
+			ancWhole:     otherTX, // ALREADY consumed by an earlier split -> replay
+		}
+		err := ValidateSplitParentsAgainstFullnode(
+			transferInfo(), testLogger(),
+			getTxByIDReturning(genInfo),
+			burnFrom(burns),
+			func([]string) (map[string]string, error) {
+				t.Fatal("Tier-1 should reject before authoritative")
+				return nil, nil
+			},
+		)
+		if err == nil || !strings.Contains(err.Error(), "double spend") {
+			t.Fatalf("expected double spend rejection, got: %v", err)
+		}
+	})
+
+	t.Run("legit re-split of a low part: higher ancestor burnt by another tx but NOT in this genesis -> accept", func(t *testing.T) {
+		// The over-rejection guard. genTX splits only the immediate parent; the
+		// whole token was legitimately burnt long ago by a different split. Since
+		// genTX does NOT list the whole token in CommittedTokens, it must NOT be
+		// checked. genInfoLow lists only the immediate parent.
+		genInfoLow := &models.TransactionInfo{
+			CommittedTokens: []*models.TokenInfo{
+				{TokenID: ancImmediate, PreviousTransactionID: ""},
+			},
+		}
+		burns := map[string]string{
+			ancImmediate: genTX,   // this split burns it
+			ancWhole:     otherTX, // legitimately burnt by an EARLIER split; genTX doesn't touch it
+		}
+		err := ValidateSplitParentsAgainstFullnode(
+			transferInfo(), testLogger(),
+			getTxByIDReturning(genInfoLow),
+			burnFrom(burns),
+			func([]string) (map[string]string, error) { return map[string]string{}, nil },
+		)
+		if err != nil {
+			t.Fatalf("expected accept (higher ancestor not consumed by this split), got: %v", err)
+		}
+	})
+
+	t.Run("replay caught only after authoritative sync -> reject", func(t *testing.T) {
+		// Local view: ancestors not burnt (fresh quorum). Tier-2 sync returns
+		// the authoritative burn map revealing the whole token already burnt by
+		// otherTX. getParentBurnTx (tier-1) never resolves it locally.
+		err := ValidateSplitParentsAgainstFullnode(
+			transferInfo(), testLogger(),
+			getTxByIDReturning(genInfo),
+			burnFrom(map[string]string{}), // tier-1 finds nothing locally
+			func(ids []string) (map[string]string, error) {
+				return map[string]string{ancWhole: otherTX}, nil
+			},
+		)
+		if err == nil || !strings.Contains(err.Error(), "double spend") {
+			t.Fatalf("expected double spend after authoritative sync, got: %v", err)
+		}
+	})
+
+	t.Run("legit first split confirmed after authoritative sync (all free) -> accept", func(t *testing.T) {
+		err := ValidateSplitParentsAgainstFullnode(
+			transferInfo(), testLogger(),
+			getTxByIDReturning(genInfo),
+			burnFrom(map[string]string{}), // nothing burnt locally
+			// Authoritative sync serves the chains but none are burnt ("" per token).
+			func(ids []string) (map[string]string, error) {
+				m := make(map[string]string, len(ids))
+				for _, id := range ids {
+					m[id] = ""
+				}
+				return m, nil
+			},
+		)
+		if err != nil {
+			t.Fatalf("expected accept, got: %v", err)
+		}
+	})
+
+	t.Run("fullnode unreachable -> fail open (no reject)", func(t *testing.T) {
+		err := ValidateSplitParentsAgainstFullnode(
+			transferInfo(), testLogger(),
+			getTxByIDReturning(genInfo),
+			burnFrom(map[string]string{}), // never confirmable locally
+			func([]string) (map[string]string, error) { return nil, errors.New("fullnode down") },
+		)
+		if err != nil {
+			t.Fatalf("expected fail-open (nil), got: %v", err)
+		}
+	})
+
+	t.Run("prev is not a split genesis -> pass through", func(t *testing.T) {
+		err := ValidateSplitParentsAgainstFullnode(
+			transferInfo(), testLogger(),
+			func(string) (*models.TransactionInfo, error) { return nil, errors.New("not found") },
+			func(string) (string, bool, error) { t.Fatal("no ancestors to check"); return "", false, nil },
+			func([]string) (map[string]string, error) { t.Fatal("no ancestors to sync"); return nil, nil },
+		)
+		if err != nil {
+			t.Fatalf("expected pass-through, got: %v", err)
+		}
+	})
+
+	t.Run("split genesis with empty committedTokens -> pass through", func(t *testing.T) {
+		// getTxByID resolves but the tx has no committedTokens → not a split.
+		plainGen := &models.TransactionInfo{}
+		err := ValidateSplitParentsAgainstFullnode(
+			transferInfo(), testLogger(),
+			getTxByIDReturning(plainGen),
+			func(string) (string, bool, error) { t.Fatal("no ancestors to check"); return "", false, nil },
+			func([]string) (map[string]string, error) { t.Fatal("nothing to sync"); return nil, nil },
+		)
+		if err != nil {
+			t.Fatalf("expected pass-through, got: %v", err)
+		}
+	})
+
+	t.Run("whole-token transfer (no ancestors) -> pass through", func(t *testing.T) {
+		wholeXfer := &models.TransactionInfo{
+			Tokens: &models.TransactionTokens{
+				RBT: []*models.TokenInfo{{TokenID: "1_1", PreviousTransactionID: genTX}},
+			},
+		}
+		err := ValidateSplitParentsAgainstFullnode(
+			wholeXfer, testLogger(),
+			getTxByIDReturning(genInfo),
+			func(string) (string, bool, error) { return "", false, nil },
+			func([]string) (map[string]string, error) { return map[string]string{}, nil },
+		)
+		if err != nil {
+			t.Fatalf("expected pass-through for whole token, got: %v", err)
+		}
+	})
 }
 
 // =============================================================================

--- a/core/fullnode.go
+++ b/core/fullnode.go
@@ -220,9 +220,18 @@ func (c *Core) processSingleTransaction(newEvent *models.EventTransaction) error
 	syncTxChains := func(peerDID string, tokenIDs []string, prevTxIDs map[string]string, excludeTxIDs []string) error {
 		return c.SyncTransactionChainsFromPeer(peerDID, tokenIDs, prevTxIDs, excludeTxIDs, false, c.fullNode)
 	}
+	syncAuthoritative := func(tokenIDs []string) (map[string]string, error) {
+		return c.syncTokensFromFullnode(tokenIDs)
+	}
+	getTxByID := func(txID string) (*models.TransactionInfo, error) {
+		return c.getTransactionInfoByID(txID)
+	}
+	getParentBurnTx := func(parentID string) (string, bool, error) {
+		return c.getParentBurnTxID(parentID)
+	}
 	// Fullnode trusts the quorum's earlier transfer-auth decision; the flag
 	// is not in the EventTransaction.
-	_, err = consensus.ValidateTransaction(txn, c.fullNode, c.w, c.log, initiatorDIDCrypto, quorumDCs, c.testnet, c.mainnet, c.localnet, c.checkTokenStateHashPinned, syncTxChains, false)
+	_, err = consensus.ValidateTransaction(txn, c.fullNode, c.w, c.log, initiatorDIDCrypto, quorumDCs, c.testnet, c.mainnet, c.localnet, c.checkTokenStateHashPinned, syncTxChains, syncAuthoritative, getTxByID, getParentBurnTx, false)
 	if err != nil {
 		c.log.Error("processSingleTransaction:failed to validate transaction", "error", err)
 		// Storing the invalid transaction is deferred to processTxnWithRetry,

--- a/core/fullnode.go
+++ b/core/fullnode.go
@@ -81,6 +81,7 @@ func (c *Core) TxnCallBack(peerID string, topic string, data []byte) {
 	publisherDetails := models.DID{
 		DID:    txInfo.Initiator,
 		PeerID: peerID,
+		Local:  peerID == c.peerID, // This was empty and was getting updated to false by default, so we set it based on the peerID comparison
 	}
 	err = c.AddPeerDetails(publisherDetails)
 	if err != nil {

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -195,6 +195,34 @@ func (c *Core) initiateConsensusHandler(request *ensweb.Request) *ensweb.Result 
 	}
 	c.log.Info("Consensus request parsed successfully", "request", consensusRequest)
 
+	// Release-on-abort guard for the pledge lock.
+	//
+	// The initiator locks this quorum's selected pledge tokens (status Locked) in
+	// the earlier requestPledgeTokenHandler call, BEFORE this handler runs. Those
+	// locks are only transitioned to Pledged — and recorded in
+	// unpledge_sequence_info so CallBackQuorumUnpledge can later release them — by
+	// PledgeV2 near the end of this handler. Any early return before PledgeV2
+	// commits (a failed ValidateTransaction such as a rejected replay, a consensus
+	// failure, or any of the validation errors below) would otherwise leave those
+	// tokens stuck Locked forever: no unpledge_sequence_info row exists, so the
+	// deferred CallBackQuorumUnpledge skips them, and nothing else frees them.
+	//
+	// This defer releases the locked tokens on every abort path unless
+	// pledgeCommitted is set true immediately after PledgeV2 succeeds.
+	pledgeCommitted := false
+	defer func() {
+		if pledgeCommitted {
+			return
+		}
+		if releaseErr := c.w.ReleaseAllLockedRBTTokensForDID(c.w.Ctx, quorumDid, consensusRequest.ReferenceId); releaseErr != nil {
+			c.log.Error("initiateConsensusHandler: failed to release locked tokens on abort",
+				"did", quorumDid, "referenceID", consensusRequest.ReferenceId, "err", releaseErr)
+		} else {
+			c.log.Info("initiateConsensusHandler: released locked tokens on abort (pledge not committed)",
+				"did", quorumDid, "referenceID", consensusRequest.ReferenceId)
+		}
+	}()
+
 	// Validation pipeline: run stateless checks BEFORE calling InitiateConsensus
 
 	// Check 0: Nil-check TransactionInfo
@@ -420,6 +448,12 @@ func (c *Core) initiateConsensusHandler(request *ensweb.Request) *ensweb.Result 
 		// Alerting is needed to investigate and resolve the underlying issue.
 		return c.l.RenderJSON(request, response, http.StatusInternalServerError)
 	}
+
+	// PledgeV2 committed the pledge: the tokens are now Pledged and recorded in
+	// unpledge_sequence_info, so CallBackQuorumUnpledge owns their release. Disarm
+	// the abort-release guard so it does not free tokens that are legitimately
+	// pledged.
+	pledgeCommitted = true
 
 	return c.l.RenderJSON(request, &consensusResponse, http.StatusOK)
 }

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -241,7 +241,22 @@ func (c *Core) initiateConsensusHandler(request *ensweb.Request) *ensweb.Result 
 	syncTxChains := func(peerDID string, tokenIDs []string, prevTxIDs map[string]string, excludeTxIDs []string) error {
 		return c.SyncTransactionChainsFromPeer(peerDID, tokenIDs, prevTxIDs, excludeTxIDs, false, c.fullNode)
 	}
-	isTransactionInfoValidated, err := consensus.ValidateTransaction(txn, c.fullNode, c.w, c.log, initiatorDIDCrypto, nil, c.testnet, c.mainnet, c.localnet, c.checkTokenStateHashPinned, syncTxChains, consensusRequest.TransferNFTOwnership)
+	// Committed (burnt parent) tokens are verified against an authoritative full
+	// node so a rolled-back initiator cannot drive a replayed split through
+	// consensus.
+	syncAuthoritative := func(tokenIDs []string) (map[string]string, error) {
+		return c.syncTokensFromFullnode(tokenIDs)
+	}
+	// Resolve a split genesis transaction by ID so the replay check can read the
+	// burnt parents it carries, and read a parent's burning transaction from its
+	// local (or freshly-synced) chain.
+	getTxByID := func(txID string) (*models.TransactionInfo, error) {
+		return c.getTransactionInfoByID(txID)
+	}
+	getParentBurnTx := func(parentID string) (string, bool, error) {
+		return c.getParentBurnTxID(parentID)
+	}
+	isTransactionInfoValidated, err := consensus.ValidateTransaction(txn, c.fullNode, c.w, c.log, initiatorDIDCrypto, nil, c.testnet, c.mainnet, c.localnet, c.checkTokenStateHashPinned, syncTxChains, syncAuthoritative, getTxByID, getParentBurnTx, consensusRequest.TransferNFTOwnership)
 	if err != nil || !isTransactionInfoValidated {
 		c.log.Error("initiateConsensusHandler: transaction info validation failed", "err", err)
 		if err != nil {

--- a/core/sync.go
+++ b/core/sync.go
@@ -394,6 +394,14 @@ func (c *Core) applyTokenChainFromSync(tokenID string, remoteTxs []types.Transac
 			tokenStatus = int16(constants.TokenStatus_Deployed)
 		case int16(models.GetTokenRoleID(constants.TokenRole_Execute)):
 			tokenStatus = int16(constants.TokenStatus_Executed)
+		// A consumed parent must not default to Free, or it can be re-selected by
+		// LockTokensForSplit and re-split into a duplicate genesis (double-mint).
+		// Mirror the originating node: Commit -> Committed, Burn -> Burnt.
+		// See docs/PROBLEM.md.
+		case int16(models.GetTokenRoleID(constants.TokenRole_Commit)):
+			tokenStatus = int16(constants.TokenStatus_Committed)
+		case int16(models.GetTokenRoleID(constants.TokenRole_Burn)):
+			tokenStatus = int16(constants.TokenStatus_Burnt)
 		}
 
 		newToken := models.Token{
@@ -473,6 +481,15 @@ func (c *Core) applyTokenChainFromSync(tokenID string, remoteTxs []types.Transac
 		lastStatus = int16(constants.TokenStatus_Deployed)
 	case int16(models.GetTokenRoleID(constants.TokenRole_Execute)):
 		lastStatus = int16(constants.TokenStatus_Executed)
+	// A consumed parent must stay consumed after sync. This update runs even
+	// for pre-existing tokens, so without these cases a re-synced burnt parent
+	// would be overwritten back to Free and become re-splittable (double-mint).
+	// Mirror the originating node: Commit -> Committed, Burn -> Burnt.
+	// See docs/PROBLEM.md.
+	case int16(models.GetTokenRoleID(constants.TokenRole_Commit)):
+		lastStatus = int16(constants.TokenStatus_Committed)
+	case int16(models.GetTokenRoleID(constants.TokenRole_Burn)):
+		lastStatus = int16(constants.TokenStatus_Burnt)
 	}
 	// For NFT executions, ownership doesn't change
 	// in sync with the chain head when a non-owner subscriber executes an NFT.

--- a/core/sync.go
+++ b/core/sync.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rubixchain/rubixgoplatform/constants"
 	rubixsync "github.com/rubixchain/rubixgoplatform/core/sync"
 	rubixmath "github.com/rubixchain/rubixgoplatform/math"
+	"github.com/rubixchain/rubixgoplatform/setup"
 	"github.com/rubixchain/rubixgoplatform/types"
 	"github.com/rubixchain/rubixgoplatform/types/models"
 	"github.com/rubixchain/rubixgoplatform/util"
@@ -152,6 +153,198 @@ func (c *Core) SyncTransactionChainsFromPeer(peerDID string, tokenIDs []string, 
 
 	c.log.Info("SyncTransactionChainsFromPeer: Sync completed", "peerDID", peerDID, "tokenCount", len(tokenIDs))
 	return nil
+}
+
+// syncTokensFromFullnode fetches the given tokens' chains from an authoritative
+// full node (selected from the canonical fullnodes list) and returns, for each
+// token the full node knows, the ID of the transaction that BURNT it (the last
+// role=burn entry), or "" if the full node's chain shows it as not burnt.
+//
+// This exists so consensus validation can verify a burnt/committed parent
+// token's TRUE latest state instead of trusting the transaction initiator's
+// view — a rolled-back initiator can serve a stale (pre-burn) parent chain and
+// drive a replayed split through consensus.
+//
+// It deliberately does NOT persist the fetched chain into the local wallet.
+// The only consumer (ValidateSplitParentsAgainstFullnode) needs a single fact
+// per ancestor — "which tx burnt it" — which the SyncedTxn response already
+// carries (id + role per entry). Persisting via applyTokenChainFromSync would
+// (a) require the transaction SIGNATURE, which the fullnode sync-info endpoint
+// (SyncedTxn) does not transmit — the insert into `transactions` (signature NOT
+// NULL) would fail — and (b) pollute this node's wallet with fullnode chains for
+// tokens it does not own. Reading the burn tx straight from the response avoids
+// both. (See the commented-out apply-based variant below for the alternative
+// that would additionally need the SyncedTxn signature plumbing.)
+//
+// The fullnode sync endpoint (APISyncTransactionInfoFromFullnode) is any-peer
+// callable and requires no ownership proof, so unlike wallet recovery this does
+// not fetch/sign a nonce. It paginates until all pages are consumed.
+//
+// Returned map keys are only the tokens the fullnode actually returned data
+// for; a token absent from the map means the fullnode had no chain for it.
+func (c *Core) syncTokensFromFullnode(tokenIDs []string) (map[string]string, error) {
+	if len(tokenIDs) == 0 {
+		return map[string]string{}, nil
+	}
+
+	peerID, err := c.selectActiveFullnodePeer(c.Ctx)
+	if err != nil {
+		return nil, fmt.Errorf("syncTokensFromFullnode: select fullnode peer: %w", err)
+	}
+
+	peer, err := c.pm.OpenPeerConn(peerID, "", c.getCoreAppName(peerID))
+	if err != nil {
+		return nil, fmt.Errorf("syncTokensFromFullnode: connect to fullnode %s: %w", peerID, err)
+	}
+	defer peer.Close()
+
+	c.log.Info("syncTokensFromFullnode: syncing parent tokens from fullnode",
+		"fullnode_peer", peerID, "tokenCount", len(tokenIDs))
+
+	burnRole := int16(models.GetTokenRoleID(constants.TokenRole_Burn))
+	// burnTxByToken[tokenID] = the ID of the last role=burn entry the fullnode
+	// served for that token; "" recorded when the fullnode returned the chain
+	// but it has no burn entry (token still free on the authoritative record).
+	burnTxByToken := make(map[string]string, len(tokenIDs))
+	tokensInResponse := make(map[string]struct{}, len(tokenIDs))
+
+	pageNumber := 1
+	for {
+		syncReq := types.SyncTransactionInfoFromFullnodeRequest{
+			TokenIDs:   tokenIDs,
+			PageNumber: pageNumber,
+		}
+		// The fullnode wraps the result in a BasicResponse envelope
+		// ({status, message, result}), and SendJSONRequest decodes the raw body
+		// into the target WITHOUT unwrapping. Decoding directly into a bare
+		// SyncTransactionInfoFromFullnodeResult therefore silently yields a
+		// zero-value (Data=nil, TotalItems=0) — the payload lives under "result".
+		// Decode into the envelope and read the typed Result.
+		var syncEnvelope struct {
+			Status  bool                                        `json:"status"`
+			Message string                                      `json:"message"`
+			Result  types.SyncTransactionInfoFromFullnodeResult `json:"result"`
+		}
+		if err := peer.SendJSONRequest("POST", setup.APISyncTransactionInfoFromFullnode, nil, &syncReq, &syncEnvelope, false, 30*time.Second); err != nil {
+			return nil, fmt.Errorf("syncTokensFromFullnode: request page %d from %s: %w", pageNumber, peerID, err)
+		}
+		syncResp := syncEnvelope.Result
+
+		c.log.Debug("syncTokensFromFullnode: page received",
+			"fullnode_peer", peerID, "page", pageNumber, "totalPages", syncResp.TotalPages,
+			"tokensInPage", len(syncResp.Data), "totalItems", syncResp.TotalItems,
+			"divergentTokens", syncResp.DivergentTokens)
+
+		for tokenID, syncedTxns := range syncResp.Data {
+			tokensInResponse[tokenID] = struct{}{}
+			// Entries are position-ordered; the last role=burn entry is the tx
+			// that consumed this token on the authoritative record. We read it
+			// straight from the response — no local persistence, no signature.
+			for _, st := range syncedTxns {
+				if st.Role == burnRole {
+					burnTxByToken[tokenID] = st.ID
+				}
+			}
+			if _, seen := burnTxByToken[tokenID]; !seen {
+				// Chain served but no burn entry → authoritatively not burnt.
+				burnTxByToken[tokenID] = ""
+			}
+
+			// --- OPTION A (apply-based) — INTENTIONALLY DISABLED --------------
+			// The alternative below persists the authoritative chain locally via
+			// applyTokenChainFromSync, so getParentBurnTxID could re-read it from
+			// the tokenchain table. It is disabled because it requires the
+			// transaction SIGNATURE (transactions.signature is NOT NULL), which
+			// the fullnode SyncedTxn payload does not currently carry — enabling
+			// it needs the SyncedTxn signature plumbing on the fullnode
+			// sync-serve path. It also writes fullnode chains into this node's
+			// wallet for tokens it does not own. Kept for reference only.
+			//
+			// remoteTxs := make([]types.TransactionWithRole, 0, len(syncedTxns))
+			// for _, st := range syncedTxns {
+			// 	remoteTxs = append(remoteTxs, types.TransactionWithRole{
+			// 		// Signature: st.Signature, // requires SyncedTxn.Signature (see Option A note)
+			// 		Tx:   models.Transactions{ID: st.ID, Info: st.Info},
+			// 		Role: st.Role,
+			// 	})
+			// }
+			// if len(remoteTxs) > 0 {
+			// 	if applyErr := c.applyTokenChainFromSync(tokenID, remoteTxs, "", false); applyErr != nil {
+			// 		c.log.Warn("syncTokensFromFullnode: apply failed (non-fatal)", "tokenID", tokenID, "err", applyErr)
+			// 	}
+			// }
+			// ------------------------------------------------------------------
+		}
+
+		if syncResp.TotalPages <= 0 || pageNumber >= syncResp.TotalPages {
+			break
+		}
+		pageNumber++
+	}
+
+	// Surface tokens the fullnode returned NOTHING for — the authoritative
+	// source has no chain to serve for them. This is the signal that made the
+	// replayed-split check accept: an empty fullnode response is indistinguishable
+	// from "ancestor is free" unless we log it explicitly.
+	missing := make([]string, 0)
+	for _, t := range tokenIDs {
+		if _, ok := tokensInResponse[t]; !ok {
+			missing = append(missing, t)
+		}
+	}
+	c.log.Info("syncTokensFromFullnode: sync completed",
+		"fullnode_peer", peerID, "tokenCount", len(tokenIDs),
+		"tokensReturnedByFullnode", len(tokensInResponse),
+		"tokensFullnodeHadNothingFor", missing, "burnTxByToken", burnTxByToken)
+	return burnTxByToken, nil
+}
+
+// getTransactionInfoByID fetches a stored transaction by ID and returns its
+// unmarshalled TransactionInfo. Used by the replayed-split check to read the
+// burnt parents carried in a split genesis transaction's CommittedTokens.
+// Returns an error if the transaction is not present locally or cannot be
+// decoded; callers treat a miss as "not a resolvable split genesis".
+func (c *Core) getTransactionInfoByID(txID string) (*models.TransactionInfo, error) {
+	if txID == "" {
+		return nil, fmt.Errorf("getTransactionInfoByID: empty transaction id")
+	}
+	txn, err := c.w.GetTransactionByID(txID, c.fullNode)
+	if err != nil {
+		return nil, err
+	}
+	var info models.TransactionInfo
+	if err := json.Unmarshal(txn.Info, &info); err != nil {
+		return nil, fmt.Errorf("getTransactionInfoByID: unmarshal info for %s: %w", txID, err)
+	}
+	return &info, nil
+}
+
+// getParentBurnTxID reads a parent token's chain and returns the ID of the
+// transaction that burnt it (the last row with role=burn), if any. Used by the
+// replayed-split check to confirm a parent was burnt by the split genesis that
+// claims it, and not by an earlier, different transaction. A parent that is not
+// burnt in the local (or freshly-synced) chain returns found=false.
+func (c *Core) getParentBurnTxID(parentID string) (string, bool, error) {
+	if parentID == "" {
+		return "", false, nil
+	}
+	chain, err := c.w.GetTokenChainByTokenID(parentID, c.fullNode)
+	if err != nil {
+		// No chain locally is not an error for this check — the caller falls
+		// back to an authoritative sync.
+		c.log.Debug("getParentBurnTxID: no local chain for token (unconfirmed)", "tokenID", parentID, "err", err)
+		return "", false, nil
+	}
+	burnRole := int16(models.GetTokenRoleID(constants.TokenRole_Burn))
+	burnTxID := ""
+	for _, row := range chain {
+		if row.Role == burnRole {
+			burnTxID = row.TransactionID
+		}
+	}
+	c.log.Debug("getParentBurnTxID: read token chain",
+		"tokenID", parentID, "chainLen", len(chain), "burnTxID", burnTxID, "burnt", burnTxID != "")
+	return burnTxID, burnTxID != "", nil
 }
 
 // applyTokenChainFromSync validates and applies synced transactions for a single token.
@@ -397,7 +590,6 @@ func (c *Core) applyTokenChainFromSync(tokenID string, remoteTxs []types.Transac
 		// A consumed parent must not default to Free, or it can be re-selected by
 		// LockTokensForSplit and re-split into a duplicate genesis (double-mint).
 		// Mirror the originating node: Commit -> Committed, Burn -> Burnt.
-		// See docs/PROBLEM.md.
 		case int16(models.GetTokenRoleID(constants.TokenRole_Commit)):
 			tokenStatus = int16(constants.TokenStatus_Committed)
 		case int16(models.GetTokenRoleID(constants.TokenRole_Burn)):
@@ -485,7 +677,6 @@ func (c *Core) applyTokenChainFromSync(tokenID string, remoteTxs []types.Transac
 	// for pre-existing tokens, so without these cases a re-synced burnt parent
 	// would be overwritten back to Free and become re-splittable (double-mint).
 	// Mirror the originating node: Commit -> Committed, Burn -> Burnt.
-	// See docs/PROBLEM.md.
 	case int16(models.GetTokenRoleID(constants.TokenRole_Commit)):
 		lastStatus = int16(constants.TokenStatus_Committed)
 	case int16(models.GetTokenRoleID(constants.TokenRole_Burn)):

--- a/core/sync/transaction_chain.go
+++ b/core/sync/transaction_chain.go
@@ -198,7 +198,7 @@ func SyncTransactionChainFrom(p *ipfsport.Peer, tokenID string, tokenType int, w
 				// A consumed parent must not default to Free, or it can be re-selected
 				// by LockTokensForSplit and re-split into a duplicate genesis
 				// (double-mint). Mirror the originating node's status:
-				// Commit -> Committed, Burn -> Burnt. See docs/PROBLEM.md.
+				// Commit -> Committed, Burn -> Burnt.
 				case int16(models.GetTokenRoleID(constants.TokenRole_Commit)):
 					tokenStatus = int16(constants.TokenStatus_Committed)
 				case int16(models.GetTokenRoleID(constants.TokenRole_Burn)):

--- a/core/sync/transaction_chain.go
+++ b/core/sync/transaction_chain.go
@@ -195,6 +195,14 @@ func SyncTransactionChainFrom(p *ipfsport.Peer, tokenID string, tokenType int, w
 					tokenStatus = int16(constants.TokenStatus_Deployed)
 				case int16(models.GetTokenRoleID(constants.TokenRole_Execute)):
 					tokenStatus = int16(constants.TokenStatus_Executed)
+				// A consumed parent must not default to Free, or it can be re-selected
+				// by LockTokensForSplit and re-split into a duplicate genesis
+				// (double-mint). Mirror the originating node's status:
+				// Commit -> Committed, Burn -> Burnt. See docs/PROBLEM.md.
+				case int16(models.GetTokenRoleID(constants.TokenRole_Commit)):
+					tokenStatus = int16(constants.TokenStatus_Committed)
+				case int16(models.GetTokenRoleID(constants.TokenRole_Burn)):
+					tokenStatus = int16(constants.TokenStatus_Burnt)
 				}
 
 				if err = w.CreateTransaction(tx); err != nil {

--- a/core/wallet/fullnode.go
+++ b/core/wallet/fullnode.go
@@ -255,6 +255,14 @@ func (w *Wallet) GetFullNodeSyncedChainPageByOffset(
 		return nil, nil, nil
 	}
 
+	// NOTE (replayed-split check, Option A — DISABLED): this SELECT deliberately
+	// omits t.signature, so SyncedTxn carries no signature. The only current
+	// consumer (ValidateSplitParentsAgainstFullnode) does not persist the chain,
+	// so it does not need it. To enable Option A (applying the synced chain into a
+	// signature-NOT-NULL transactions table), add `, t.signature` to the SELECT,
+	// add a Signature field to syncChainRow, and set SyncedTxn.Signature in the
+	// SyncedTxn build below — mirroring the recovery query in
+	// core/wallet/recovery.go which selects t.info AND t.signature.
 	rows, err := w.db.Pool().Query(w.Ctx, `
 		SELECT tc.token_id, tc.transaction_id, tc.role, tc.position,
 		       tc.previous_transaction_id, t.info

--- a/types/fullnode.go
+++ b/types/fullnode.go
@@ -59,6 +59,18 @@ type SyncTransactionInfoFromFullnodeResult struct {
 // unmarshal+remarshal on the server). Position is the entry's chain position
 // on the fullnode — the caller uses it to update KnownPositions for the next
 // request.
+//
+// NOTE (replayed-split check, Option A — DISABLED): SyncedTxn intentionally does
+// NOT carry the transaction Signature. The replayed-split verifier
+// (ValidateSplitParentsAgainstFullnode) consumes this endpoint but only needs
+// each ancestor's burn-tx ID, which it reads straight from these entries (id +
+// role) WITHOUT persisting the chain — so no signature is required. If a future
+// caller needs to APPLY the synced chain into a local wallet (whose transactions
+// table has signature NOT NULL), Option A would add a `Signature json.RawMessage
+// json:"signature"` field here, mirroring the recovery path's
+// RecoveredTransaction.Signature, and populate it in the sync-serve query +
+// handler (see core/wallet/fullnode.go GetFullNodeSyncedChainPageByOffset and
+// core/sync.go syncTokensFromFullnode's commented Option-A block).
 type SyncedTxn struct {
 	ID                    string          `json:"id"`
 	Role                  int16           `json:"role"`


### PR DESCRIPTION
## Summary

A rolled-back initiator could re-split an already-burnt parent RBT token under a new
genesis and drive the duplicate through quorum consensus, minting the child tokens a
second time (a **double-mint**). The invalid transaction was only caught later by the
full node during ingestion, leaving a permanently invalid transaction on the network and
cascading chain-mismatch failures for anything built on the second split.

This PR closes that hole with two layers of defense and fixes three related bugs
uncovered while validating the fix end-to-end on a live testnet.

## What was wrong

1. **Parent resurrection (sync status).** On applying a synced token chain, a consumed
   parent's `token_status` was derived only for Deploy/Execute roles; Commit/Burn fell
   through to the default `Free`. A burnt parent synced onto a node became `Free`, and
   since `LockTokensForSplit` only picks `Free` tokens, it was re-selectable and
   re-splittable — producing the same deterministic child IDs (duplicate genesis).

2. **No authoritative parent check at consensus.** The quorum validating a split had no
   independent view of a parent's true state. It synced the parent from the initiator
   (the rolled-back node), validating a corrupted view against itself.

## The fix

### 1. Keep consumed parents Burnt/Committed on sync (`c2307e21`)
Add the missing `Commit → Committed` and `Burn → Burnt` cases to the sync
status-derivation switches (`core/sync.go`, both create-time and update-time; the
update-time switch was the actual resurrection point, overwriting a `Burnt` row back to
`Free` on re-sync). Mirrors the mapping the full-node apply path already used.

### 2. Reject replayed splits at consensus via a full-node ancestor check (`4f000003`)
New `ValidateSplitParentsAgainstFullnode` (`core/consensus/checks.go`). For each
transferred RBT child whose previous transaction resolves to a split genesis:
- **Derive** the child's ancestor tokens from the token-ID hierarchy
  (`util.TokenID.GetHierarchy`) — deterministic and **not initiator-controlled**.
- **Intersect** with the genesis's declared `CommittedTokens` — exactly the tokens this
  split actually consumes.
- For each such ancestor, the **authoritative full node's** burn transaction must be
  either absent (legitimate first split) or *this* genesis. If the ancestor was burnt by
  a **different, earlier** transaction, the split is re-consuming an already-spent token
  → rejected as a double spend.

Why this shape: deriving ancestors from the hierarchy (not the initiator's parent list)
closes an evasion where a rolled-back initiator presents a double-spent parent as an
empty-prev "fresh mint." The derive∩committed **intersection** is essential — the
derived hierarchy alone over-rejects a legitimate split of a low part (whose higher
ancestors were legitimately burnt by earlier splits), while `CommittedTokens` alone is
initiator-forgeable.

The check is **tiered** (local burn records first, then a one-shot authoritative
full-node sync of unconfirmed ancestors) and **fails open** (accepts with a warning)
when no full node is reachable, so transactions keep flowing.

**Also fixes two bugs that made the full-node sync silently return empty (which had
rendered the check dead code):**
- **Envelope mismatch:** the client decoded the full node's `{status,message,result}`
  response into a bare result struct, yielding a zero value. Now decodes the envelope
  and reads `.Result`.
- **Missing signature on apply:** the synced payload carries no signature, so
  re-inserting into `transactions` (signature `NOT NULL`) failed. `syncTokensFromFullnode`
  now returns an in-memory `map[ancestor]burnTxID` read straight from the sync response —
  no DB apply, no signature needed. The full-node sync-serve code is untouched.

### 3. Release quorum pledge locks on aborted consensus (`f27d9364`)
Rejected transactions could leave a quorum's selected pledge tokens permanently `Locked`.
Adds a defer-based cleanup guard that releases locks (scoped by `lock_reference_id`) on
every abort path unless `PledgeV2` committed. (Pre-existing orphaned `Locked` balances
are out of scope.)

### 4. Preserve the local flag for a quorum's own DID (`708d3050`)
`TxnCallBack` rebuilt the publisher DID without `Local`, and `CreateOrUpdateDID`'s
`ON CONFLICT` overwrites `local` unconditionally — silently flipping a quorum node's own
DID to `local=false` on its first self-initiated transaction. Now sets
`Local: peerID == c.peerID`, re-affirming the node's own DID as local on every
self-initiated event.

## Testing

- **Unit:** `core/consensus/checks_test.go` — deep-replay reject, low-part re-split
  accept, empty-prev evasion, fail-open, pass-through cases.
- **End-to-end (live 3-node testnet + local full node):** replays rejected on both the
  local-override and default remote-registry full-node paths; legitimate transfers (whole
  split, whole-intact, whole+part combination) all accepted; rejected transactions no
  longer leave the quorum's balance stuck `Locked`; a DID stuck at `local=false` repaired
  on its next self-initiated split.

## Files

```
core/consensus/checks.go        +263   ValidateSplitParentsAgainstFullnode + wiring
core/consensus/checks_test.go   +220   unit tests
core/sync.go                    +208   syncTokensFromFullnode (+envelope fix), status mapping, helpers
core/quorum_initiator.go        +51    callback wiring (quorum path) + pledge-lock cleanup
core/fullnode.go                +12    callback wiring (full node path)
core/sync/transaction_chain.go  +8     status mapping (legacy path)
core/wallet/fullnode.go         +8     sync-serve query note
types/fullnode.go               +12    SyncedTxn note
```
