### PR TITLE
Fix smart contract deploy collateral accounting

### DIFF
--- a/core/transaction_builder.go
+++ b/core/transaction_builder.go
@@ -167,6 +167,102 @@ func BuildTransactionInfoFromRequest(
 		log.Info("BuildTransactionInfoFromRequest: RBT tokens collected", "tokenCount", len(rbtTokens), "amount", req.GetRBTAmount())
 	}
 
+	// --- SC deploy collateral: split before the non-RBT transaction opens ---
+	//
+	// LockTokensForSplit selects whole denominations, so backing a 0.001
+	// commitment picks a whole 1.000 token. Committing that token as-is sinks
+	// the other 0.999 — a 0.001 contract costs a full RBT. So split first and
+	// keep the change, exactly as the RBT transfer path does.
+	//
+	// This runs BEFORE the non-RBT tx begins: PersistGenesisTransaction opens
+	// its own connection and upserts the burnt parent row, which would deadlock
+	// against locks held by that outer transaction until lock_timeout fires.
+	//
+	// scCommittedTokens maps a smart contract ID to the tokens backing it.
+	scCommittedTokens := make(map[string][]*models.TokenInfo)
+	if req.HasSmartContract() {
+		for _, scInfo := range req.GetAllSmartContracts() {
+			if scInfo.Value <= 0 {
+				continue
+			}
+			// Execute-mode SCs reuse their existing value and need no collateral.
+			exists, err := w.TokenExists(ctx, nil, scInfo.SmartContractId)
+			if err != nil {
+				return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest: failed to check SC existence: %w", err)
+			}
+			if exists {
+				continue
+			}
+
+			log.Info("BuildTransactionInfoFromRequest: Locking RBT tokens for SC committed value", "scID", scInfo.SmartContractId, "value", scInfo.Value)
+			ownedRBTTokens, err := w.LockTokensForSplit(ctx, req.Initiator, scInfo.Value, referenceID)
+			if err != nil {
+				log.Error("BuildTransactionInfoFromRequest: Failed to lock RBT for SC committed tokens", "err", err, "scID", scInfo.SmartContractId, "value", scInfo.Value)
+				return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest: failed to lock RBT for SC committed tokens: %w", err)
+			}
+			log.Info("BuildTransactionInfoFromRequest: RBT tokens locked for SC commitment", "scID", scInfo.SmartContractId, "tokenCount", len(ownedRBTTokens))
+
+			denomMap, err := w.GetTokenDenomArray(req.Initiator)
+			if err != nil {
+				log.Error("BuildTransactionInfoFromRequest: Failed to get denom array for SC commitment", "err", err, "did", req.Initiator)
+				return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest: get denom array for SC commitment: %w", err)
+			}
+
+			committedRBTTokens, childTokensKept, burntParentToken, mintTokensBeingBurnt, err := parts.CollectRBTTokens(
+				dc, w, scInfo.Value, ownedRBTTokens, denomMap, networkMode, log,
+			)
+			if err != nil {
+				log.Error("BuildTransactionInfoFromRequest: RBT collection failed for SC commitment", "err", err, "scID", scInfo.SmartContractId, "value", scInfo.Value)
+				return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest: RBT collection failed for SC commitment: %w", err)
+			}
+
+			// A split happened: persist the minted change and the burnt parent.
+			var scGenTX *models.Transactions
+			if len(childTokensKept) > 0 && len(burntParentToken) > 0 {
+				scGenTX = childTokensKept[0].TxRecord
+				if scGenTX == nil {
+					return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest(SC): generated transaction record is nil")
+				}
+
+				if errPersist := w.PersistGenesisTransaction(&wallet.PersistGenesisTransactionReq{
+					DID:                  req.Initiator,
+					GenesisTokens:        childTokensKept,
+					BurnTokens:           burntParentToken,
+					GenesisTransaction:   scGenTX,
+					MintTokensBeingBurnt: mintTokensBeingBurnt,
+				}); errPersist != nil {
+					return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest(SC): failed to persist genesis transaction, err: %v", errPersist)
+				}
+
+				var genTxInfo models.TransactionInfo
+				if err := json.Unmarshal(scGenTX.Info, &genTxInfo); err != nil {
+					return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest(SC): failed to unmarshal transaction info, err: %v", err)
+				}
+
+				var genTxSignature models.Signature
+				if err := json.Unmarshal(scGenTX.Signature, &genTxSignature); err != nil {
+					return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest(SC): failed to unmarshal signature, err: %v", err)
+				}
+
+				if networkMode != constants.NetworkMode_Localnet {
+					if _, err := util.PublishTransaction(pubsub, &genTxInfo, &genTxSignature, true, ""); err != nil {
+						log.Error("BuildTransactionInfoFromRequest(SC): failed to publish transaction, err: %v", err)
+					}
+				}
+			}
+
+			// Split-derived tokens have no previous transaction yet — their
+			// genesis is the split just persisted.
+			for _, token := range committedRBTTokens {
+				if token.PreviousTransactionID == "" && scGenTX != nil {
+					token.PreviousTransactionID = scGenTX.ID
+				}
+			}
+			scCommittedTokens[scInfo.SmartContractId] = committedRBTTokens
+			log.Debug("BuildTransactionInfoFromRequest: SC collateral split", "scID", scInfo.SmartContractId, "committedCount", len(committedRBTTokens))
+		}
+	}
+
 	// --- FT/NFT/SC: single DB transaction for all non-RBT assets ---
 	hasNonRBT := req.HasFT() || req.HasNFT() || req.HasSmartContract()
 	if hasNonRBT {
@@ -330,28 +426,16 @@ func BuildTransactionInfoFromRequest(
 				} else {
 					// DEPLOYMENT MODE: Token doesn't exist, prepare for deployment
 					log.Info("BuildTransactionInfoFromRequest: SC does not exist - DEPLOYMENT MODE", "scID", scInfo.SmartContractId, "value", scInfo.Value)
-					// Collect committed tokens if SC has value > 0
-					if scInfo.Value > 0 {
-						log.Info("BuildTransactionInfoFromRequest: Locking RBT tokens for SC committed value", "scID", scInfo.SmartContractId, "value", scInfo.Value)
-						// Lock RBT tokens for the smart contract value
-						ownedRBTTokens, err := w.LockTokensForSplit(ctx, req.Initiator, scInfo.Value, referenceID)
-						if err != nil {
-							log.Error("BuildTransactionInfoFromRequest: Failed to lock RBT for SC committed tokens", "err", err, "scID", scInfo.SmartContractId, "value", scInfo.Value)
-							return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest: failed to lock RBT for SC committed tokens: %w", err)
-						}
-						log.Info("BuildTransactionInfoFromRequest: RBT tokens locked for SC commitment", "scID", scInfo.SmartContractId, "tokenCount", len(ownedRBTTokens))
-
-						// Convert to TokenInfo format for CommittedTokens and add to locked list
-						for _, token := range ownedRBTTokens {
-							committedToken := &models.TokenInfo{
-								TokenID:               token.TokenID,
-								PreviousTransactionID: token.TransactionID,
-							}
-							allCommittedTokens = append(allCommittedTokens, committedToken)
+					// Collateral was locked and split in the pre-pass above, so only
+					// the tokens actually backing scInfo.Value are committed here;
+					// the change was minted back to the initiator as Free.
+					if committed, ok := scCommittedTokens[scInfo.SmartContractId]; ok {
+						for _, token := range committed {
+							allCommittedTokens = append(allCommittedTokens, token)
 							// Add to locked list so they get marked as Locked (not Committed yet - that happens during consensus)
 							allLockedIDs = append(allLockedIDs, token.TokenID)
 						}
-						log.Debug("BuildTransactionInfoFromRequest: Committed tokens prepared", "count", len(ownedRBTTokens))
+						log.Debug("BuildTransactionInfoFromRequest: Committed tokens prepared", "count", len(committed))
 					}
 
 					// Add SC to transaction tokens (will be deployed during consensus)

--- a/core/wallet/post_consensus_persistence.go
+++ b/core/wallet/post_consensus_persistence.go
@@ -145,8 +145,28 @@ func (pc *PostConsensusPersistenceCoordinator) Persist(ctx context.Context, req 
 	if err := pc.upsertTokenStates(ctx, tx, req.TokenStates); err != nil {
 		return err
 	}
-	if len(req.TransactionInfo.Tokens.RBT) != 0 {
-		if err := pc.upsertTokenDenomDeltas(ctx, tx, req.DID, req.TokenStates, req.ExecutionRole, isLocalTransfer, req.TransactionInfo.Owner); err != nil {
+	// An SC deploy moves RBT collateral from Free to Committed while carrying
+	// Tokens.RBT empty — the collateral rides in CommittedTokens instead. Gating
+	// only on Tokens.RBT skipped the decrement, so token_denom kept counting
+	// those tokens as spendable and a later selection failed with
+	// "lockSelectedTokens: no tokens provided".
+	//
+	// hasSCDeploy is deliberately the same predicate isSCDeployCommit uses to
+	// flip that status (see post_consensus_payload_builder.go), so the counter
+	// update and the status change cannot diverge. Testing CommittedTokens
+	// directly would be wrong: a split genesis also carries burnt parents there,
+	// and those are already accounted for by PersistGenesisTransaction.
+	//
+	// The isLocalTransfer credit is suppressed for a deploy. That block exists
+	// for a same-node RBT transfer, where sender and receiver are different DIDs
+	// on one node: decrement the sender, credit the receiver. A deploy pins Owner
+	// to Initiator, so isLocalTransfer is always true and the credit lands on the
+	// very DID just decremented — cancelling it out and leaving the collateral
+	// counted as spendable. There is no receiver: the collateral is terminally
+	// Committed, so nothing should be credited back.
+	scDeploy := hasSCDeploy(req.TransactionInfo)
+	if len(req.TransactionInfo.Tokens.RBT) != 0 || scDeploy {
+		if err := pc.upsertTokenDenomDeltas(ctx, tx, req.DID, req.TokenStates, req.ExecutionRole, isLocalTransfer && !scDeploy, req.TransactionInfo.Owner); err != nil {
 			return err
 		}
 	}

--- a/test/integration/runner.py
+++ b/test/integration/runner.py
@@ -329,9 +329,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "Run the SC deploy collateral suite: deploys contracts at a "
             "FRACTIONAL value (0.001) and asserts the deployer's balance falls "
             "by exactly that value, that only that value is held as Committed, "
-            "and that token_denom stays consistent with the real Free rows. "
-            "The main SC suite deploys at 1.0, where committing a whole token "
-            "is correct, so it cannot see this. Auto-enabled by --run-all-tests."
+            "and that token_denom stays consistent with the real Free rows at "
+            "that denomination. The main SC suite deploys at 1.0, where "
+            "committing a whole token is correct, so it cannot see this. Also "
+            "reports FT-caused denom drift separately (known-failing until the "
+            "FT paths decrement token_denom). Skips itself when earlier phases "
+            "have drained node A. Auto-enabled by --run-all-tests."
         ),
     )
     return p

--- a/test/integration/runner.py
+++ b/test/integration/runner.py
@@ -322,6 +322,18 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "Auto-enabled by --run-all-tests."
         ),
     )
+    p.add_argument(
+        "--sc-collateral-tests",
+        action="store_true",
+        help=(
+            "Run the SC deploy collateral suite: deploys contracts at a "
+            "FRACTIONAL value (0.001) and asserts the deployer's balance falls "
+            "by exactly that value, that only that value is held as Committed, "
+            "and that token_denom stays consistent with the real Free rows. "
+            "The main SC suite deploys at 1.0, where committing a whole token "
+            "is correct, so it cannot see this. Auto-enabled by --run-all-tests."
+        ),
+    )
     return p
 
 
@@ -364,6 +376,7 @@ def main() -> None:
         args.all_in_one_test = True
         args.intra_node_test = True
         args.negative_tests = True
+        args.sc_collateral_tests = True
         args.nft_only = False
         args.sc_only = False
         args.ft_only = False
@@ -521,6 +534,7 @@ def main() -> None:
             intra_node_ft_fund=args.intra_node_ft_fund,
             run_all_tests=args.run_all_tests,
             negative_tests=args.negative_tests,
+            sc_collateral_tests=args.sc_collateral_tests,
         )
     except Exception as exc:
         log.error("Integration run failed: %s", exc, exc_info=True)

--- a/test/integration/tests/happy_path.py
+++ b/test/integration/tests/happy_path.py
@@ -1073,7 +1073,13 @@ FROM tokens;
         """
         passed = sum(1 for r in results if r["status"] == "PASS")
         failed = sum(1 for r in results if r["status"] == "FAIL")
-        total = len(results)
+        # SKIP records a check that could not run because its preconditions were
+        # not met (e.g. an earlier phase drained the wallet it needed). It is
+        # neither a pass nor a failure, so it stays out of the ratio — but it is
+        # logged, because a check that silently stops running is worse than one
+        # that fails.
+        skipped = sum(1 for r in results if r["status"] == "SKIP")
+        total = len(results) - skipped
 
         # Record for the entry point so a failed check becomes a non-zero exit.
         self.verification_failed = failed
@@ -1083,6 +1089,7 @@ FROM tokens;
             "total_checks": total,
             "passed": passed,
             "failed": failed,
+            "skipped": skipped,
             "results": results,
         }
 
@@ -1099,6 +1106,11 @@ FROM tokens;
             for r in results:
                 if r["status"] == "FAIL":
                     log.warning("  FAIL: %s — %s", r["check"], r["detail"])
+        # Surface SKIPs too: a check that stopped running is easy to miss and
+        # looks identical to one that never existed.
+        for r in results:
+            if r["status"] == "SKIP":
+                log.warning("  SKIP: %s — %s", r["check"], r["detail"])
 
         log.info("Verification results written to %s", out_path)
 

--- a/test/integration/tests/happy_path.py
+++ b/test/integration/tests/happy_path.py
@@ -956,6 +956,23 @@ FROM tokens;
         )
         return engine.run()
 
+    def run_sc_collateral(self) -> List[Dict[str, str]]:
+        """Run the SC deploy collateral suite against node A.
+
+        Deploys at a fractional value, which the main SC suite never does, and
+        asserts the collateral is split rather than consumed whole.
+        """
+        from test.integration.tests.sc_collateral import SCCollateralEngine
+
+        log.info("=== SC COLLATERAL: running fractional-value deploy tests ===")
+        engine = SCCollateralEngine(
+            node_a=self.node_a,
+            did_a=self.did_a,
+            db_a=self.db_a,
+            password=self.cfg.password,
+        )
+        return engine.run()
+
     def run_db_snapshot(self) -> str:
         """Run diagnostic queries against all 3 DBs and write the results.
 
@@ -1132,6 +1149,7 @@ FROM tokens;
         intra_node_ft_fund: int = 2,
         run_all_tests: bool = False,
         negative_tests: bool = False,
+        sc_collateral_tests: bool = False,
     ) -> None:
         if skip_setup:
             self._load_state()
@@ -1431,6 +1449,13 @@ FROM tokens;
         if negative_tests:
             negative_verification = self.run_negative()
 
+        # SC deploy collateral. Deploys its own contracts at a fractional value
+        # and only reads balances back, so it neither depends on nor disturbs
+        # the happy-path state.
+        sc_collateral_verification: List[Dict[str, str]] = []
+        if sc_collateral_tests:
+            sc_collateral_verification = self.run_sc_collateral()
+
         # Deferred intra-node FT balance check — run at the very end so the
         # (slow) intra-node FT settlement to did_a2 has maximum elapsed time.
         deferred_verification: List[Dict[str, str]] = []
@@ -1459,6 +1484,7 @@ FROM tokens;
             + all_in_one_verification
             + intra_node_verification
             + negative_verification
+            + sc_collateral_verification
             + deferred_verification
             + extra_api_verification
             + tx_persist_verification

--- a/test/integration/tests/sc_collateral.py
+++ b/test/integration/tests/sc_collateral.py
@@ -51,7 +51,10 @@ they fold into verification.json and the runner's exit-on-fail gate.
 from __future__ import annotations
 
 import logging
+import os
+import tempfile
 import time
+import uuid
 from typing import Any, Dict, List
 
 from test.integration.clients.api_client import NodeClient
@@ -71,10 +74,10 @@ _EPSILON = 1e-9
 # Settle time after a consensus round before reading balances back.
 _SETTLE = 6
 
-# The suite makes 4 deploys, each splitting a whole token to take _SC_VALUE from
+# The suite makes 5 deploys, each splitting a whole token to take _SC_VALUE from
 # it. One whole RBT per deploy must be selectable at the moment of the split, so
-# require a small whole-token float rather than 4 * _SC_VALUE.
-_MIN_REQUIRED_BALANCE = 4.0
+# require a small whole-token float rather than 5 * _SC_VALUE.
+_MIN_REQUIRED_BALANCE = 5.0
 
 # token_status values (constants/constants.go): Free=0, Committed=5,
 # BurntForFT=9.
@@ -100,6 +103,10 @@ class SCCollateralEngine:
         self.did_a = did_a
         self.db_a = db_a
         self.password = password
+
+        # Token IDs deployed by this suite, so a collision (which would make a
+        # deploy a silent no-op) is caught rather than mis-measured.
+        self._deployed_sc_ids: set = set()
 
     # ---------------------------------------------------------------- helpers
 
@@ -149,6 +156,18 @@ class SCCollateralEngine:
             (self.did_a, _STATUS_COMMITTED, _TYPE_RBT),
         )
         return float(rows[0][0])
+
+    def _sc_token_value(self, sc_id: str) -> float:
+        """Stored token_value of a deployed smart contract token."""
+        rows = self._query(
+            """
+            SELECT t.token_value
+              FROM tokens t JOIN token_type tt ON tt.id = t.token_type
+             WHERE t.token_id = %s AND tt.name = %s
+            """,
+            (sc_id, "smart_contract"),
+        )
+        return float(rows[0][0]) if rows else -1.0
 
     def _denom_drift(self) -> List[tuple]:
         """Rows where token_denom disagrees with the real count of Free rows.
@@ -202,12 +221,44 @@ class SCCollateralEngine:
         return ", ".join(f"status={s} n={n}" for s, n in rows)
 
     def _deploy_fractional(self, label: str) -> Dict[str, Any]:
-        """Generate and deploy one contract at _SC_VALUE. Raises on failure."""
+        """Generate and deploy one contract at _SC_VALUE. Raises on failure.
+
+        The source file is made unique per deploy. A smart contract token ID is
+        the IPFS hash of its wasm+source folder (GenerateSmartContractToken ->
+        AddDir), so two deploys of identical files produce the SAME token ID and
+        the second is a no-op: it returns success but splits no RBT and commits
+        no collateral. select_smart_contract_files() picks at random from every
+        .wasm/.rs in the tree, so that collision happened intermittently and made
+        SCCOL_REPEATED_COST flaky — 3 deploys would charge for 2. Writing a
+        unique source per deploy guarantees a distinct token ID, so each deploy
+        is a real deploy and the cost assertion is meaningful.
+        """
         wasm_path, source_path = select_smart_contract_files()
-        result = self.node_a.create_smart_contract(self.did_a, wasm_path, source_path)
+
+        unique_source = os.path.join(
+            tempfile.mkdtemp(prefix="sccol-"), os.path.basename(source_path)
+        )
+        with open(source_path, "rb") as src:
+            original = src.read()
+        with open(unique_source, "wb") as dst:
+            dst.write(original)
+            dst.write(
+                f"\n// sc-collateral unique marker: {label} {uuid.uuid4()}\n".encode()
+            )
+
+        result = self.node_a.create_smart_contract(self.did_a, wasm_path, unique_source)
         sc_id = result.get("smartContractId")
         if not sc_id:
             raise RuntimeError(f"{label}: generate returned no smartContractId")
+
+        # A repeated token ID means the uniqueness guarantee above broke; the
+        # deploy would silently no-op and the cost assertions would be wrong.
+        if sc_id in self._deployed_sc_ids:
+            raise RuntimeError(
+                f"{label}: smart contract ID {sc_id} was already deployed in this "
+                "suite — the deploy would be a no-op and charge no collateral"
+            )
+        self._deployed_sc_ids.add(sc_id)
 
         req_id = self.node_a.initiate_smart_contract_transaction(
             initiator_did=self.did_a,
@@ -249,6 +300,7 @@ class SCCollateralEngine:
 
         for phase in (
             self._check_single_deploy_accounting,
+            self._check_deploy_value_matches_pledge,
             self._check_repeated_fractional_deploys,
         ):
             try:
@@ -407,6 +459,57 @@ class SCCollateralEngine:
                 + "; ".join(parts)
             ),
         }
+
+    def _check_deploy_value_matches_pledge(self) -> List[Dict[str, str]]:
+        """A deploy must be worth exactly the value requested for it.
+
+        transactionValue is what the initiator asks the quorum to pledge
+        (InitiateTransaction -> PledgeTokenRequest.TransactionValue), and it
+        comes from BuildTransactionInfoFromRequest. On the DEPLOY branch that is
+        scInfo.Value; on the EXECUTE branch it is the SC token's stored
+        TokenValue instead. So if a "deploy" is really a re-deploy of an
+        existing contract, the quorum is asked to pledge that contract's old
+        value rather than the value requested now — observed as a quorum
+        pledging 1 RBT for a 0.001 contract.
+
+        Asserting the deployed token's recorded value equals _SC_VALUE catches
+        that: a token carrying any other value was not deployed by this request.
+        """
+        out: List[Dict[str, str]] = []
+
+        deployed = self._deploy_fractional("pledge-value")
+        time.sleep(_SETTLE)
+
+        sc_id = deployed["sc_id"]
+        stored = self._sc_token_value(sc_id)
+
+        if stored < 0:
+            out.append({
+                "check": "SCCOL_DEPLOY_VALUE",
+                "status": "FAIL",
+                "detail": f"deployed SC {sc_id} has no smart_contract token row",
+            })
+        elif abs(stored - _SC_VALUE) < _EPSILON:
+            out.append({
+                "check": "SCCOL_DEPLOY_VALUE",
+                "status": "PASS",
+                "detail": (
+                    f"deployed SC token value is exactly {stored} — the quorum is "
+                    f"asked to pledge the requested {_SC_VALUE}, not a whole token"
+                ),
+            })
+        else:
+            out.append({
+                "check": "SCCOL_DEPLOY_VALUE",
+                "status": "FAIL",
+                "detail": (
+                    f"deployed SC {sc_id} carries value {stored}, expected {_SC_VALUE}; "
+                    "the quorum would be asked to pledge that value instead of the "
+                    "requested one (execute branch taken for what should be a deploy)"
+                ),
+            })
+
+        return out
 
     def _check_repeated_fractional_deploys(self) -> List[Dict[str, str]]:
         """Three fractional deploys back to back must all succeed.

--- a/test/integration/tests/sc_collateral.py
+++ b/test/integration/tests/sc_collateral.py
@@ -1,0 +1,331 @@
+"""
+sc_collateral.py — smart-contract deploy collateral accounting.
+
+Deploying a smart contract with a value locks RBT as collateral: the tokens
+backing that value are marked Committed (terminal) and the rest must come back
+to the deployer as change.
+
+The bug this guards against: LockTokensForSplit selects whole denominations, so
+backing a 0.001 commitment picks a whole 1.000 token. If that token is committed
+as-is, the other 0.999 is silently destroyed — a 0.001 contract costs a full RBT.
+
+SCCOL_DENOM_CONSISTENT covers a second, independent defect: post-consensus gates
+its token_denom update on Tokens.RBT being non-empty, but an SC deploy carries
+its collateral in CommittedTokens with Tokens.RBT empty, so the committed token
+is never decremented from the counter. The counter then over-reports free tokens
+and a later selection fails with "lockSelectedTokens: no tokens provided". That
+check is expected to FAIL until the denom guard is fixed separately.
+
+Why the existing smart_contract_engine suite cannot catch this: it deploys at
+sc_value=1.0, the single value where committing a whole 1.000 token is exactly
+correct, and it asserts only that deployment succeeded — never on balance. The
+defect is only visible when sc_value < denomination, so every case here uses a
+FRACTIONAL value.
+
+Cases:
+  - balance delta:  deployer's free balance drops by exactly sc_value
+  - committed sum:  Committed RBT totals sc_value, not a whole denomination
+  - denom drift:    token_denom agrees with the actual count of Free rows
+  - repeat deploys: three fractional deploys in a row all succeed (the failure
+                    mode that first exposed this — contracts 2 and 3 died once
+                    the stale counter over-reported availability)
+
+Results use the same {"check", "status", "detail"} shape as the other engines so
+they fold into verification.json and the runner's exit-on-fail gate.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, List
+
+from test.integration.clients.api_client import NodeClient
+from test.integration.engines.file_selector import select_smart_contract_files
+
+log = logging.getLogger(__name__)
+
+# Deliberately smaller than the 1.000 denomination the wallet holds, so the
+# deploy must split a whole token and return change. At 1.0 the split is a
+# no-op and the bug is invisible.
+_SC_VALUE = 0.001
+
+# Sum of token_value may carry float representation noise; compare with a
+# tolerance well below the smallest value under test.
+_EPSILON = 1e-9
+
+# Settle time after a consensus round before reading balances back.
+_SETTLE = 6
+
+# token_status values (constants/constants.go): Free=0, Committed=5.
+_STATUS_FREE = 0
+_STATUS_COMMITTED = 5
+
+# token_type ids are lowercase names in the token_type table.
+_TYPE_RBT = "rbt"
+
+
+class SCCollateralEngine:
+    """Asserts SC deploy collateral is split, not consumed whole."""
+
+    def __init__(
+        self,
+        node_a: NodeClient,
+        did_a: str,
+        db_a: Any,
+        password: str = "mypassword",
+    ) -> None:
+        self.node_a = node_a
+        self.did_a = did_a
+        self.db_a = db_a
+        self.password = password
+
+    # ---------------------------------------------------------------- helpers
+
+    def _query(self, sql: str, params: tuple = ()) -> List[tuple]:
+        """Run a read-only query against node A's DB.
+
+        Connects by literal IPv4 rather than reusing db_a._connect(): in native
+        mode Postgres binds 127.0.0.1 only, while "localhost" resolves to ::1
+        first on some hosts, which fails with a misleading 'database does not
+        exist'. Copying the params and pinning the host keeps this suite working
+        in both native and Docker modes.
+        """
+        import psycopg2
+
+        params_ipv4 = dict(self.db_a.conn_params)
+        if params_ipv4.get("host") == "localhost":
+            params_ipv4["host"] = "127.0.0.1"
+
+        with psycopg2.connect(**params_ipv4) as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            return cur.fetchall()
+
+    def _free_balance(self) -> float:
+        """Sum of Free RBT for the deployer, straight from the DB."""
+        rows = self._query(
+            """
+            SELECT COALESCE(SUM(token_value), 0)
+              FROM tokens
+             WHERE did = %s
+               AND token_status = %s
+               AND token_type = (SELECT id FROM token_type WHERE name = %s)
+            """,
+            (self.did_a, _STATUS_FREE, _TYPE_RBT),
+        )
+        return float(rows[0][0])
+
+    def _committed_sum(self) -> float:
+        """Sum of Committed RBT for the deployer — the SC collateral."""
+        rows = self._query(
+            """
+            SELECT COALESCE(SUM(token_value), 0)
+              FROM tokens
+             WHERE did = %s
+               AND token_status = %s
+               AND token_type = (SELECT id FROM token_type WHERE name = %s)
+            """,
+            (self.did_a, _STATUS_COMMITTED, _TYPE_RBT),
+        )
+        return float(rows[0][0])
+
+    def _denom_drift(self) -> List[tuple]:
+        """Rows where token_denom disagrees with the real count of Free rows.
+
+        Returns (denom, counter, actual, drift) for each mismatch; empty when
+        the counter is consistent.
+        """
+        return self._query(
+            """
+            SELECT d.denom,
+                   d.count,
+                   COALESCE(f.free_rows, 0),
+                   d.count - COALESCE(f.free_rows, 0) AS drift
+              FROM token_denom d
+              LEFT JOIN (
+                    SELECT did, token_value AS denom, COUNT(*) AS free_rows
+                      FROM tokens
+                     WHERE token_type = (SELECT id FROM token_type WHERE name = %s)
+                       AND token_status = %s
+                     GROUP BY did, token_value
+              ) f ON f.did = d.did AND f.denom = d.denom
+             WHERE d.did = %s
+               AND d.count - COALESCE(f.free_rows, 0) <> 0
+            """,
+            (_TYPE_RBT, _STATUS_FREE, self.did_a),
+        )
+
+    def _deploy_fractional(self, label: str) -> Dict[str, Any]:
+        """Generate and deploy one contract at _SC_VALUE. Raises on failure."""
+        wasm_path, source_path = select_smart_contract_files()
+        result = self.node_a.create_smart_contract(self.did_a, wasm_path, source_path)
+        sc_id = result.get("smartContractId")
+        if not sc_id:
+            raise RuntimeError(f"{label}: generate returned no smartContractId")
+
+        req_id = self.node_a.initiate_smart_contract_transaction(
+            initiator_did=self.did_a,
+            sc_id=sc_id,
+            sc_value=_SC_VALUE,
+            data="collateral-test",
+        )
+        response = self.node_a.complete_transaction(req_id, self.password)
+        return {"sc_id": sc_id, "response": response}
+
+    # ------------------------------------------------------------------- run
+
+    def run(self) -> List[Dict[str, str]]:
+        """Run every collateral check. Never raises — failures become results."""
+        results: List[Dict[str, str]] = []
+
+        for phase in (
+            self._check_single_deploy_accounting,
+            self._check_repeated_fractional_deploys,
+        ):
+            try:
+                results.extend(phase())
+            except Exception as exc:  # noqa: BLE001 - report, never abort the suite
+                log.error("SC collateral phase %s failed: %s", phase.__name__, exc)
+                results.append({
+                    "check": f"SCCOL_{phase.__name__.strip('_').upper()}",
+                    "status": "FAIL",
+                    "detail": f"phase raised: {exc}",
+                })
+
+        return results
+
+    # ---------------------------------------------------------------- phases
+
+    def _check_single_deploy_accounting(self) -> List[Dict[str, str]]:
+        """One fractional deploy: balance delta, committed sum, denom drift."""
+        out: List[Dict[str, str]] = []
+
+        balance_before = self._free_balance()
+        committed_before = self._committed_sum()
+        log.info(
+            "=== SC COLLATERAL: deploying at value=%s (free=%s committed=%s) ===",
+            _SC_VALUE, balance_before, committed_before,
+        )
+
+        self._deploy_fractional("single")
+        time.sleep(_SETTLE)
+
+        balance_after = self._free_balance()
+        committed_after = self._committed_sum()
+
+        # 1. The deployer loses exactly the contract's value — not a whole token.
+        spent = balance_before - balance_after
+        if abs(spent - _SC_VALUE) < _EPSILON:
+            out.append({
+                "check": "SCCOL_BALANCE_DELTA",
+                "status": "PASS",
+                "detail": f"free balance fell by exactly {spent} (value {_SC_VALUE})",
+            })
+        else:
+            out.append({
+                "check": "SCCOL_BALANCE_DELTA",
+                "status": "FAIL",
+                "detail": (
+                    f"free balance fell by {spent}, expected {_SC_VALUE} "
+                    f"({balance_before} -> {balance_after}); "
+                    "collateral was committed without splitting, so the change was lost"
+                ),
+            })
+
+        # 2. Only the contract's value is held as collateral.
+        newly_committed = committed_after - committed_before
+        if abs(newly_committed - _SC_VALUE) < _EPSILON:
+            out.append({
+                "check": "SCCOL_COMMITTED_SUM",
+                "status": "PASS",
+                "detail": f"committed RBT rose by exactly {newly_committed}",
+            })
+        else:
+            out.append({
+                "check": "SCCOL_COMMITTED_SUM",
+                "status": "FAIL",
+                "detail": (
+                    f"committed RBT rose by {newly_committed}, expected {_SC_VALUE}; "
+                    "a whole denomination was committed to back a fractional value"
+                ),
+            })
+
+        # 3. token_denom must still agree with reality. Drift here is what
+        #    later causes a spurious "no tokens provided" on the next deploy.
+        drift = self._denom_drift()
+        if not drift:
+            out.append({
+                "check": "SCCOL_DENOM_CONSISTENT",
+                "status": "PASS",
+                "detail": "token_denom matches the actual count of Free rows",
+            })
+        else:
+            detail = "; ".join(
+                f"denom={d} counter={c} actual={a} drift={dr}" for d, c, a, dr in drift
+            )
+            out.append({
+                "check": "SCCOL_DENOM_CONSISTENT",
+                "status": "FAIL",
+                "detail": f"token_denom drifted from actual Free rows: {detail}",
+            })
+
+        return out
+
+    def _check_repeated_fractional_deploys(self) -> List[Dict[str, str]]:
+        """Three fractional deploys back to back must all succeed.
+
+        This is the shape of the original failure: the first deploy consumed a
+        whole token, the denom counter kept advertising it, and deploys 2 and 3
+        died with "lockSelectedTokens: no tokens provided".
+        """
+        out: List[Dict[str, str]] = []
+        rounds = 3
+
+        balance_before = self._free_balance()
+        failures: List[str] = []
+
+        for i in range(1, rounds + 1):
+            try:
+                self._deploy_fractional(f"repeat-{i}")
+                log.info("SC collateral: repeat deploy %d/%d succeeded", i, rounds)
+            except Exception as exc:  # noqa: BLE001 - collected, reported below
+                failures.append(f"deploy {i}: {exc}")
+                log.error("SC collateral: repeat deploy %d/%d failed: %s", i, rounds, exc)
+            time.sleep(_SETTLE)
+
+        if failures:
+            out.append({
+                "check": "SCCOL_REPEATED_DEPLOYS",
+                "status": "FAIL",
+                "detail": f"{len(failures)}/{rounds} fractional deploys failed: " + "; ".join(failures),
+            })
+        else:
+            out.append({
+                "check": "SCCOL_REPEATED_DEPLOYS",
+                "status": "PASS",
+                "detail": f"all {rounds} consecutive fractional deploys succeeded",
+            })
+
+        # Whatever landed, the cost must be value-proportional, never one whole
+        # token per contract.
+        balance_after = self._free_balance()
+        spent = balance_before - balance_after
+        expected = _SC_VALUE * (rounds - len(failures))
+
+        if abs(spent - expected) < _EPSILON:
+            out.append({
+                "check": "SCCOL_REPEATED_COST",
+                "status": "PASS",
+                "detail": f"{rounds - len(failures)} deploys cost exactly {spent}",
+            })
+        else:
+            out.append({
+                "check": "SCCOL_REPEATED_COST",
+                "status": "FAIL",
+                "detail": (
+                    f"{rounds - len(failures)} deploys cost {spent}, expected {expected} "
+                    f"({balance_before} -> {balance_after})"
+                ),
+            })
+
+        return out

--- a/test/integration/tests/sc_collateral.py
+++ b/test/integration/tests/sc_collateral.py
@@ -74,10 +74,11 @@ _EPSILON = 1e-9
 # Settle time after a consensus round before reading balances back.
 _SETTLE = 6
 
-# The suite makes 5 deploys, each splitting a whole token to take _SC_VALUE from
-# it. One whole RBT per deploy must be selectable at the moment of the split, so
-# require a small whole-token float rather than 5 * _SC_VALUE.
-_MIN_REQUIRED_BALANCE = 5.0
+# The suite makes 6 deploys (one of which is also executed), each splitting a
+# whole token to take _SC_VALUE from it. One whole RBT per deploy must be
+# selectable at the moment of the split, so require a small whole-token float
+# rather than 6 * _SC_VALUE.
+_MIN_REQUIRED_BALANCE = 7.0
 
 # token_status values (constants/constants.go): Free=0, Committed=5,
 # BurntForFT=9.
@@ -301,6 +302,7 @@ class SCCollateralEngine:
         for phase in (
             self._check_single_deploy_accounting,
             self._check_deploy_value_matches_pledge,
+            self._check_execute_cost_matches_value,
             self._check_repeated_fractional_deploys,
         ):
             try:
@@ -506,6 +508,77 @@ class SCCollateralEngine:
                     f"deployed SC {sc_id} carries value {stored}, expected {_SC_VALUE}; "
                     "the quorum would be asked to pledge that value instead of the "
                     "requested one (execute branch taken for what should be a deploy)"
+                ),
+            })
+
+        return out
+
+    def _check_execute_cost_matches_value(self) -> List[Dict[str, str]]:
+        """Executing a 0.001 contract must pledge 0.001, not a whole token.
+
+        On the EXECUTE branch BuildTransactionInfoFromRequest sets
+        transactionValue from the SC token's stored TokenValue, and that value
+        is what the quorum is asked to pledge. The stored value is written at
+        deploy time from scInfo.Value, so the execute pledge inherits whatever
+        the deploy recorded: deploy at 0.001 and every later execution pledges
+        0.001; deploy at 1.0 and every execution pledges a whole RBT forever.
+
+        Execution commits no new RBT — the collateral pre-pass skips tokens that
+        already exist — so there is no balance delta to measure. What matters is
+        that the token still carries its deployed value after executing, since
+        that is the number the pledge is derived from.
+        """
+        out: List[Dict[str, str]] = []
+
+        deployed = self._deploy_fractional("execute-value")
+        sc_id = deployed["sc_id"]
+        time.sleep(_SETTLE)
+
+        value_before = self._sc_token_value(sc_id)
+
+        try:
+            self.node_a.execute_smart_contract(
+                executor_did=self.did_a,
+                sc_id=sc_id,
+                data="collateral-execute",
+                password=self.password,
+            )
+        except Exception as exc:  # noqa: BLE001 - reported as a result
+            out.append({
+                "check": "SCCOL_EXECUTE_VALUE",
+                "status": "FAIL",
+                "detail": f"execute of {sc_id} (value {value_before}) failed: {exc}",
+            })
+            return out
+
+        time.sleep(_SETTLE)
+        value_after = self._sc_token_value(sc_id)
+
+        if abs(value_before - _SC_VALUE) >= _EPSILON:
+            out.append({
+                "check": "SCCOL_EXECUTE_VALUE",
+                "status": "FAIL",
+                "detail": (
+                    f"SC {sc_id} was deployed at {value_before}, expected {_SC_VALUE}; "
+                    "every execution would pledge that value"
+                ),
+            })
+        elif abs(value_after - _SC_VALUE) < _EPSILON:
+            out.append({
+                "check": "SCCOL_EXECUTE_VALUE",
+                "status": "PASS",
+                "detail": (
+                    f"SC token still carries {value_after} after execution, so the "
+                    f"quorum is asked to pledge {_SC_VALUE} — not a whole token"
+                ),
+            })
+        else:
+            out.append({
+                "check": "SCCOL_EXECUTE_VALUE",
+                "status": "FAIL",
+                "detail": (
+                    f"SC {sc_id} value changed from {value_before} to {value_after} "
+                    "on execution; the execute pledge is derived from this value"
                 ),
             })
 

--- a/test/integration/tests/sc_collateral.py
+++ b/test/integration/tests/sc_collateral.py
@@ -9,12 +9,23 @@ The bug this guards against: LockTokensForSplit selects whole denominations, so
 backing a 0.001 commitment picks a whole 1.000 token. If that token is committed
 as-is, the other 0.999 is silently destroyed — a 0.001 contract costs a full RBT.
 
-SCCOL_DENOM_CONSISTENT covers a second, independent defect: post-consensus gates
-its token_denom update on Tokens.RBT being non-empty, but an SC deploy carries
-its collateral in CommittedTokens with Tokens.RBT empty, so the committed token
-is never decremented from the counter. The counter then over-reports free tokens
-and a later selection fails with "lockSelectedTokens: no tokens provided". That
-check is expected to FAIL until the denom guard is fixed separately.
+SCCOL_DENOM_CONSISTENT covers a second, independent defect on the same flow:
+post-consensus skipped its token_denom update for an SC deploy (the collateral
+rides in CommittedTokens with Tokens.RBT empty), and when it did run, the
+isLocalTransfer credit landed back on the initiator — a deploy pins Owner to
+Initiator — cancelling the decrement. Either way the counter kept advertising
+committed tokens as spendable until a later selection failed with
+"lockSelectedTokens: no tokens provided".
+
+This is the first token_denom invariant anywhere in the repo: the table is
+written by six code paths and, before this suite, was never once checked against
+reality. That is why it has been repaired repeatedly and drifted again. Running
+it immediately surfaced two further FT-side defects, reported separately by
+SCCOL_FT_DENOM_DRIFT with their attributed cause. That check FAILS: the drift is
+a real accounting defect (the counter advertises tokens that cannot be selected)
+and stays red until the FT paths decrement token_denom the way the RBT and SC
+paths do. It is kept separate from SCCOL_DENOM_CONSISTENT so an SC regression is
+never mistaken for the known FT one.
 
 Why the existing smart_contract_engine suite cannot catch this: it deploys at
 sc_value=1.0, the single value where committing a whole 1.000 token is exactly
@@ -25,7 +36,10 @@ FRACTIONAL value.
 Cases:
   - balance delta:  deployer's free balance drops by exactly sc_value
   - committed sum:  Committed RBT totals sc_value, not a whole denomination
-  - denom drift:    token_denom agrees with the actual count of Free rows
+  - denom drift:    token_denom agrees with the real Free rows at the SC
+                    collateral denomination
+  - FT denom drift: drift at other denominations, reported separately with its
+                    cause attributed (known-failing: FT paths do not decrement)
   - repeat deploys: three fractional deploys in a row all succeed (the failure
                     mode that first exposed this — contracts 2 and 3 died once
                     the stale counter over-reported availability)
@@ -57,9 +71,16 @@ _EPSILON = 1e-9
 # Settle time after a consensus round before reading balances back.
 _SETTLE = 6
 
-# token_status values (constants/constants.go): Free=0, Committed=5.
+# The suite makes 4 deploys, each splitting a whole token to take _SC_VALUE from
+# it. One whole RBT per deploy must be selectable at the moment of the split, so
+# require a small whole-token float rather than 4 * _SC_VALUE.
+_MIN_REQUIRED_BALANCE = 4.0
+
+# token_status values (constants/constants.go): Free=0, Committed=5,
+# BurntForFT=9.
 _STATUS_FREE = 0
 _STATUS_COMMITTED = 5
+_STATUS_BURNT_FOR_FT = 9
 
 # token_type ids are lowercase names in the token_type table.
 _TYPE_RBT = "rbt"
@@ -133,7 +154,9 @@ class SCCollateralEngine:
         """Rows where token_denom disagrees with the real count of Free rows.
 
         Returns (denom, counter, actual, drift) for each mismatch; empty when
-        the counter is consistent.
+        the counter is consistent. Scoped to self.did_a: node A also hosts the
+        intra-node secondary DID (did_a2), and mixing the two makes the numbers
+        impossible to read.
         """
         return self._query(
             """
@@ -154,6 +177,29 @@ class SCCollateralEngine:
             """,
             (_TYPE_RBT, _STATUS_FREE, self.did_a),
         )
+
+    def _status_breakdown(self, denom: float) -> str:
+        """Where this denomination's non-Free tokens went, as 'status=N count'.
+
+        A drift means the counter still claims tokens that have left Free, so
+        the statuses they moved to name the path that failed to decrement.
+        """
+        rows = self._query(
+            """
+            SELECT token_status, COUNT(*)
+              FROM tokens
+             WHERE did = %s
+               AND token_value = %s
+               AND token_type = (SELECT id FROM token_type WHERE name = %s)
+               AND token_status <> %s
+             GROUP BY token_status
+             ORDER BY token_status
+            """,
+            (self.did_a, denom, _TYPE_RBT, _STATUS_FREE),
+        )
+        if not rows:
+            return "no non-Free rows"
+        return ", ".join(f"status={s} n={n}" for s, n in rows)
 
     def _deploy_fractional(self, label: str) -> Dict[str, Any]:
         """Generate and deploy one contract at _SC_VALUE. Raises on failure."""
@@ -177,6 +223,29 @@ class SCCollateralEngine:
     def run(self) -> List[Dict[str, str]]:
         """Run every collateral check. Never raises — failures become results."""
         results: List[Dict[str, str]] = []
+
+        # Inside --run-all-tests this suite runs late, after the shuttle and the
+        # asset phases have spent from the same wallet. With no funds left every
+        # deploy fails on "no tokens provided" — the very error this suite exists
+        # to detect — for a reason that has nothing to do with the code under
+        # test. Distinguish the two up front: an unfunded wallet is a harness
+        # budgeting problem (SKIP), not an SC accounting defect (FAIL).
+        balance = self._free_balance()
+        if balance < _MIN_REQUIRED_BALANCE:
+            log.warning(
+                "SC collateral: skipping — node A holds %s RBT, need >= %s",
+                balance, _MIN_REQUIRED_BALANCE,
+            )
+            return [{
+                "check": "SCCOL_PRECONDITION",
+                "status": "SKIP",
+                "detail": (
+                    f"node A holds {balance} free RBT for did={self.did_a}, "
+                    f"below the {_MIN_REQUIRED_BALANCE} this suite needs. Earlier "
+                    "phases drained the wallet; raise min_balance_buffer in the "
+                    "config rather than reading this as an SC failure."
+                ),
+            }]
 
         for phase in (
             self._check_single_deploy_accounting,
@@ -250,26 +319,94 @@ class SCCollateralEngine:
                 ),
             })
 
-        # 3. token_denom must still agree with reality. Drift here is what
-        #    later causes a spurious "no tokens provided" on the next deploy.
+        # 3. token_denom must still agree with reality for the denomination this
+        #    suite spends. Drift here is what later causes a spurious
+        #    "no tokens provided" on the next deploy.
+        #
+        #    Drift at OTHER denominations is reported separately rather than
+        #    failing this check: it comes from known FT-side defects that this
+        #    suite does not exercise and must not be blamed for. Failing on it
+        #    would leave the check permanently red and teach people to ignore it.
         drift = self._denom_drift()
-        if not drift:
+        sc_drift = [row for row in drift if abs(float(row[0]) - _SC_VALUE) < _EPSILON]
+        other_drift = [row for row in drift if row not in sc_drift]
+
+        if not sc_drift:
             out.append({
                 "check": "SCCOL_DENOM_CONSISTENT",
                 "status": "PASS",
-                "detail": "token_denom matches the actual count of Free rows",
+                "detail": (
+                    f"token_denom matches the actual count of Free rows at "
+                    f"denom={_SC_VALUE} (the denomination this suite spends)"
+                ),
             })
         else:
             detail = "; ".join(
-                f"denom={d} counter={c} actual={a} drift={dr}" for d, c, a, dr in drift
+                f"denom={d} counter={c} actual={a} drift={dr} [{self._status_breakdown(d)}]"
+                for d, c, a, dr in sc_drift
             )
             out.append({
                 "check": "SCCOL_DENOM_CONSISTENT",
                 "status": "FAIL",
-                "detail": f"token_denom drifted from actual Free rows: {detail}",
+                "detail": (
+                    f"token_denom drifted at the SC collateral denomination for "
+                    f"did={self.did_a}: {detail}"
+                ),
             })
 
+        out.append(self._report_ft_denom_drift(other_drift))
+
         return out
+
+    def _report_ft_denom_drift(self, other_drift: List[tuple]) -> Dict[str, str]:
+        """Report denom drift this suite did not cause, attributing each cause.
+
+        token_denom has never had an invariant check before this suite, and the
+        run surfaces two long-standing FT-side defects:
+
+          - FT minting flips whole RBT parents to BurntForFT
+            (core/wallet/token_chain.go, FTGenesisTxn -> UpdateTokenInfo) without
+            decrementing token_denom, so the counter keeps advertising burnt
+            tokens as spendable.
+          - PersistGenesisTokenRecord upserts token_denom keyed on
+            token.TokenValue, and an FT token carries value 0, creating a phantom
+            denom=0 row counting tokens that can never be selected.
+
+        This FAILS, deliberately. The drift is a real accounting defect: the
+        counter advertises tokens that cannot be selected, which is what produced
+        "lockSelectedTokens: no tokens provided" on the SC side. Recording it as
+        advisory would let it sit indefinitely. It stays red until the FT paths
+        decrement token_denom the way the RBT and SC paths now do.
+        """
+        if not other_drift:
+            return {
+                "check": "SCCOL_FT_DENOM_DRIFT",
+                "status": "PASS",
+                "detail": "no denom drift outside the SC collateral denomination",
+            }
+
+        parts: List[str] = []
+        for denom, counter, actual, drift in other_drift:
+            breakdown = self._status_breakdown(denom)
+            if abs(float(denom)) < _EPSILON:
+                cause = "phantom denom=0 row from FT genesis (FT tokens carry value 0)"
+            elif f"status={_STATUS_BURNT_FOR_FT}" in breakdown:
+                cause = "RBT burnt for FT minting, never decremented"
+            else:
+                cause = "unattributed — investigate"
+            parts.append(
+                f"denom={denom} counter={counter} actual={actual} drift={drift} "
+                f"[{breakdown}] -> {cause}"
+            )
+
+        return {
+            "check": "SCCOL_FT_DENOM_DRIFT",
+            "status": "FAIL",
+            "detail": (
+                f"denom drift not caused by SC deploys, did={self.did_a}: "
+                + "; ".join(parts)
+            ),
+        }
 
     def _check_repeated_fractional_deploys(self) -> List[Dict[str, str]]:
         """Three fractional deploys back to back must all succeed.


### PR DESCRIPTION
 Problem

  Deploying a smart contract with value: 0.001 consumed a whole 1.000 RBT token. Deploying three contracts at 0.001 each cost 3 RBT instead of 0.003 — the remaining 0.999 of each token was silently
  destroyed.

  Found on a 10-node deployment where the first contract per node succeeded and contracts 2 and 3 failed with:

  BuildTransactionInfoFromRequest: failed to lock RBT for SC committed tokens:
  lockSelectedTokens: no tokens provided

  Root causes
  
  Three distinct defects on the same flow:                                                                                                                                                                

  1. No split on the collateral path. LockTokensForSplit selects whole denominations — covering 0.001 picks a whole 1.000 token. The RBT transfer path splits that token and returns change via
     CollectRBTTokens → PersistGenesisTransaction; the SC deploy path committed it as-is. The change was never minted.
  2. token_denom never decremented for a deploy. Post-consensus gated its counter update on Tokens.RBT being non-empty, but an SC deploy carries collateral in CommittedTokens with Tokens.RBT empty. The
     counter kept advertising committed tokens as spendable, which is what produced the no tokens provided failures on subsequent deploys.
  3. isLocalTransfer cancelled the decrement. Even once the update ran, that block credited the tokens back. It exists for same-node RBT transfers (decrement sender, credit receiver), but a deploy pins Owner
     to Initiator, so the credit landed on the DID just decremented. Net zero.

Why existing tests could not catch this
  
  smart_contract_engine.py deploys at sc_value=1.0 — the one value where committing a whole 1.000 token is correct — and asserts only that deployment succeeded, never on balance. It also could not catch a
  regression in this fix, since at 1.0 the split is a no-op.

  This is also the first token_denom assertion anywhere in the repo. Six code paths write that table; nothing had ever checked it. That is consistent with it having been repaired four times (ac34d44e,
  04dd4bb8, 5f72d84f, 6055a1e2) and drifting again each time.

  Known failure: SCCOL_FT_DENOM_DRIFT — CI will be red

  Running the new invariant immediately surfaced two pre-existing FT-side defects, unrelated to smart contracts and not fixed here:

  - Phantom denom=0 rows — PersistGenesisTokenRecord upserts token_denom keyed on token.TokenValue, and FT tokens carry value 0.
  - RBT burnt for FT never decremented — FTGenesisTxn → UpdateTokenInfo flips whole parents to BurntForFT with no counter update.
  
  Reported as a failure by design — the drift is a real accounting defect (the counter advertises unselectable tokens) and stays red until the FT paths are fixed. It is kept separate from
  SCCOL_DENOM_CONSISTENT so an SC regression is never mistaken for the known FT one.

  This means CI will fail on this check. If branch protection requires green, either fix the FT paths in a follow-up or record the expected failure on the PR.