### PR TITLE
Fix Denom Array Updation while Creating FTs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -9,7 +9,7 @@ mac/
 linux/
 windows/
 logs/
-docker/data/
+test/docker/data/
 
 # ---- Prebuilt binaries committed at repo root (rebuilt inside the image) ----
 /ipfs

--- a/.github/workflows/docker-integration.yml
+++ b/.github/workflows/docker-integration.yml
@@ -3,7 +3,8 @@ name: Docker Integration Tests
 # Behavioral end-to-end suite: spins up the 3-node Postgres-backed cluster via
 # Docker Compose and drives it through the HTTP API across every subsystem
 # (RBT, FT, NFT, smart contracts, bundled, all-in-one, intra-node) plus the
-# negative / failure-path checks. Localnet only.
+# negative / failure-path checks and the accounting suites (SC deploy
+# collateral, FT-from-parts). Localnet only.
 #
 # Docker-on-Linux only by design: GitHub's Windows/macOS runners can't run the
 # Linux node containers, and PostgreSQL is mandatory for the node — so this
@@ -75,6 +76,73 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: integration-logs
+          path: |
+            test/docker/data/stress/logs/**
+          if-no-files-found: warn
+
+      - name: Tear down stack
+        if: always()
+        run: docker compose -f test/docker/docker-compose.stress.yml -p rubix-stress down -v
+
+  # ------------------------------------------------------------------------ #
+  # FT minted out of PART RBTs, on a wallet that holds nothing else.
+  #
+  # Runs as its own job rather than only inside the matrix above because the
+  # suite needs funds: it creates a DID of its own and pays sub-1.0 tranches
+  # into it, and under --run-all-tests it runs last, after every other phase
+  # has spent from node A. If the wallet is short it SKIPs — green, and the
+  # regression it guards goes unnoticed. On a fresh stack of its own, with the
+  # shuttle and every other subsystem off, it always has the balance to run.
+  #
+  # What it guards: minting an FT burns whole RBT, and the parents burnt may be
+  # part tokens. FTGenesisTxn -> UpdateTokenInfo must DECREMENT token_denom for
+  # each burnt part (it used to increment, keyed on an uncopied TokenValue, so
+  # it both added a phantom denom=0 row and missed the real denomination).
+  # token_denom is what lockTokensForSplitOnce selects denominations from, so a
+  # counter that over-reports makes a later spend fail with "no tokens
+  # provided" — attributed to whatever ran next, not to the mint that broke it.
+  # The main FT suite mints from did_a, whose whole 1.000 tokens are picked
+  # first, so it never burns parts and cannot see any of this.
+  ft-parts:
+    name: FT from part RBTs
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install test dependencies
+        run: pip install -r test/integration/requirements.txt
+
+      - name: Build node image
+        run: docker compose -f test/docker/docker-compose.stress.yml -p rubix-stress build nodeA
+
+      - name: Run FT-from-parts suite
+        # --ft-parts-only skips the shuttle and every other subsystem, so the
+        # freshly minted node A wallet is spent only by this suite.
+        run: python3 -m test.integration.runner --small-test --ft-parts-only
+
+      - name: Dump container diagnostics on failure
+        if: failure()
+        run: |
+          mkdir -p test/docker/data/stress/logs
+          echo "=== docker compose ps ===" | tee test/docker/data/stress/logs/_ci_diagnostics.txt
+          docker compose -f test/docker/docker-compose.stress.yml -p rubix-stress ps -a 2>&1 | tee -a test/docker/data/stress/logs/_ci_diagnostics.txt || true
+          echo "=== docker compose logs ===" | tee -a test/docker/data/stress/logs/_ci_diagnostics.txt
+          docker compose -f test/docker/docker-compose.stress.yml -p rubix-stress logs --no-color --tail=400 2>&1 | tee -a test/docker/data/stress/logs/_ci_diagnostics.txt || true
+
+      - name: Upload run artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ft-parts-logs
           path: |
             test/docker/data/stress/logs/**
           if-no-files-found: warn

--- a/.github/workflows/native-integration.yml
+++ b/.github/workflows/native-integration.yml
@@ -6,6 +6,11 @@ name: Native Integration Tests
 # the same suite passes on macOS and Windows, where GitHub-hosted runners can't
 # run the Linux node containers.
 #
+# --run-all-tests covers every subsystem plus the negative and accounting
+# suites (SC deploy collateral, FT-from-parts). The FT-from-parts suite skips
+# itself if the earlier phases have drained node A; docker-integration.yml runs
+# it standalone in a job of its own so it is always exercised somewhere.
+#
 # Each OS: install Postgres, build the node binary natively (CGO), then run the
 # --native runner against config.native.json (node_index-derived ports).
 

--- a/core/transaction_builder.go
+++ b/core/transaction_builder.go
@@ -167,6 +167,102 @@ func BuildTransactionInfoFromRequest(
 		log.Info("BuildTransactionInfoFromRequest: RBT tokens collected", "tokenCount", len(rbtTokens), "amount", req.GetRBTAmount())
 	}
 
+	// --- SC deploy collateral: split before the non-RBT transaction opens ---
+	//
+	// LockTokensForSplit selects whole denominations, so backing a 0.001
+	// commitment picks a whole 1.000 token. Committing that token as-is sinks
+	// the other 0.999 — a 0.001 contract costs a full RBT. So split first and
+	// keep the change, exactly as the RBT transfer path does.
+	//
+	// This runs BEFORE the non-RBT tx begins: PersistGenesisTransaction opens
+	// its own connection and upserts the burnt parent row, which would deadlock
+	// against locks held by that outer transaction until lock_timeout fires.
+	//
+	// scCommittedTokens maps a smart contract ID to the tokens backing it.
+	scCommittedTokens := make(map[string][]*models.TokenInfo)
+	if req.HasSmartContract() {
+		for _, scInfo := range req.GetAllSmartContracts() {
+			if scInfo.Value <= 0 {
+				continue
+			}
+			// Execute-mode SCs reuse their existing value and need no collateral.
+			exists, err := w.TokenExists(ctx, nil, scInfo.SmartContractId)
+			if err != nil {
+				return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest: failed to check SC existence: %w", err)
+			}
+			if exists {
+				continue
+			}
+
+			log.Info("BuildTransactionInfoFromRequest: Locking RBT tokens for SC committed value", "scID", scInfo.SmartContractId, "value", scInfo.Value)
+			ownedRBTTokens, err := w.LockTokensForSplit(ctx, req.Initiator, scInfo.Value, referenceID)
+			if err != nil {
+				log.Error("BuildTransactionInfoFromRequest: Failed to lock RBT for SC committed tokens", "err", err, "scID", scInfo.SmartContractId, "value", scInfo.Value)
+				return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest: failed to lock RBT for SC committed tokens: %w", err)
+			}
+			log.Info("BuildTransactionInfoFromRequest: RBT tokens locked for SC commitment", "scID", scInfo.SmartContractId, "tokenCount", len(ownedRBTTokens))
+
+			denomMap, err := w.GetTokenDenomArray(req.Initiator)
+			if err != nil {
+				log.Error("BuildTransactionInfoFromRequest: Failed to get denom array for SC commitment", "err", err, "did", req.Initiator)
+				return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest: get denom array for SC commitment: %w", err)
+			}
+
+			committedRBTTokens, childTokensKept, burntParentToken, mintTokensBeingBurnt, err := parts.CollectRBTTokens(
+				dc, w, scInfo.Value, ownedRBTTokens, denomMap, networkMode, log,
+			)
+			if err != nil {
+				log.Error("BuildTransactionInfoFromRequest: RBT collection failed for SC commitment", "err", err, "scID", scInfo.SmartContractId, "value", scInfo.Value)
+				return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest: RBT collection failed for SC commitment: %w", err)
+			}
+
+			// A split happened: persist the minted change and the burnt parent.
+			var scGenTX *models.Transactions
+			if len(childTokensKept) > 0 && len(burntParentToken) > 0 {
+				scGenTX = childTokensKept[0].TxRecord
+				if scGenTX == nil {
+					return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest(SC): generated transaction record is nil")
+				}
+
+				if errPersist := w.PersistGenesisTransaction(&wallet.PersistGenesisTransactionReq{
+					DID:                  req.Initiator,
+					GenesisTokens:        childTokensKept,
+					BurnTokens:           burntParentToken,
+					GenesisTransaction:   scGenTX,
+					MintTokensBeingBurnt: mintTokensBeingBurnt,
+				}); errPersist != nil {
+					return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest(SC): failed to persist genesis transaction, err: %v", errPersist)
+				}
+
+				var genTxInfo models.TransactionInfo
+				if err := json.Unmarshal(scGenTX.Info, &genTxInfo); err != nil {
+					return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest(SC): failed to unmarshal transaction info, err: %v", err)
+				}
+
+				var genTxSignature models.Signature
+				if err := json.Unmarshal(scGenTX.Signature, &genTxSignature); err != nil {
+					return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest(SC): failed to unmarshal signature, err: %v", err)
+				}
+
+				if networkMode != constants.NetworkMode_Localnet {
+					if _, err := util.PublishTransaction(pubsub, &genTxInfo, &genTxSignature, true, ""); err != nil {
+						log.Error("BuildTransactionInfoFromRequest(SC): failed to publish transaction, err: %v", err)
+					}
+				}
+			}
+
+			// Split-derived tokens have no previous transaction yet — their
+			// genesis is the split just persisted.
+			for _, token := range committedRBTTokens {
+				if token.PreviousTransactionID == "" && scGenTX != nil {
+					token.PreviousTransactionID = scGenTX.ID
+				}
+			}
+			scCommittedTokens[scInfo.SmartContractId] = committedRBTTokens
+			log.Debug("BuildTransactionInfoFromRequest: SC collateral split", "scID", scInfo.SmartContractId, "committedCount", len(committedRBTTokens))
+		}
+	}
+
 	// --- FT/NFT/SC: single DB transaction for all non-RBT assets ---
 	hasNonRBT := req.HasFT() || req.HasNFT() || req.HasSmartContract()
 	if hasNonRBT {
@@ -330,28 +426,16 @@ func BuildTransactionInfoFromRequest(
 				} else {
 					// DEPLOYMENT MODE: Token doesn't exist, prepare for deployment
 					log.Info("BuildTransactionInfoFromRequest: SC does not exist - DEPLOYMENT MODE", "scID", scInfo.SmartContractId, "value", scInfo.Value)
-					// Collect committed tokens if SC has value > 0
-					if scInfo.Value > 0 {
-						log.Info("BuildTransactionInfoFromRequest: Locking RBT tokens for SC committed value", "scID", scInfo.SmartContractId, "value", scInfo.Value)
-						// Lock RBT tokens for the smart contract value
-						ownedRBTTokens, err := w.LockTokensForSplit(ctx, req.Initiator, scInfo.Value, referenceID)
-						if err != nil {
-							log.Error("BuildTransactionInfoFromRequest: Failed to lock RBT for SC committed tokens", "err", err, "scID", scInfo.SmartContractId, "value", scInfo.Value)
-							return nil, 0, fmt.Errorf("BuildTransactionInfoFromRequest: failed to lock RBT for SC committed tokens: %w", err)
-						}
-						log.Info("BuildTransactionInfoFromRequest: RBT tokens locked for SC commitment", "scID", scInfo.SmartContractId, "tokenCount", len(ownedRBTTokens))
-
-						// Convert to TokenInfo format for CommittedTokens and add to locked list
-						for _, token := range ownedRBTTokens {
-							committedToken := &models.TokenInfo{
-								TokenID:               token.TokenID,
-								PreviousTransactionID: token.TransactionID,
-							}
-							allCommittedTokens = append(allCommittedTokens, committedToken)
+					// Collateral was locked and split in the pre-pass above, so only
+					// the tokens actually backing scInfo.Value are committed here;
+					// the change was minted back to the initiator as Free.
+					if committed, ok := scCommittedTokens[scInfo.SmartContractId]; ok {
+						for _, token := range committed {
+							allCommittedTokens = append(allCommittedTokens, token)
 							// Add to locked list so they get marked as Locked (not Committed yet - that happens during consensus)
 							allLockedIDs = append(allLockedIDs, token.TokenID)
 						}
-						log.Debug("BuildTransactionInfoFromRequest: Committed tokens prepared", "count", len(ownedRBTTokens))
+						log.Debug("BuildTransactionInfoFromRequest: Committed tokens prepared", "count", len(committed))
 					}
 
 					// Add SC to transaction tokens (will be deployed during consensus)

--- a/core/wallet/post_consensus_persistence.go
+++ b/core/wallet/post_consensus_persistence.go
@@ -145,8 +145,28 @@ func (pc *PostConsensusPersistenceCoordinator) Persist(ctx context.Context, req 
 	if err := pc.upsertTokenStates(ctx, tx, req.TokenStates); err != nil {
 		return err
 	}
-	if len(req.TransactionInfo.Tokens.RBT) != 0 {
-		if err := pc.upsertTokenDenomDeltas(ctx, tx, req.DID, req.TokenStates, req.ExecutionRole, isLocalTransfer, req.TransactionInfo.Owner); err != nil {
+	// An SC deploy moves RBT collateral from Free to Committed while carrying
+	// Tokens.RBT empty — the collateral rides in CommittedTokens instead. Gating
+	// only on Tokens.RBT skipped the decrement, so token_denom kept counting
+	// those tokens as spendable and a later selection failed with
+	// "lockSelectedTokens: no tokens provided".
+	//
+	// hasSCDeploy is deliberately the same predicate isSCDeployCommit uses to
+	// flip that status (see post_consensus_payload_builder.go), so the counter
+	// update and the status change cannot diverge. Testing CommittedTokens
+	// directly would be wrong: a split genesis also carries burnt parents there,
+	// and those are already accounted for by PersistGenesisTransaction.
+	//
+	// The isLocalTransfer credit is suppressed for a deploy. That block exists
+	// for a same-node RBT transfer, where sender and receiver are different DIDs
+	// on one node: decrement the sender, credit the receiver. A deploy pins Owner
+	// to Initiator, so isLocalTransfer is always true and the credit lands on the
+	// very DID just decremented — cancelling it out and leaving the collateral
+	// counted as spendable. There is no receiver: the collateral is terminally
+	// Committed, so nothing should be credited back.
+	scDeploy := hasSCDeploy(req.TransactionInfo)
+	if len(req.TransactionInfo.Tokens.RBT) != 0 || scDeploy {
+		if err := pc.upsertTokenDenomDeltas(ctx, tx, req.DID, req.TokenStates, req.ExecutionRole, isLocalTransfer && !scDeploy, req.TransactionInfo.Owner); err != nil {
 			return err
 		}
 	}

--- a/core/wallet/token_chain.go
+++ b/core/wallet/token_chain.go
@@ -985,6 +985,7 @@ func (w *Wallet) UpdateTokenInfo(tx pgx.Tx, tokenInfo *models.TokenInfo, did, tx
 	token := &models.Token{
 		TokenID:        tokenInfo.TokenID, // assigned by PersistGenesisTokenRecord
 		DID:            did,
+		TokenValue:     tokenInfo.TokenValue,
 		TokenStatus:    int16(tokenStatus),
 		TransactionID:  txID,
 		LatestPosition: newTokenChainHeight,
@@ -1046,16 +1047,23 @@ func (w *Wallet) UpdateTokenInfo(tx pgx.Tx, tokenInfo *models.TokenInfo, did, tx
 		return fmt.Errorf("UpdateTokenInfo: update tokenchain_index: %w", err)
 	}
 
-	// Update token_denom table for RBTs
-	if tokenType == constants.TokenType_RBT {
+	// Decrement token_denom: this function moves an RBT OUT of Free (its only
+	// caller burns parent RBTs for FT minting), so the denomination it leaves
+	// behind must stop being advertised as spendable. It previously incremented
+	// instead, and keyed the write on token.TokenValue while that field was
+	// never copied from tokenInfo — so every burn added a phantom denom=0 row
+	// AND skipped the real decrement. GREATEST floors the counter at 0 so a
+	// double call can never drive it negative; token_value=0 is skipped to keep
+	// token_denom keyed on real denominations only, matching the guards in
+	// post_consensus_persistence.go and recovery.go.
+	if tokenType == constants.TokenType_RBT && token.TokenValue > 0 {
 		if _, err = tx.Exec(w.Ctx, `
-			INSERT INTO token_denom (did, denom, count, created_at, updated_at)
-			VALUES ($1, $2, $3, NOW(), NOW())
-			ON CONFLICT (did, denom) DO UPDATE SET
-			  count = token_denom.count + 1,
+			UPDATE token_denom SET
+			  count      = GREATEST(count - 1, 0),
 			  updated_at = NOW()
-		`, token.DID, token.TokenValue, 1); err != nil {
-			return fmt.Errorf("UpdateTokenInfo: upsert token_denom: %w", err)
+			WHERE did = $1 AND denom = $2
+		`, token.DID, token.TokenValue); err != nil {
+			return fmt.Errorf("UpdateTokenInfo: decrement token_denom: %w", err)
 		}
 	}
 

--- a/test/integration/README.md
+++ b/test/integration/README.md
@@ -106,6 +106,7 @@ does not itself raise; `runner.py` reads `StressRunner.verification_failed`.)
 | `--nft-count N` / `--nft-only` / `--nft-self-execute` / `--nft-transfer` / `--nft-cross-execute` | NFT scope |
 | `--sc-count N` / `--sc-execute` / `--sc-only` | Smart contract scope |
 | `--ft-count N` / `--ft-only` / `--ft-transfer` | FT scope |
+| `--ft-parts-tests` / `--ft-parts-only` | FT minted out of PART RBTs + token_denom accounting (auto-enabled by `--run-all-tests`; `--ft-parts-only` runs it alone against a fresh wallet) |
 | `--bundled-test` / `--all-in-one-test` / `--intra-node-test` | Combined flows |
 | `--skip-ft` | Disable all FT-dependent paths (composes with `--run-all-tests`) |
 | `--no-docker` | Don't manage Docker; nodes already running |

--- a/test/integration/TESTS.md
+++ b/test/integration/TESTS.md
@@ -27,8 +27,14 @@ window between each:
 
 ```
 MINTING → SHUTTLE → NFT → SMART_CONTRACT → BUNDLED_TX → FT → ALL_IN_ONE
-        → INTRA_NODE → NEGATIVE → FINALISE
+        → INTRA_NODE → NEGATIVE → SC_COLLATERAL → FT_PARTS → FINALISE
 ```
+
+The last two are accounting suites rather than subsystem exercises: each funds
+or deploys its own assets and only reads state back, so they run after every
+subsystem without disturbing it. Both SKIP themselves if the earlier phases
+have drained node A — `docker-integration.yml` runs FT_PARTS standalone in a
+job of its own (`--ft-parts-only`) so it is always exercised somewhere.
 
 ---
 
@@ -191,7 +197,43 @@ state change) is a FAIL.
 
 ---
 
-## 9. Transaction persistence (final cross-node assurance)
+## 9. FT from part RBTs (`--ft-parts-tests` / `--ft-parts-only`)
+
+Minting an FT burns whole RBT — but the tokens burnt need not be whole. A wallet
+holding only fractional RBT must mint just the same, with several **part** tokens
+burnt per FT batch. The suite funds a DID of its own with sub-1.0 transfers (so
+by construction it holds parts and no 1.000 token), mints from it twice, and
+audits what the burns did to the wallet.
+
+**Why the FT suite above cannot catch this.** It mints from `did_a`, whose
+hundreds of whole tokens are selected first, so one whole parent is burnt per
+batch — and it asserts FT counts and balances, never `token_denom`.
+
+**Why `token_denom` matters.** It is not a statistic:
+`lockTokensForSplitOnce` picks *which denominations* to select from
+`token_denom`, then reads the matching rows out of `tokens`. A counter that
+still advertises burnt tokens makes a later selection ask for rows that are no
+longer Free, and the operation dies with `lockSelectedTokens: no tokens
+provided` — attributed to whatever transaction ran next, not to the mint that
+corrupted the counter. `FTPARTS_SPEND_AFTER_MINT` reproduces exactly that.
+
+**Verification checks**
+
+| Check | Asserts |
+|-------|---------|
+| `FTPARTS_PRECONDITION` | SKIP-only: node A lacks the balance to fund a parts wallet (a harness budgeting problem, never an FT failure). |
+| `FTPARTS_WALLET_PARTS_ONLY` | The funded DID holds the full funded amount as fractional denominations and no whole token — without which the mint below would not exercise the parts path. |
+| `FTPARTS_MINT_FROM_PARTS` | An FT mint backed by several part tokens succeeds, and really did burn more than one RBT row. |
+| `FTPARTS_PARTS_BURNT` | Free balance falls by exactly the RBT minted, and that same value is recorded as `BurntForFT` — no part silently destroyed. |
+| `FTPARTS_FT_BALANCE` | The minting DID holds the FTs, per the API and independently per the `tokens` table. |
+| `FTPARTS_DENOM_CONSISTENT` | `token_denom` matches the real count of Free RBT rows at every denomination. Guards `UpdateTokenInfo`, which used to **increment** the counter for tokens it was burning. |
+| `FTPARTS_NO_ZERO_DENOM` | No phantom `denom=0` row for the minting DID. Guards the same write, which keyed on a `TokenValue` never copied from `tokenInfo` — landing on denom 0 and missing the real denomination. |
+| `FTPARTS_REPEAT_MINT` | A second mint from the same parts wallet still succeeds and costs exactly the RBT requested. |
+| `FTPARTS_SPEND_AFTER_MINT` | The parts left over after the burns are still spendable — the user-visible failure a stale counter produces. |
+
+---
+
+## 10. Transaction persistence (final cross-node assurance)
 
 A cross-cutting check that runs **last**, after every subsystem and the deferred
 intra-node check, so all writes have committed across nodes. For every recorded

--- a/test/integration/runner.py
+++ b/test/integration/runner.py
@@ -13,6 +13,7 @@ Usage (from repo root):
   python3 -m test.integration.runner --micro-test --run-all-tests   # fast smoke
   python3 -m test.integration.runner --small-test --run-all-tests
   python3 -m test.integration.runner --micro-test --nft-only --nft-count 5
+  python3 -m test.integration.runner --small-test --ft-parts-only   # FT-from-parts alone
   python3 -m test.integration.runner --no-docker --run-all-tests     # nodes already up
 
 Scope: this committed harness intentionally omits the scratchpad-only resume
@@ -337,6 +338,33 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "have drained node A. Auto-enabled by --run-all-tests."
         ),
     )
+    p.add_argument(
+        "--ft-parts-tests",
+        action="store_true",
+        help=(
+            "Run the FT-from-parts suite: funds a DID of its own with "
+            "sub-1.0 RBT transfers (so it holds PART tokens and no whole "
+            "token), mints FTs out of those parts, and asserts the burn is "
+            "accounted for — balance falls by exactly the RBT minted, the same "
+            "value is recorded as BurntForFT, token_denom still matches the "
+            "real Free rows with no phantom denom=0 row, a second mint "
+            "succeeds, and the leftover parts stay spendable. The main FT "
+            "suite mints from did_a, where whole 1.000 tokens are selected "
+            "first, so it never burns parts. Skips itself when earlier phases "
+            "have drained node A. Auto-enabled by --run-all-tests, disabled by "
+            "--skip-ft."
+        ),
+    )
+    p.add_argument(
+        "--ft-parts-only",
+        action="store_true",
+        help=(
+            "Skip the RBT shuttle and every other subsystem and run ONLY the "
+            "FT-from-parts suite (implies --ft-parts-tests). Used by CI to run "
+            "it against a freshly minted wallet, where it can never skip itself "
+            "for lack of funds."
+        ),
+    )
     return p
 
 
@@ -380,6 +408,7 @@ def main() -> None:
         args.intra_node_test = True
         args.negative_tests = True
         args.sc_collateral_tests = True
+        args.ft_parts_tests = True
         args.nft_only = False
         args.sc_only = False
         args.ft_only = False
@@ -396,6 +425,13 @@ def main() -> None:
         if args.exec_rounds == 0:
             args.exec_rounds = 10
         args.nft_only = True
+
+    # --ft-parts-only: scope the run down to that suite alone. Everything else
+    # is left at its default (off), so this composes only with the global flags
+    # (--small-test / --native / --config).
+    if args.ft_parts_only:
+        log.info("=== FT-PARTS-ONLY MODE ENABLED ===")
+        args.ft_parts_tests = True
 
     # Validate *-only requirements
     if args.nft_only and args.nft_count == 0:
@@ -453,6 +489,8 @@ def main() -> None:
         args.ft_transfer_rounds = 0
         args.all_in_one_test = False
         args.intra_node_ft_rounds = 0
+        args.ft_parts_tests = False
+        args.ft_parts_only = False
 
     # Build NFT phases
     nft_phases = None
@@ -538,6 +576,8 @@ def main() -> None:
             run_all_tests=args.run_all_tests,
             negative_tests=args.negative_tests,
             sc_collateral_tests=args.sc_collateral_tests,
+            ft_parts_tests=args.ft_parts_tests,
+            ft_parts_only=args.ft_parts_only,
         )
     except Exception as exc:
         log.error("Integration run failed: %s", exc, exc_info=True)

--- a/test/integration/runner.py
+++ b/test/integration/runner.py
@@ -329,9 +329,12 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "Run the SC deploy collateral suite: deploys contracts at a "
             "FRACTIONAL value (0.001) and asserts the deployer's balance falls "
             "by exactly that value, that only that value is held as Committed, "
-            "and that token_denom stays consistent with the real Free rows. "
-            "The main SC suite deploys at 1.0, where committing a whole token "
-            "is correct, so it cannot see this. Auto-enabled by --run-all-tests."
+            "and that token_denom stays consistent with the real Free rows at "
+            "that denomination. The main SC suite deploys at 1.0, where "
+            "committing a whole token is correct, so it cannot see this. Also "
+            "reports FT-caused denom drift separately (known-failing until the "
+            "FT paths decrement token_denom). Skips itself when earlier phases "
+            "have drained node A. Auto-enabled by --run-all-tests."
         ),
     )
     return p

--- a/test/integration/runner.py
+++ b/test/integration/runner.py
@@ -322,6 +322,18 @@ def _build_arg_parser() -> argparse.ArgumentParser:
             "Auto-enabled by --run-all-tests."
         ),
     )
+    p.add_argument(
+        "--sc-collateral-tests",
+        action="store_true",
+        help=(
+            "Run the SC deploy collateral suite: deploys contracts at a "
+            "FRACTIONAL value (0.001) and asserts the deployer's balance falls "
+            "by exactly that value, that only that value is held as Committed, "
+            "and that token_denom stays consistent with the real Free rows. "
+            "The main SC suite deploys at 1.0, where committing a whole token "
+            "is correct, so it cannot see this. Auto-enabled by --run-all-tests."
+        ),
+    )
     return p
 
 
@@ -364,6 +376,7 @@ def main() -> None:
         args.all_in_one_test = True
         args.intra_node_test = True
         args.negative_tests = True
+        args.sc_collateral_tests = True
         args.nft_only = False
         args.sc_only = False
         args.ft_only = False
@@ -521,6 +534,7 @@ def main() -> None:
             intra_node_ft_fund=args.intra_node_ft_fund,
             run_all_tests=args.run_all_tests,
             negative_tests=args.negative_tests,
+            sc_collateral_tests=args.sc_collateral_tests,
         )
     except Exception as exc:
         log.error("Integration run failed: %s", exc, exc_info=True)

--- a/test/integration/tests/ft_parts.py
+++ b/test/integration/tests/ft_parts.py
@@ -1,0 +1,705 @@
+"""
+ft_parts.py — FT creation out of PART RBTs (fractional denominations).
+
+Minting an FT burns whole RBT: ``createFTs`` locks ``token_count`` RBT worth of
+tokens, ``parts.CollectRBTTokens`` assembles them, ``BatchRBTs`` groups them
+into batches summing to exactly 1.0, and ``FTGenesisTxn`` flips each parent RBT
+to BurntForFT via ``UpdateTokenInfo``.
+
+Nothing says those parents have to be WHOLE tokens. A wallet holding only
+fractional RBT (0.5 / 0.1 / 0.05 …) must be able to mint just the same, with
+several part tokens burnt per FT batch. That is the path this suite drives, and
+it is the path where the accounting has been wrong:
+
+  - ``UpdateTokenInfo`` INCREMENTED ``token_denom`` for every RBT it burnt, when
+    burning moves a token OUT of Free and must DECREMENT it.
+  - It keyed that write on ``token.TokenValue`` while never copying the value
+    from ``tokenInfo`` — so the write landed on denom 0, adding a phantom
+    ``denom=0`` row AND missing the real denomination entirely.
+
+Both are fixed in ``core/wallet/token_chain.go`` (``UpdateTokenInfo`` now
+decrements, floors at 0, and skips ``token_value = 0``). The damage they caused
+is invisible to the existing FT suite: it asserts FT counts and balances, never
+``token_denom``, and it mints from a wallet full of whole tokens where a single
+1.000 parent is burnt per batch — one wrong counter row that the wallet's
+hundreds of other whole tokens hide. Burning PARTS makes it loud: the parts
+wallet here holds a handful of tokens at two denominations, so a counter that
+still advertises the burnt ones is both measurable and fatal to the next spend.
+
+Why token_denom matters at all: it is not a statistic. ``lockTokensForSplitOnce``
+picks WHICH denominations to select from ``token_denom`` and only then reads the
+matching rows out of ``tokens``. When the counter over-reports, selection asks
+for tokens that are no longer Free, gets fewer rows back than it planned for (or
+none), and the operation dies with ``lockSelectedTokens: no tokens provided`` —
+attributed to whatever transaction happened to run next, not to the FT mint that
+corrupted the counter. FTPARTS_SPEND_AFTER_MINT reproduces exactly that.
+
+Isolation: the suite creates its OWN DID on node A and funds it only with
+sub-1.0 transfers, so by construction the wallet holds parts and no whole token.
+That gives an exact expected state for every assertion — impossible against
+``did_a``, whose balance every other phase is concurrently spending, and where a
+1.000 token would be picked in preference to the parts we care about.
+
+Cases:
+  - parts-only wallet: the funded DID holds fractional RBT and no 1.0 token
+  - mint from parts:   an FT mint backed by several part tokens succeeds
+  - burn accounting:   free balance falls by exactly the RBT minted, and that
+                       same value shows up as BurntForFT
+  - denom consistency: token_denom agrees with the real Free rows at every
+                       denomination (the decrement that was an increment)
+  - no phantom row:    no denom=0 row for the minting DID
+  - repeat mint:       a second mint from the same parts wallet still succeeds
+  - spend after mint:  RBT left over after the burns is still spendable — the
+                       failure the stale counter actually produced
+
+Results use the same {"check", "status", "detail"} shape as the other engines so
+they fold into verification.json and the runner's exit-on-fail gate.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from typing import Any, Dict, List, Optional, Tuple
+
+from test.integration.clients.api_client import NodeClient
+
+log = logging.getLogger(__name__)
+
+# Funding tranches for the parts wallet, did_a -> the suite's own DID. EVERY
+# amount is < 1.0, which is what guarantees a parts-only wallet: a transfer
+# splits the sender's whole token and hands over the fraction, so the receiver
+# can never end up holding a 1.000 token. The 0.7 / 0.3 tranches land at the 0.1
+# denomination as well as 0.5, so collection has to span two denominations
+# rather than repeatedly taking the same one.
+_FUND_TRANCHES: Tuple[float, ...] = (0.5, 0.5, 0.5, 0.5, 0.7, 0.3)
+_FUND_TOTAL = round(sum(_FUND_TRANCHES), 3)   # 3.0
+
+# RBT burnt per mint. 1 whole RBT is the minimum a mint can consume (BatchRBTs
+# requires batches summing to exactly 1.0) and is deliberately more than any
+# single token in the parts wallet, so the mint MUST assemble several parts.
+_MINT_RBT = 1
+
+# FTs created per mint. Bounded by token_count * 1000 (createFTs); 10 keeps each
+# FT worth 0.1 RBT and the genesis batch small.
+_MINT_FT_COUNT = 10
+
+# Spent back to did_a after the mints, to prove the leftover parts are still
+# selectable. Smaller than the balance the mints leave behind.
+_SPEND_AFTER_MINT = 0.5
+
+# node A must hold this much free RBT before the suite funds its wallet. The
+# suite runs late under --run-all-tests, after the other phases have spent from
+# did_a; an unfunded wallet is a harness budgeting problem, not an FT defect.
+_MIN_REQUIRED_BALANCE = _FUND_TOTAL + 2.0
+
+# Sums of token_value carry float representation noise; compare with a tolerance
+# far below the smallest denomination in play (0.001).
+_EPSILON = 1e-9
+
+# Settle time after a consensus round before reading state back.
+_SETTLE = 6
+
+# token_status values (constants/constants.go): Free=0, BurntForFT=9.
+_STATUS_FREE = 0
+_STATUS_BURNT_FOR_FT = 9
+
+# token_type ids are lowercase names in the token_type table.
+_TYPE_RBT = "rbt"
+_TYPE_FT = "ft"
+
+
+class FTPartsEngine:
+    """Asserts FT minting works, and accounts correctly, when backed by parts."""
+
+    def __init__(
+        self,
+        node_a: NodeClient,
+        node_b: NodeClient,
+        quorum: NodeClient,
+        did_a: str,
+        db_a: Any,
+        password: str = "mypassword",
+    ) -> None:
+        self.node_a = node_a
+        self.node_b = node_b
+        self.quorum = quorum
+        self.did_a = did_a
+        self.db_a = db_a
+        self.password = password
+
+        # The suite's own DID on node A, funded with parts only.
+        self.parts_did: Optional[str] = None
+
+        # FT series minted here, so the balance check knows what to look for.
+        self._minted: List[Dict[str, Any]] = []
+
+    # ---------------------------------------------------------------- helpers
+
+    def _query(self, sql: str, params: tuple = ()) -> List[tuple]:
+        """Run a read-only query against node A's DB.
+
+        Connects by literal IPv4 rather than reusing db_a._connect(): in native
+        mode Postgres binds 127.0.0.1 only, while "localhost" resolves to ::1
+        first on some hosts, which fails with a misleading 'database does not
+        exist'. Copying the params and pinning the host keeps this suite working
+        in both native and Docker modes.
+        """
+        import psycopg2
+
+        params_ipv4 = dict(self.db_a.conn_params)
+        if params_ipv4.get("host") == "localhost":
+            params_ipv4["host"] = "127.0.0.1"
+
+        with psycopg2.connect(**params_ipv4) as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            return cur.fetchall()
+
+    def _free_balance(self, did: str) -> float:
+        """Sum of Free RBT held by *did*, straight from the DB."""
+        rows = self._query(
+            """
+            SELECT COALESCE(SUM(token_value), 0)
+              FROM tokens
+             WHERE did = %s
+               AND token_status = %s
+               AND token_type = (SELECT id FROM token_type WHERE name = %s)
+            """,
+            (did, _STATUS_FREE, _TYPE_RBT),
+        )
+        return float(rows[0][0])
+
+    def _free_rows_by_denom(self, did: str) -> List[Tuple[float, int]]:
+        """(denomination, count) of the Free RBT rows held by *did*."""
+        rows = self._query(
+            """
+            SELECT token_value, COUNT(*)
+              FROM tokens
+             WHERE did = %s
+               AND token_status = %s
+               AND token_type = (SELECT id FROM token_type WHERE name = %s)
+             GROUP BY token_value
+             ORDER BY token_value DESC
+            """,
+            (did, _STATUS_FREE, _TYPE_RBT),
+        )
+        return [(float(v), int(n)) for v, n in rows]
+
+    def _burnt_for_ft(self, did: str) -> Tuple[float, int]:
+        """(summed value, row count) of RBT *did* has burnt for FT minting."""
+        rows = self._query(
+            """
+            SELECT COALESCE(SUM(token_value), 0), COUNT(*)
+              FROM tokens
+             WHERE did = %s
+               AND token_status = %s
+               AND token_type = (SELECT id FROM token_type WHERE name = %s)
+            """,
+            (did, _STATUS_BURNT_FOR_FT, _TYPE_RBT),
+        )
+        return float(rows[0][0]), int(rows[0][1])
+
+    def _ft_token_count(self, did: str) -> int:
+        """Number of Free FT tokens held by *did* in the tokens table."""
+        rows = self._query(
+            """
+            SELECT COUNT(*)
+              FROM tokens
+             WHERE did = %s
+               AND token_status = %s
+               AND token_type = (SELECT id FROM token_type WHERE name = %s)
+            """,
+            (did, _STATUS_FREE, _TYPE_FT),
+        )
+        return int(rows[0][0])
+
+    def _denom_rows(self, did: str) -> List[Tuple[float, int]]:
+        """Raw (denom, count) rows of token_denom for *did*."""
+        rows = self._query(
+            "SELECT denom, count FROM token_denom WHERE did = %s ORDER BY denom DESC",
+            (did,),
+        )
+        return [(float(d), int(c)) for d, c in rows]
+
+    def _denom_drift(self, did: str) -> List[tuple]:
+        """Rows where token_denom disagrees with the real count of Free rows.
+
+        Returns (denom, counter, actual, drift) per mismatch; empty when the
+        counter is consistent. A FULL OUTER JOIN so a counter row with no
+        matching Free tokens and Free tokens with no counter row are both
+        caught — the burn defect produces the former.
+        """
+        return self._query(
+            """
+            SELECT COALESCE(d.denom, f.denom),
+                   COALESCE(d.count, 0),
+                   COALESCE(f.free_rows, 0),
+                   COALESCE(d.count, 0) - COALESCE(f.free_rows, 0) AS drift
+              FROM (SELECT denom, count FROM token_denom WHERE did = %s) d
+              FULL OUTER JOIN (
+                    SELECT token_value AS denom, COUNT(*) AS free_rows
+                      FROM tokens
+                     WHERE did = %s
+                       AND token_type = (SELECT id FROM token_type WHERE name = %s)
+                       AND token_status = %s
+                     GROUP BY token_value
+              ) f ON f.denom = d.denom
+             WHERE COALESCE(d.count, 0) - COALESCE(f.free_rows, 0) <> 0
+             ORDER BY 1 DESC
+            """,
+            (did, did, _TYPE_RBT, _STATUS_FREE),
+        )
+
+    def _status_breakdown(self, did: str, denom: float) -> str:
+        """Where this denomination's non-Free tokens went, as 'status=N n=C'.
+
+        A drift means the counter still claims tokens that have left Free, so
+        the statuses they moved to name the path that failed to decrement.
+        """
+        rows = self._query(
+            """
+            SELECT token_status, COUNT(*)
+              FROM tokens
+             WHERE did = %s
+               AND token_value = %s
+               AND token_type = (SELECT id FROM token_type WHERE name = %s)
+               AND token_status <> %s
+             GROUP BY token_status
+             ORDER BY token_status
+            """,
+            (did, denom, _TYPE_RBT, _STATUS_FREE),
+        )
+        if not rows:
+            return "no non-Free rows"
+        return ", ".join(f"status={s} n={n}" for s, n in rows)
+
+    def _mint(self, label: str, start_index: int) -> Dict[str, Any]:
+        """Mint one FT series from the parts wallet. Raises on failure.
+
+        The FT id is ``<ft_name>_<did>_<index>``, so the name must be unique per
+        creator and must not contain an underscore of its own.
+        """
+        ft_name = f"FTPARTS{label}{uuid.uuid4().hex[:8]}".upper()
+        result = self.node_a.mint_ft(
+            did=self.parts_did,
+            ft_name=ft_name,
+            ft_count=_MINT_FT_COUNT,
+            token_count=_MINT_RBT,
+            ft_num_start_index=start_index,
+        )
+        record = {"ft_name": ft_name, "result": result}
+        self._minted.append(record)
+        return record
+
+    # ------------------------------------------------------------------- run
+
+    def run(self) -> List[Dict[str, str]]:
+        """Run every parts-mint check. Never raises — failures become results."""
+        results: List[Dict[str, str]] = []
+
+        # Under --run-all-tests this suite runs late, after the shuttle and the
+        # asset phases have spent from did_a. With nothing left to fund the
+        # parts wallet, every check below would fail for a reason that has
+        # nothing to do with FT accounting. Separate the two up front.
+        balance = self._free_balance(self.did_a)
+        if balance < _MIN_REQUIRED_BALANCE:
+            log.warning(
+                "FT parts: skipping — node A holds %s RBT, need >= %s",
+                balance, _MIN_REQUIRED_BALANCE,
+            )
+            return [{
+                "check": "FTPARTS_PRECONDITION",
+                "status": "SKIP",
+                "detail": (
+                    f"node A holds {balance} free RBT for did={self.did_a}, below "
+                    f"the {_MIN_REQUIRED_BALANCE} needed to fund a parts wallet. "
+                    "Earlier phases drained it; raise min_balance_buffer in the "
+                    "config rather than reading this as an FT failure."
+                ),
+            }]
+
+        try:
+            results.extend(self._setup_parts_wallet())
+        except Exception as exc:  # noqa: BLE001 - report, never abort the suite
+            log.error("FT parts: parts wallet setup failed: %s", exc)
+            return results + [{
+                "check": "FTPARTS_SETUP",
+                "status": "FAIL",
+                "detail": f"could not build the parts wallet: {exc}",
+            }]
+
+        for phase in (
+            self._check_mint_from_parts,
+            self._check_repeat_mint,
+            self._check_spend_after_mint,
+        ):
+            try:
+                results.extend(phase())
+            except Exception as exc:  # noqa: BLE001 - report, never abort the suite
+                log.error("FT parts phase %s failed: %s", phase.__name__, exc)
+                results.append({
+                    "check": f"FTPARTS_{phase.__name__.strip('_').upper()}",
+                    "status": "FAIL",
+                    "detail": f"phase raised: {exc}",
+                })
+
+        return results
+
+    # ---------------------------------------------------------------- phases
+
+    def _setup_parts_wallet(self) -> List[Dict[str, str]]:
+        """Create a DID on node A and fund it with fractional RBT only."""
+        log.info("=== FT PARTS: creating a dedicated DID on node A ===")
+
+        created = self.node_a.create_did(self.password)
+        self.parts_did = created["did"]
+
+        # Give IPFS a moment to propagate the new DID object before RegisterDID
+        # (same wait the intra-node engine needs).
+        time.sleep(5)
+        self.node_a.register_did(self.parts_did)
+
+        # The funding transfers run through the quorum, which has to resolve the
+        # new DID to node A's peer — so broadcast the mapping first.
+        peer_a = self.node_a.get_peer_id()
+        self.node_b.add_peer_details(peer_a, self.parts_did)
+        self.quorum.add_peer_details(peer_a, self.parts_did)
+
+        log.info(
+            "=== FT PARTS: funding %s with %s (tranches %s) ===",
+            self.parts_did, _FUND_TOTAL, _FUND_TRANCHES,
+        )
+        for i, amount in enumerate(_FUND_TRANCHES, start=1):
+            self.node_a.transfer_rbt(
+                sender_did=self.did_a,
+                receiver_did=self.parts_did,
+                amount=amount,
+                password=self.password,
+            )
+            log.info("FT parts: funded tranche %d/%d (%s RBT)",
+                     i, len(_FUND_TRANCHES), amount)
+            time.sleep(2)
+
+        time.sleep(_SETTLE)
+
+        balance = self._free_balance(self.parts_did)
+        by_denom = self._free_rows_by_denom(self.parts_did)
+        wholes = [(d, n) for d, n in by_denom if d >= 1.0]
+        breakdown = ", ".join(f"{d}x{n}" for d, n in by_denom) or "<empty>"
+
+        if wholes:
+            status, detail = "FAIL", (
+                f"parts wallet {self.parts_did} holds whole tokens ({wholes}); "
+                f"every funding tranche was < 1.0 so a 1.000 token cannot have "
+                f"been transferred — the mint below would not exercise the parts "
+                f"path. Free rows: {breakdown}"
+            )
+        elif abs(balance - _FUND_TOTAL) >= _EPSILON:
+            status, detail = "FAIL", (
+                f"parts wallet holds {balance} RBT, expected {_FUND_TOTAL} from "
+                f"tranches {_FUND_TRANCHES}; funding did not land as sent. "
+                f"Free rows: {breakdown}"
+            )
+        else:
+            status, detail = "PASS", (
+                f"parts wallet holds {balance} RBT across {len(by_denom)} "
+                f"fractional denomination(s) and no whole token: {breakdown}"
+            )
+
+        return [{
+            "check": "FTPARTS_WALLET_PARTS_ONLY",
+            "status": status,
+            "detail": detail,
+        }]
+
+    def _check_mint_from_parts(self) -> List[Dict[str, str]]:
+        """Mint an FT series backed by part RBTs and audit what it consumed."""
+        out: List[Dict[str, str]] = []
+
+        balance_before = self._free_balance(self.parts_did)
+        burnt_before, burnt_rows_before = self._burnt_for_ft(self.parts_did)
+        log.info(
+            "=== FT PARTS: minting %d FTs from %s RBT of parts (free=%s) ===",
+            _MINT_FT_COUNT, _MINT_RBT, balance_before,
+        )
+
+        try:
+            record = self._mint("A", start_index=0)
+        except Exception as exc:  # noqa: BLE001 - reported as a result
+            return [{
+                "check": "FTPARTS_MINT_FROM_PARTS",
+                "status": "FAIL",
+                "detail": (
+                    f"minting {_MINT_FT_COUNT} FTs from {_MINT_RBT} RBT held only "
+                    f"as parts failed: {exc}"
+                ),
+            }]
+
+        time.sleep(_SETTLE)
+
+        balance_after = self._free_balance(self.parts_did)
+        burnt_after, burnt_rows_after = self._burnt_for_ft(self.parts_did)
+        burnt_value = burnt_after - burnt_before
+        burnt_rows = burnt_rows_after - burnt_rows_before
+
+        # 1. The mint succeeded, and it really did burn PARTS: more than one RBT
+        #    row went to BurntForFT for a single whole RBT of value.
+        if burnt_rows > 1:
+            out.append({
+                "check": "FTPARTS_MINT_FROM_PARTS",
+                "status": "PASS",
+                "detail": (
+                    f"minted {_MINT_FT_COUNT} FTs ({record['ft_name']}) by burning "
+                    f"{burnt_rows} part tokens totalling {burnt_value} RBT"
+                ),
+            })
+        else:
+            out.append({
+                "check": "FTPARTS_MINT_FROM_PARTS",
+                "status": "FAIL",
+                "detail": (
+                    f"mint burnt {burnt_rows} RBT row(s) worth {burnt_value}; a "
+                    f"parts-only wallet must assemble {_MINT_RBT} RBT from several "
+                    "part tokens, so a single burnt row means the wallet was not "
+                    "parts-only and this suite proved nothing"
+                ),
+            })
+
+        # 2. The mint costs exactly the RBT requested — no part silently
+        #    destroyed, no change lost.
+        spent = balance_before - balance_after
+        if abs(spent - _MINT_RBT) < _EPSILON and abs(burnt_value - _MINT_RBT) < _EPSILON:
+            out.append({
+                "check": "FTPARTS_PARTS_BURNT",
+                "status": "PASS",
+                "detail": (
+                    f"free balance fell by exactly {spent} and the same {burnt_value} "
+                    f"is recorded as BurntForFT ({balance_before} -> {balance_after})"
+                ),
+            })
+        else:
+            out.append({
+                "check": "FTPARTS_PARTS_BURNT",
+                "status": "FAIL",
+                "detail": (
+                    f"free balance fell by {spent} and {burnt_value} was burnt, "
+                    f"expected {_MINT_RBT} for both ({balance_before} -> "
+                    f"{balance_after}); the parts backing the mint were not "
+                    "accounted for one-to-one"
+                ),
+            })
+
+        # 3. The FTs exist, per the API and independently per the tokens table.
+        out.append(self._check_ft_balance(expected=_MINT_FT_COUNT))
+
+        # 4+5. The counter that drives token selection must still describe
+        #      reality after the burns — the defect this suite exists for.
+        out.extend(self._check_denom_state("after the first parts mint"))
+
+        return out
+
+    def _check_ft_balance(self, expected: int) -> Dict[str, str]:
+        """The minting DID must hold *expected* FTs, per API and per DB.
+
+        The API is the contract; the tokens table is an independent cross-check
+        so a reporting bug in either is distinguishable from a mint that did not
+        create the FTs. Keys are name/creator/value/count (types/balance.go).
+        """
+        api_count = 0
+        api_error: Optional[str] = None
+        try:
+            for entry in self.node_a.get_ft_balance(self.parts_did):
+                if any(entry.get("name") == m["ft_name"] for m in self._minted):
+                    api_count += int(entry.get("count") or 0)
+        except Exception as exc:  # noqa: BLE001 - reported in the detail
+            api_error = str(exc)
+
+        db_count = self._ft_token_count(self.parts_did)
+
+        if api_count == expected and db_count == expected:
+            return {
+                "check": "FTPARTS_FT_BALANCE",
+                "status": "PASS",
+                "detail": (
+                    f"parts-funded DID holds {expected} FTs (API {api_count}, "
+                    f"tokens table {db_count})"
+                ),
+            }
+        return {
+            "check": "FTPARTS_FT_BALANCE",
+            "status": "FAIL",
+            "detail": (
+                f"expected {expected} FTs for the parts-funded DID, got API "
+                f"{api_count}{f' (error: {api_error})' if api_error else ''}, "
+                f"tokens table {db_count}"
+            ),
+        }
+
+    def _check_denom_state(self, when: str) -> List[Dict[str, str]]:
+        """token_denom must match the real Free rows, with no denom=0 row.
+
+        Two separate checks because they are two separate defects in the same
+        write: the increment-instead-of-decrement (drift) and the uncopied
+        TokenValue (phantom denom=0). Reporting them together would hide which
+        half regressed.
+        """
+        out: List[Dict[str, str]] = []
+        drift = self._denom_drift(self.parts_did)
+        rows = self._denom_rows(self.parts_did)
+        counter = ", ".join(f"{d}x{c}" for d, c in rows) or "<empty>"
+
+        if not drift:
+            out.append({
+                "check": "FTPARTS_DENOM_CONSISTENT",
+                "status": "PASS",
+                "detail": (
+                    f"token_denom matches the actual Free RBT rows at every "
+                    f"denomination {when}: {counter}"
+                ),
+            })
+        else:
+            detail = "; ".join(
+                f"denom={d} counter={c} actual={a} drift={dr} "
+                f"[{self._status_breakdown(self.parts_did, d)}]"
+                for d, c, a, dr in drift
+            )
+            out.append({
+                "check": "FTPARTS_DENOM_CONSISTENT",
+                "status": "FAIL",
+                "detail": (
+                    f"token_denom drifted {when} for did={self.parts_did}: {detail}. "
+                    "A positive drift at a denomination whose tokens are "
+                    f"status={_STATUS_BURNT_FOR_FT} means the FT burn incremented "
+                    "the counter instead of decrementing it; token selection will "
+                    "pick tokens that are no longer Free"
+                ),
+            })
+
+        zero_rows = [(d, c) for d, c in rows if abs(d) < _EPSILON]
+        if not zero_rows:
+            out.append({
+                "check": "FTPARTS_NO_ZERO_DENOM",
+                "status": "PASS",
+                "detail": f"no phantom denom=0 row for the minting DID {when}",
+            })
+        else:
+            out.append({
+                "check": "FTPARTS_NO_ZERO_DENOM",
+                "status": "FAIL",
+                "detail": (
+                    f"token_denom carries a denom=0 row {when} ({zero_rows}) for "
+                    f"did={self.parts_did}: the FT burn wrote the counter keyed on "
+                    "an uncopied TokenValue, counting tokens that can never be "
+                    "selected and skipping the real denomination"
+                ),
+            })
+
+        return out
+
+    def _check_repeat_mint(self) -> List[Dict[str, str]]:
+        """A second mint from the same parts wallet must also succeed.
+
+        Consecutive mints are how a broken counter surfaces: the first mint
+        leaves token_denom advertising the parts it burnt, and the next
+        selection asks for them.
+        """
+        out: List[Dict[str, str]] = []
+
+        balance_before = self._free_balance(self.parts_did)
+        try:
+            record = self._mint("B", start_index=_MINT_FT_COUNT)
+        except Exception as exc:  # noqa: BLE001 - reported as a result
+            return [{
+                "check": "FTPARTS_REPEAT_MINT",
+                "status": "FAIL",
+                "detail": (
+                    f"second mint from the same parts wallet failed: {exc}. The "
+                    "first mint left token_denom describing tokens it had already "
+                    "burnt, so selection could not find the rows it planned for"
+                ),
+            }]
+
+        time.sleep(_SETTLE)
+        balance_after = self._free_balance(self.parts_did)
+        spent = balance_before - balance_after
+
+        if abs(spent - _MINT_RBT) < _EPSILON:
+            out.append({
+                "check": "FTPARTS_REPEAT_MINT",
+                "status": "PASS",
+                "detail": (
+                    f"second mint ({record['ft_name']}) succeeded and cost exactly "
+                    f"{spent} RBT ({balance_before} -> {balance_after})"
+                ),
+            })
+        else:
+            out.append({
+                "check": "FTPARTS_REPEAT_MINT",
+                "status": "FAIL",
+                "detail": (
+                    f"second mint cost {spent} RBT, expected {_MINT_RBT} "
+                    f"({balance_before} -> {balance_after})"
+                ),
+            })
+
+        out.append(self._check_ft_balance(expected=_MINT_FT_COUNT * 2))
+        out.extend(self._check_denom_state("after the second parts mint"))
+
+        return out
+
+    def _check_spend_after_mint(self) -> List[Dict[str, str]]:
+        """The parts left over after the burns must still be spendable.
+
+        This is the user-visible failure a stale token_denom produces: selection
+        reads the counter, asks for denominations whose tokens are now
+        BurntForFT, and the transfer dies on 'lockSelectedTokens: no tokens
+        provided' — long after the mint that broke the counter.
+        """
+        balance_before = self._free_balance(self.parts_did)
+        if balance_before + _EPSILON < _SPEND_AFTER_MINT:
+            return [{
+                "check": "FTPARTS_SPEND_AFTER_MINT",
+                "status": "FAIL",
+                "detail": (
+                    f"parts wallet holds {balance_before} RBT after the mints, "
+                    f"less than the {_SPEND_AFTER_MINT} this check spends — the "
+                    f"mints consumed more than the {2 * _MINT_RBT} RBT they burnt"
+                ),
+            }]
+
+        try:
+            self.node_a.transfer_rbt(
+                sender_did=self.parts_did,
+                receiver_did=self.did_a,
+                amount=_SPEND_AFTER_MINT,
+                password=self.password,
+            )
+        except Exception as exc:  # noqa: BLE001 - reported as a result
+            return [{
+                "check": "FTPARTS_SPEND_AFTER_MINT",
+                "status": "FAIL",
+                "detail": (
+                    f"spending {_SPEND_AFTER_MINT} RBT of the parts left after "
+                    f"minting failed: {exc}. token_denom still advertises the "
+                    "parts the FT mint burnt, so token selection picks rows that "
+                    "are no longer Free"
+                ),
+            }]
+
+        time.sleep(_SETTLE)
+        balance_after = self._free_balance(self.parts_did)
+        spent = balance_before - balance_after
+
+        if abs(spent - _SPEND_AFTER_MINT) < _EPSILON:
+            status, detail = "PASS", (
+                f"spent {spent} RBT from the post-mint parts balance "
+                f"({balance_before} -> {balance_after})"
+            )
+        else:
+            status, detail = "FAIL", (
+                f"spending {_SPEND_AFTER_MINT} RBT moved {spent} "
+                f"({balance_before} -> {balance_after})"
+            )
+
+        return [{"check": "FTPARTS_SPEND_AFTER_MINT", "status": status, "detail": detail}]

--- a/test/integration/tests/happy_path.py
+++ b/test/integration/tests/happy_path.py
@@ -1073,7 +1073,13 @@ FROM tokens;
         """
         passed = sum(1 for r in results if r["status"] == "PASS")
         failed = sum(1 for r in results if r["status"] == "FAIL")
-        total = len(results)
+        # SKIP records a check that could not run because its preconditions were
+        # not met (e.g. an earlier phase drained the wallet it needed). It is
+        # neither a pass nor a failure, so it stays out of the ratio — but it is
+        # logged, because a check that silently stops running is worse than one
+        # that fails.
+        skipped = sum(1 for r in results if r["status"] == "SKIP")
+        total = len(results) - skipped
 
         # Record for the entry point so a failed check becomes a non-zero exit.
         self.verification_failed = failed
@@ -1083,6 +1089,7 @@ FROM tokens;
             "total_checks": total,
             "passed": passed,
             "failed": failed,
+            "skipped": skipped,
             "results": results,
         }
 
@@ -1099,6 +1106,11 @@ FROM tokens;
             for r in results:
                 if r["status"] == "FAIL":
                     log.warning("  FAIL: %s — %s", r["check"], r["detail"])
+        # Surface SKIPs too: a check that stopped running is easy to miss and
+        # looks identical to one that never existed.
+        for r in results:
+            if r["status"] == "SKIP":
+                log.warning("  SKIP: %s — %s", r["check"], r["detail"])
 
         log.info("Verification results written to %s", out_path)
 

--- a/test/integration/tests/happy_path.py
+++ b/test/integration/tests/happy_path.py
@@ -973,6 +973,27 @@ FROM tokens;
         )
         return engine.run()
 
+    def run_ft_parts(self) -> List[Dict[str, str]]:
+        """Run the FT-from-parts suite against node A.
+
+        Mints FTs out of a wallet holding only fractional RBT, which the main FT
+        suite never does (it mints from did_a, whose whole 1.000 tokens are
+        picked first), and audits the token_denom counter the burns must
+        decrement.
+        """
+        from test.integration.tests.ft_parts import FTPartsEngine
+
+        log.info("=== FT PARTS: running FT-mint-from-part-RBT tests ===")
+        engine = FTPartsEngine(
+            node_a=self.node_a,
+            node_b=self.node_b,
+            quorum=self.quorum,
+            did_a=self.did_a,
+            db_a=self.db_a,
+            password=self.cfg.password,
+        )
+        return engine.run()
+
     def run_db_snapshot(self) -> str:
         """Run diagnostic queries against all 3 DBs and write the results.
 
@@ -1162,6 +1183,8 @@ FROM tokens;
         run_all_tests: bool = False,
         negative_tests: bool = False,
         sc_collateral_tests: bool = False,
+        ft_parts_tests: bool = False,
+        ft_parts_only: bool = False,
     ) -> None:
         if skip_setup:
             self._load_state()
@@ -1196,7 +1219,7 @@ FROM tokens;
 
         # Skip RBT shuttle if any *-only mode is active
         shuttle_verification: List[Dict[str, str]] = []
-        if not nft_only and not sc_only and not ft_only:
+        if not nft_only and not sc_only and not ft_only and not ft_parts_only:
             shuttle_verification = self.run_shuttle(decimal_transfers=decimal_transfers)
             if run_all_tests:
                 self._settle_between_phases("SHUTTLE", "NFT")
@@ -1207,6 +1230,8 @@ FROM tokens;
                 log.info("=== SHUTTLE SKIPPED (--sc-only mode) ===")
             if ft_only:
                 log.info("=== SHUTTLE SKIPPED (--ft-only mode) ===")
+            if ft_parts_only:
+                log.info("=== SHUTTLE SKIPPED (--ft-parts-only mode) ===")
 
         if nft_phases:
             self.run_nft(nft_phases)
@@ -1468,6 +1493,13 @@ FROM tokens;
         if sc_collateral_tests:
             sc_collateral_verification = self.run_sc_collateral()
 
+        # FT minting from part RBTs. Funds a DID of its own with fractional
+        # transfers, so like the SC collateral suite it neither depends on nor
+        # disturbs the happy-path state — it only spends from did_a's balance.
+        ft_parts_verification: List[Dict[str, str]] = []
+        if ft_parts_tests:
+            ft_parts_verification = self.run_ft_parts()
+
         # Deferred intra-node FT balance check — run at the very end so the
         # (slow) intra-node FT settlement to did_a2 has maximum elapsed time.
         deferred_verification: List[Dict[str, str]] = []
@@ -1497,6 +1529,7 @@ FROM tokens;
             + intra_node_verification
             + negative_verification
             + sc_collateral_verification
+            + ft_parts_verification
             + deferred_verification
             + extra_api_verification
             + tx_persist_verification

--- a/test/integration/tests/happy_path.py
+++ b/test/integration/tests/happy_path.py
@@ -956,6 +956,23 @@ FROM tokens;
         )
         return engine.run()
 
+    def run_sc_collateral(self) -> List[Dict[str, str]]:
+        """Run the SC deploy collateral suite against node A.
+
+        Deploys at a fractional value, which the main SC suite never does, and
+        asserts the collateral is split rather than consumed whole.
+        """
+        from test.integration.tests.sc_collateral import SCCollateralEngine
+
+        log.info("=== SC COLLATERAL: running fractional-value deploy tests ===")
+        engine = SCCollateralEngine(
+            node_a=self.node_a,
+            did_a=self.did_a,
+            db_a=self.db_a,
+            password=self.cfg.password,
+        )
+        return engine.run()
+
     def run_db_snapshot(self) -> str:
         """Run diagnostic queries against all 3 DBs and write the results.
 
@@ -1132,6 +1149,7 @@ FROM tokens;
         intra_node_ft_fund: int = 2,
         run_all_tests: bool = False,
         negative_tests: bool = False,
+        sc_collateral_tests: bool = False,
     ) -> None:
         if skip_setup:
             self._load_state()
@@ -1431,6 +1449,13 @@ FROM tokens;
         if negative_tests:
             negative_verification = self.run_negative()
 
+        # SC deploy collateral. Deploys its own contracts at a fractional value
+        # and only reads balances back, so it neither depends on nor disturbs
+        # the happy-path state.
+        sc_collateral_verification: List[Dict[str, str]] = []
+        if sc_collateral_tests:
+            sc_collateral_verification = self.run_sc_collateral()
+
         # Deferred intra-node FT balance check — run at the very end so the
         # (slow) intra-node FT settlement to did_a2 has maximum elapsed time.
         deferred_verification: List[Dict[str, str]] = []
@@ -1459,6 +1484,7 @@ FROM tokens;
             + all_in_one_verification
             + intra_node_verification
             + negative_verification
+            + sc_collateral_verification
             + deferred_verification
             + extra_api_verification
             + tx_persist_verification

--- a/test/integration/tests/sc_collateral.py
+++ b/test/integration/tests/sc_collateral.py
@@ -51,7 +51,10 @@ they fold into verification.json and the runner's exit-on-fail gate.
 from __future__ import annotations
 
 import logging
+import os
+import tempfile
 import time
+import uuid
 from typing import Any, Dict, List
 
 from test.integration.clients.api_client import NodeClient
@@ -71,10 +74,10 @@ _EPSILON = 1e-9
 # Settle time after a consensus round before reading balances back.
 _SETTLE = 6
 
-# The suite makes 4 deploys, each splitting a whole token to take _SC_VALUE from
+# The suite makes 5 deploys, each splitting a whole token to take _SC_VALUE from
 # it. One whole RBT per deploy must be selectable at the moment of the split, so
-# require a small whole-token float rather than 4 * _SC_VALUE.
-_MIN_REQUIRED_BALANCE = 4.0
+# require a small whole-token float rather than 5 * _SC_VALUE.
+_MIN_REQUIRED_BALANCE = 5.0
 
 # token_status values (constants/constants.go): Free=0, Committed=5,
 # BurntForFT=9.
@@ -100,6 +103,10 @@ class SCCollateralEngine:
         self.did_a = did_a
         self.db_a = db_a
         self.password = password
+
+        # Token IDs deployed by this suite, so a collision (which would make a
+        # deploy a silent no-op) is caught rather than mis-measured.
+        self._deployed_sc_ids: set = set()
 
     # ---------------------------------------------------------------- helpers
 
@@ -149,6 +156,18 @@ class SCCollateralEngine:
             (self.did_a, _STATUS_COMMITTED, _TYPE_RBT),
         )
         return float(rows[0][0])
+
+    def _sc_token_value(self, sc_id: str) -> float:
+        """Stored token_value of a deployed smart contract token."""
+        rows = self._query(
+            """
+            SELECT t.token_value
+              FROM tokens t JOIN token_type tt ON tt.id = t.token_type
+             WHERE t.token_id = %s AND tt.name = %s
+            """,
+            (sc_id, "smart_contract"),
+        )
+        return float(rows[0][0]) if rows else -1.0
 
     def _denom_drift(self) -> List[tuple]:
         """Rows where token_denom disagrees with the real count of Free rows.
@@ -202,12 +221,44 @@ class SCCollateralEngine:
         return ", ".join(f"status={s} n={n}" for s, n in rows)
 
     def _deploy_fractional(self, label: str) -> Dict[str, Any]:
-        """Generate and deploy one contract at _SC_VALUE. Raises on failure."""
+        """Generate and deploy one contract at _SC_VALUE. Raises on failure.
+
+        The source file is made unique per deploy. A smart contract token ID is
+        the IPFS hash of its wasm+source folder (GenerateSmartContractToken ->
+        AddDir), so two deploys of identical files produce the SAME token ID and
+        the second is a no-op: it returns success but splits no RBT and commits
+        no collateral. select_smart_contract_files() picks at random from every
+        .wasm/.rs in the tree, so that collision happened intermittently and made
+        SCCOL_REPEATED_COST flaky — 3 deploys would charge for 2. Writing a
+        unique source per deploy guarantees a distinct token ID, so each deploy
+        is a real deploy and the cost assertion is meaningful.
+        """
         wasm_path, source_path = select_smart_contract_files()
-        result = self.node_a.create_smart_contract(self.did_a, wasm_path, source_path)
+
+        unique_source = os.path.join(
+            tempfile.mkdtemp(prefix="sccol-"), os.path.basename(source_path)
+        )
+        with open(source_path, "rb") as src:
+            original = src.read()
+        with open(unique_source, "wb") as dst:
+            dst.write(original)
+            dst.write(
+                f"\n// sc-collateral unique marker: {label} {uuid.uuid4()}\n".encode()
+            )
+
+        result = self.node_a.create_smart_contract(self.did_a, wasm_path, unique_source)
         sc_id = result.get("smartContractId")
         if not sc_id:
             raise RuntimeError(f"{label}: generate returned no smartContractId")
+
+        # A repeated token ID means the uniqueness guarantee above broke; the
+        # deploy would silently no-op and the cost assertions would be wrong.
+        if sc_id in self._deployed_sc_ids:
+            raise RuntimeError(
+                f"{label}: smart contract ID {sc_id} was already deployed in this "
+                "suite — the deploy would be a no-op and charge no collateral"
+            )
+        self._deployed_sc_ids.add(sc_id)
 
         req_id = self.node_a.initiate_smart_contract_transaction(
             initiator_did=self.did_a,
@@ -249,6 +300,7 @@ class SCCollateralEngine:
 
         for phase in (
             self._check_single_deploy_accounting,
+            self._check_deploy_value_matches_pledge,
             self._check_repeated_fractional_deploys,
         ):
             try:
@@ -407,6 +459,57 @@ class SCCollateralEngine:
                 + "; ".join(parts)
             ),
         }
+
+    def _check_deploy_value_matches_pledge(self) -> List[Dict[str, str]]:
+        """A deploy must be worth exactly the value requested for it.
+
+        transactionValue is what the initiator asks the quorum to pledge
+        (InitiateTransaction -> PledgeTokenRequest.TransactionValue), and it
+        comes from BuildTransactionInfoFromRequest. On the DEPLOY branch that is
+        scInfo.Value; on the EXECUTE branch it is the SC token's stored
+        TokenValue instead. So if a "deploy" is really a re-deploy of an
+        existing contract, the quorum is asked to pledge that contract's old
+        value rather than the value requested now — observed as a quorum
+        pledging 1 RBT for a 0.001 contract.
+
+        Asserting the deployed token's recorded value equals _SC_VALUE catches
+        that: a token carrying any other value was not deployed by this request.
+        """
+        out: List[Dict[str, str]] = []
+
+        deployed = self._deploy_fractional("pledge-value")
+        time.sleep(_SETTLE)
+
+        sc_id = deployed["sc_id"]
+        stored = self._sc_token_value(sc_id)
+
+        if stored < 0:
+            out.append({
+                "check": "SCCOL_DEPLOY_VALUE",
+                "status": "FAIL",
+                "detail": f"deployed SC {sc_id} has no smart_contract token row",
+            })
+        elif abs(stored - _SC_VALUE) < _EPSILON:
+            out.append({
+                "check": "SCCOL_DEPLOY_VALUE",
+                "status": "PASS",
+                "detail": (
+                    f"deployed SC token value is exactly {stored} — the quorum is "
+                    f"asked to pledge the requested {_SC_VALUE}, not a whole token"
+                ),
+            })
+        else:
+            out.append({
+                "check": "SCCOL_DEPLOY_VALUE",
+                "status": "FAIL",
+                "detail": (
+                    f"deployed SC {sc_id} carries value {stored}, expected {_SC_VALUE}; "
+                    "the quorum would be asked to pledge that value instead of the "
+                    "requested one (execute branch taken for what should be a deploy)"
+                ),
+            })
+
+        return out
 
     def _check_repeated_fractional_deploys(self) -> List[Dict[str, str]]:
         """Three fractional deploys back to back must all succeed.

--- a/test/integration/tests/sc_collateral.py
+++ b/test/integration/tests/sc_collateral.py
@@ -1,0 +1,331 @@
+"""
+sc_collateral.py — smart-contract deploy collateral accounting.
+
+Deploying a smart contract with a value locks RBT as collateral: the tokens
+backing that value are marked Committed (terminal) and the rest must come back
+to the deployer as change.
+
+The bug this guards against: LockTokensForSplit selects whole denominations, so
+backing a 0.001 commitment picks a whole 1.000 token. If that token is committed
+as-is, the other 0.999 is silently destroyed — a 0.001 contract costs a full RBT.
+
+SCCOL_DENOM_CONSISTENT covers a second, independent defect: post-consensus gates
+its token_denom update on Tokens.RBT being non-empty, but an SC deploy carries
+its collateral in CommittedTokens with Tokens.RBT empty, so the committed token
+is never decremented from the counter. The counter then over-reports free tokens
+and a later selection fails with "lockSelectedTokens: no tokens provided". That
+check is expected to FAIL until the denom guard is fixed separately.
+
+Why the existing smart_contract_engine suite cannot catch this: it deploys at
+sc_value=1.0, the single value where committing a whole 1.000 token is exactly
+correct, and it asserts only that deployment succeeded — never on balance. The
+defect is only visible when sc_value < denomination, so every case here uses a
+FRACTIONAL value.
+
+Cases:
+  - balance delta:  deployer's free balance drops by exactly sc_value
+  - committed sum:  Committed RBT totals sc_value, not a whole denomination
+  - denom drift:    token_denom agrees with the actual count of Free rows
+  - repeat deploys: three fractional deploys in a row all succeed (the failure
+                    mode that first exposed this — contracts 2 and 3 died once
+                    the stale counter over-reported availability)
+
+Results use the same {"check", "status", "detail"} shape as the other engines so
+they fold into verification.json and the runner's exit-on-fail gate.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Dict, List
+
+from test.integration.clients.api_client import NodeClient
+from test.integration.engines.file_selector import select_smart_contract_files
+
+log = logging.getLogger(__name__)
+
+# Deliberately smaller than the 1.000 denomination the wallet holds, so the
+# deploy must split a whole token and return change. At 1.0 the split is a
+# no-op and the bug is invisible.
+_SC_VALUE = 0.001
+
+# Sum of token_value may carry float representation noise; compare with a
+# tolerance well below the smallest value under test.
+_EPSILON = 1e-9
+
+# Settle time after a consensus round before reading balances back.
+_SETTLE = 6
+
+# token_status values (constants/constants.go): Free=0, Committed=5.
+_STATUS_FREE = 0
+_STATUS_COMMITTED = 5
+
+# token_type ids are lowercase names in the token_type table.
+_TYPE_RBT = "rbt"
+
+
+class SCCollateralEngine:
+    """Asserts SC deploy collateral is split, not consumed whole."""
+
+    def __init__(
+        self,
+        node_a: NodeClient,
+        did_a: str,
+        db_a: Any,
+        password: str = "mypassword",
+    ) -> None:
+        self.node_a = node_a
+        self.did_a = did_a
+        self.db_a = db_a
+        self.password = password
+
+    # ---------------------------------------------------------------- helpers
+
+    def _query(self, sql: str, params: tuple = ()) -> List[tuple]:
+        """Run a read-only query against node A's DB.
+
+        Connects by literal IPv4 rather than reusing db_a._connect(): in native
+        mode Postgres binds 127.0.0.1 only, while "localhost" resolves to ::1
+        first on some hosts, which fails with a misleading 'database does not
+        exist'. Copying the params and pinning the host keeps this suite working
+        in both native and Docker modes.
+        """
+        import psycopg2
+
+        params_ipv4 = dict(self.db_a.conn_params)
+        if params_ipv4.get("host") == "localhost":
+            params_ipv4["host"] = "127.0.0.1"
+
+        with psycopg2.connect(**params_ipv4) as conn, conn.cursor() as cur:
+            cur.execute(sql, params)
+            return cur.fetchall()
+
+    def _free_balance(self) -> float:
+        """Sum of Free RBT for the deployer, straight from the DB."""
+        rows = self._query(
+            """
+            SELECT COALESCE(SUM(token_value), 0)
+              FROM tokens
+             WHERE did = %s
+               AND token_status = %s
+               AND token_type = (SELECT id FROM token_type WHERE name = %s)
+            """,
+            (self.did_a, _STATUS_FREE, _TYPE_RBT),
+        )
+        return float(rows[0][0])
+
+    def _committed_sum(self) -> float:
+        """Sum of Committed RBT for the deployer — the SC collateral."""
+        rows = self._query(
+            """
+            SELECT COALESCE(SUM(token_value), 0)
+              FROM tokens
+             WHERE did = %s
+               AND token_status = %s
+               AND token_type = (SELECT id FROM token_type WHERE name = %s)
+            """,
+            (self.did_a, _STATUS_COMMITTED, _TYPE_RBT),
+        )
+        return float(rows[0][0])
+
+    def _denom_drift(self) -> List[tuple]:
+        """Rows where token_denom disagrees with the real count of Free rows.
+
+        Returns (denom, counter, actual, drift) for each mismatch; empty when
+        the counter is consistent.
+        """
+        return self._query(
+            """
+            SELECT d.denom,
+                   d.count,
+                   COALESCE(f.free_rows, 0),
+                   d.count - COALESCE(f.free_rows, 0) AS drift
+              FROM token_denom d
+              LEFT JOIN (
+                    SELECT did, token_value AS denom, COUNT(*) AS free_rows
+                      FROM tokens
+                     WHERE token_type = (SELECT id FROM token_type WHERE name = %s)
+                       AND token_status = %s
+                     GROUP BY did, token_value
+              ) f ON f.did = d.did AND f.denom = d.denom
+             WHERE d.did = %s
+               AND d.count - COALESCE(f.free_rows, 0) <> 0
+            """,
+            (_TYPE_RBT, _STATUS_FREE, self.did_a),
+        )
+
+    def _deploy_fractional(self, label: str) -> Dict[str, Any]:
+        """Generate and deploy one contract at _SC_VALUE. Raises on failure."""
+        wasm_path, source_path = select_smart_contract_files()
+        result = self.node_a.create_smart_contract(self.did_a, wasm_path, source_path)
+        sc_id = result.get("smartContractId")
+        if not sc_id:
+            raise RuntimeError(f"{label}: generate returned no smartContractId")
+
+        req_id = self.node_a.initiate_smart_contract_transaction(
+            initiator_did=self.did_a,
+            sc_id=sc_id,
+            sc_value=_SC_VALUE,
+            data="collateral-test",
+        )
+        response = self.node_a.complete_transaction(req_id, self.password)
+        return {"sc_id": sc_id, "response": response}
+
+    # ------------------------------------------------------------------- run
+
+    def run(self) -> List[Dict[str, str]]:
+        """Run every collateral check. Never raises — failures become results."""
+        results: List[Dict[str, str]] = []
+
+        for phase in (
+            self._check_single_deploy_accounting,
+            self._check_repeated_fractional_deploys,
+        ):
+            try:
+                results.extend(phase())
+            except Exception as exc:  # noqa: BLE001 - report, never abort the suite
+                log.error("SC collateral phase %s failed: %s", phase.__name__, exc)
+                results.append({
+                    "check": f"SCCOL_{phase.__name__.strip('_').upper()}",
+                    "status": "FAIL",
+                    "detail": f"phase raised: {exc}",
+                })
+
+        return results
+
+    # ---------------------------------------------------------------- phases
+
+    def _check_single_deploy_accounting(self) -> List[Dict[str, str]]:
+        """One fractional deploy: balance delta, committed sum, denom drift."""
+        out: List[Dict[str, str]] = []
+
+        balance_before = self._free_balance()
+        committed_before = self._committed_sum()
+        log.info(
+            "=== SC COLLATERAL: deploying at value=%s (free=%s committed=%s) ===",
+            _SC_VALUE, balance_before, committed_before,
+        )
+
+        self._deploy_fractional("single")
+        time.sleep(_SETTLE)
+
+        balance_after = self._free_balance()
+        committed_after = self._committed_sum()
+
+        # 1. The deployer loses exactly the contract's value — not a whole token.
+        spent = balance_before - balance_after
+        if abs(spent - _SC_VALUE) < _EPSILON:
+            out.append({
+                "check": "SCCOL_BALANCE_DELTA",
+                "status": "PASS",
+                "detail": f"free balance fell by exactly {spent} (value {_SC_VALUE})",
+            })
+        else:
+            out.append({
+                "check": "SCCOL_BALANCE_DELTA",
+                "status": "FAIL",
+                "detail": (
+                    f"free balance fell by {spent}, expected {_SC_VALUE} "
+                    f"({balance_before} -> {balance_after}); "
+                    "collateral was committed without splitting, so the change was lost"
+                ),
+            })
+
+        # 2. Only the contract's value is held as collateral.
+        newly_committed = committed_after - committed_before
+        if abs(newly_committed - _SC_VALUE) < _EPSILON:
+            out.append({
+                "check": "SCCOL_COMMITTED_SUM",
+                "status": "PASS",
+                "detail": f"committed RBT rose by exactly {newly_committed}",
+            })
+        else:
+            out.append({
+                "check": "SCCOL_COMMITTED_SUM",
+                "status": "FAIL",
+                "detail": (
+                    f"committed RBT rose by {newly_committed}, expected {_SC_VALUE}; "
+                    "a whole denomination was committed to back a fractional value"
+                ),
+            })
+
+        # 3. token_denom must still agree with reality. Drift here is what
+        #    later causes a spurious "no tokens provided" on the next deploy.
+        drift = self._denom_drift()
+        if not drift:
+            out.append({
+                "check": "SCCOL_DENOM_CONSISTENT",
+                "status": "PASS",
+                "detail": "token_denom matches the actual count of Free rows",
+            })
+        else:
+            detail = "; ".join(
+                f"denom={d} counter={c} actual={a} drift={dr}" for d, c, a, dr in drift
+            )
+            out.append({
+                "check": "SCCOL_DENOM_CONSISTENT",
+                "status": "FAIL",
+                "detail": f"token_denom drifted from actual Free rows: {detail}",
+            })
+
+        return out
+
+    def _check_repeated_fractional_deploys(self) -> List[Dict[str, str]]:
+        """Three fractional deploys back to back must all succeed.
+
+        This is the shape of the original failure: the first deploy consumed a
+        whole token, the denom counter kept advertising it, and deploys 2 and 3
+        died with "lockSelectedTokens: no tokens provided".
+        """
+        out: List[Dict[str, str]] = []
+        rounds = 3
+
+        balance_before = self._free_balance()
+        failures: List[str] = []
+
+        for i in range(1, rounds + 1):
+            try:
+                self._deploy_fractional(f"repeat-{i}")
+                log.info("SC collateral: repeat deploy %d/%d succeeded", i, rounds)
+            except Exception as exc:  # noqa: BLE001 - collected, reported below
+                failures.append(f"deploy {i}: {exc}")
+                log.error("SC collateral: repeat deploy %d/%d failed: %s", i, rounds, exc)
+            time.sleep(_SETTLE)
+
+        if failures:
+            out.append({
+                "check": "SCCOL_REPEATED_DEPLOYS",
+                "status": "FAIL",
+                "detail": f"{len(failures)}/{rounds} fractional deploys failed: " + "; ".join(failures),
+            })
+        else:
+            out.append({
+                "check": "SCCOL_REPEATED_DEPLOYS",
+                "status": "PASS",
+                "detail": f"all {rounds} consecutive fractional deploys succeeded",
+            })
+
+        # Whatever landed, the cost must be value-proportional, never one whole
+        # token per contract.
+        balance_after = self._free_balance()
+        spent = balance_before - balance_after
+        expected = _SC_VALUE * (rounds - len(failures))
+
+        if abs(spent - expected) < _EPSILON:
+            out.append({
+                "check": "SCCOL_REPEATED_COST",
+                "status": "PASS",
+                "detail": f"{rounds - len(failures)} deploys cost exactly {spent}",
+            })
+        else:
+            out.append({
+                "check": "SCCOL_REPEATED_COST",
+                "status": "FAIL",
+                "detail": (
+                    f"{rounds - len(failures)} deploys cost {spent}, expected {expected} "
+                    f"({balance_before} -> {balance_after})"
+                ),
+            })
+
+        return out

--- a/test/integration/tests/sc_collateral.py
+++ b/test/integration/tests/sc_collateral.py
@@ -74,10 +74,11 @@ _EPSILON = 1e-9
 # Settle time after a consensus round before reading balances back.
 _SETTLE = 6
 
-# The suite makes 5 deploys, each splitting a whole token to take _SC_VALUE from
-# it. One whole RBT per deploy must be selectable at the moment of the split, so
-# require a small whole-token float rather than 5 * _SC_VALUE.
-_MIN_REQUIRED_BALANCE = 5.0
+# The suite makes 6 deploys (one of which is also executed), each splitting a
+# whole token to take _SC_VALUE from it. One whole RBT per deploy must be
+# selectable at the moment of the split, so require a small whole-token float
+# rather than 6 * _SC_VALUE.
+_MIN_REQUIRED_BALANCE = 7.0
 
 # token_status values (constants/constants.go): Free=0, Committed=5,
 # BurntForFT=9.
@@ -301,6 +302,7 @@ class SCCollateralEngine:
         for phase in (
             self._check_single_deploy_accounting,
             self._check_deploy_value_matches_pledge,
+            self._check_execute_cost_matches_value,
             self._check_repeated_fractional_deploys,
         ):
             try:
@@ -506,6 +508,77 @@ class SCCollateralEngine:
                     f"deployed SC {sc_id} carries value {stored}, expected {_SC_VALUE}; "
                     "the quorum would be asked to pledge that value instead of the "
                     "requested one (execute branch taken for what should be a deploy)"
+                ),
+            })
+
+        return out
+
+    def _check_execute_cost_matches_value(self) -> List[Dict[str, str]]:
+        """Executing a 0.001 contract must pledge 0.001, not a whole token.
+
+        On the EXECUTE branch BuildTransactionInfoFromRequest sets
+        transactionValue from the SC token's stored TokenValue, and that value
+        is what the quorum is asked to pledge. The stored value is written at
+        deploy time from scInfo.Value, so the execute pledge inherits whatever
+        the deploy recorded: deploy at 0.001 and every later execution pledges
+        0.001; deploy at 1.0 and every execution pledges a whole RBT forever.
+
+        Execution commits no new RBT — the collateral pre-pass skips tokens that
+        already exist — so there is no balance delta to measure. What matters is
+        that the token still carries its deployed value after executing, since
+        that is the number the pledge is derived from.
+        """
+        out: List[Dict[str, str]] = []
+
+        deployed = self._deploy_fractional("execute-value")
+        sc_id = deployed["sc_id"]
+        time.sleep(_SETTLE)
+
+        value_before = self._sc_token_value(sc_id)
+
+        try:
+            self.node_a.execute_smart_contract(
+                executor_did=self.did_a,
+                sc_id=sc_id,
+                data="collateral-execute",
+                password=self.password,
+            )
+        except Exception as exc:  # noqa: BLE001 - reported as a result
+            out.append({
+                "check": "SCCOL_EXECUTE_VALUE",
+                "status": "FAIL",
+                "detail": f"execute of {sc_id} (value {value_before}) failed: {exc}",
+            })
+            return out
+
+        time.sleep(_SETTLE)
+        value_after = self._sc_token_value(sc_id)
+
+        if abs(value_before - _SC_VALUE) >= _EPSILON:
+            out.append({
+                "check": "SCCOL_EXECUTE_VALUE",
+                "status": "FAIL",
+                "detail": (
+                    f"SC {sc_id} was deployed at {value_before}, expected {_SC_VALUE}; "
+                    "every execution would pledge that value"
+                ),
+            })
+        elif abs(value_after - _SC_VALUE) < _EPSILON:
+            out.append({
+                "check": "SCCOL_EXECUTE_VALUE",
+                "status": "PASS",
+                "detail": (
+                    f"SC token still carries {value_after} after execution, so the "
+                    f"quorum is asked to pledge {_SC_VALUE} — not a whole token"
+                ),
+            })
+        else:
+            out.append({
+                "check": "SCCOL_EXECUTE_VALUE",
+                "status": "FAIL",
+                "detail": (
+                    f"SC {sc_id} value changed from {value_before} to {value_after} "
+                    "on execution; the execute pledge is derived from this value"
                 ),
             })
 

--- a/test/integration/tests/sc_collateral.py
+++ b/test/integration/tests/sc_collateral.py
@@ -9,12 +9,23 @@ The bug this guards against: LockTokensForSplit selects whole denominations, so
 backing a 0.001 commitment picks a whole 1.000 token. If that token is committed
 as-is, the other 0.999 is silently destroyed — a 0.001 contract costs a full RBT.
 
-SCCOL_DENOM_CONSISTENT covers a second, independent defect: post-consensus gates
-its token_denom update on Tokens.RBT being non-empty, but an SC deploy carries
-its collateral in CommittedTokens with Tokens.RBT empty, so the committed token
-is never decremented from the counter. The counter then over-reports free tokens
-and a later selection fails with "lockSelectedTokens: no tokens provided". That
-check is expected to FAIL until the denom guard is fixed separately.
+SCCOL_DENOM_CONSISTENT covers a second, independent defect on the same flow:
+post-consensus skipped its token_denom update for an SC deploy (the collateral
+rides in CommittedTokens with Tokens.RBT empty), and when it did run, the
+isLocalTransfer credit landed back on the initiator — a deploy pins Owner to
+Initiator — cancelling the decrement. Either way the counter kept advertising
+committed tokens as spendable until a later selection failed with
+"lockSelectedTokens: no tokens provided".
+
+This is the first token_denom invariant anywhere in the repo: the table is
+written by six code paths and, before this suite, was never once checked against
+reality. That is why it has been repaired repeatedly and drifted again. Running
+it immediately surfaced two further FT-side defects, reported separately by
+SCCOL_FT_DENOM_DRIFT with their attributed cause. That check FAILS: the drift is
+a real accounting defect (the counter advertises tokens that cannot be selected)
+and stays red until the FT paths decrement token_denom the way the RBT and SC
+paths do. It is kept separate from SCCOL_DENOM_CONSISTENT so an SC regression is
+never mistaken for the known FT one.
 
 Why the existing smart_contract_engine suite cannot catch this: it deploys at
 sc_value=1.0, the single value where committing a whole 1.000 token is exactly
@@ -25,7 +36,10 @@ FRACTIONAL value.
 Cases:
   - balance delta:  deployer's free balance drops by exactly sc_value
   - committed sum:  Committed RBT totals sc_value, not a whole denomination
-  - denom drift:    token_denom agrees with the actual count of Free rows
+  - denom drift:    token_denom agrees with the real Free rows at the SC
+                    collateral denomination
+  - FT denom drift: drift at other denominations, reported separately with its
+                    cause attributed (known-failing: FT paths do not decrement)
   - repeat deploys: three fractional deploys in a row all succeed (the failure
                     mode that first exposed this — contracts 2 and 3 died once
                     the stale counter over-reported availability)
@@ -57,9 +71,16 @@ _EPSILON = 1e-9
 # Settle time after a consensus round before reading balances back.
 _SETTLE = 6
 
-# token_status values (constants/constants.go): Free=0, Committed=5.
+# The suite makes 4 deploys, each splitting a whole token to take _SC_VALUE from
+# it. One whole RBT per deploy must be selectable at the moment of the split, so
+# require a small whole-token float rather than 4 * _SC_VALUE.
+_MIN_REQUIRED_BALANCE = 4.0
+
+# token_status values (constants/constants.go): Free=0, Committed=5,
+# BurntForFT=9.
 _STATUS_FREE = 0
 _STATUS_COMMITTED = 5
+_STATUS_BURNT_FOR_FT = 9
 
 # token_type ids are lowercase names in the token_type table.
 _TYPE_RBT = "rbt"
@@ -133,7 +154,9 @@ class SCCollateralEngine:
         """Rows where token_denom disagrees with the real count of Free rows.
 
         Returns (denom, counter, actual, drift) for each mismatch; empty when
-        the counter is consistent.
+        the counter is consistent. Scoped to self.did_a: node A also hosts the
+        intra-node secondary DID (did_a2), and mixing the two makes the numbers
+        impossible to read.
         """
         return self._query(
             """
@@ -154,6 +177,29 @@ class SCCollateralEngine:
             """,
             (_TYPE_RBT, _STATUS_FREE, self.did_a),
         )
+
+    def _status_breakdown(self, denom: float) -> str:
+        """Where this denomination's non-Free tokens went, as 'status=N count'.
+
+        A drift means the counter still claims tokens that have left Free, so
+        the statuses they moved to name the path that failed to decrement.
+        """
+        rows = self._query(
+            """
+            SELECT token_status, COUNT(*)
+              FROM tokens
+             WHERE did = %s
+               AND token_value = %s
+               AND token_type = (SELECT id FROM token_type WHERE name = %s)
+               AND token_status <> %s
+             GROUP BY token_status
+             ORDER BY token_status
+            """,
+            (self.did_a, denom, _TYPE_RBT, _STATUS_FREE),
+        )
+        if not rows:
+            return "no non-Free rows"
+        return ", ".join(f"status={s} n={n}" for s, n in rows)
 
     def _deploy_fractional(self, label: str) -> Dict[str, Any]:
         """Generate and deploy one contract at _SC_VALUE. Raises on failure."""
@@ -177,6 +223,29 @@ class SCCollateralEngine:
     def run(self) -> List[Dict[str, str]]:
         """Run every collateral check. Never raises — failures become results."""
         results: List[Dict[str, str]] = []
+
+        # Inside --run-all-tests this suite runs late, after the shuttle and the
+        # asset phases have spent from the same wallet. With no funds left every
+        # deploy fails on "no tokens provided" — the very error this suite exists
+        # to detect — for a reason that has nothing to do with the code under
+        # test. Distinguish the two up front: an unfunded wallet is a harness
+        # budgeting problem (SKIP), not an SC accounting defect (FAIL).
+        balance = self._free_balance()
+        if balance < _MIN_REQUIRED_BALANCE:
+            log.warning(
+                "SC collateral: skipping — node A holds %s RBT, need >= %s",
+                balance, _MIN_REQUIRED_BALANCE,
+            )
+            return [{
+                "check": "SCCOL_PRECONDITION",
+                "status": "SKIP",
+                "detail": (
+                    f"node A holds {balance} free RBT for did={self.did_a}, "
+                    f"below the {_MIN_REQUIRED_BALANCE} this suite needs. Earlier "
+                    "phases drained the wallet; raise min_balance_buffer in the "
+                    "config rather than reading this as an SC failure."
+                ),
+            }]
 
         for phase in (
             self._check_single_deploy_accounting,
@@ -250,26 +319,94 @@ class SCCollateralEngine:
                 ),
             })
 
-        # 3. token_denom must still agree with reality. Drift here is what
-        #    later causes a spurious "no tokens provided" on the next deploy.
+        # 3. token_denom must still agree with reality for the denomination this
+        #    suite spends. Drift here is what later causes a spurious
+        #    "no tokens provided" on the next deploy.
+        #
+        #    Drift at OTHER denominations is reported separately rather than
+        #    failing this check: it comes from known FT-side defects that this
+        #    suite does not exercise and must not be blamed for. Failing on it
+        #    would leave the check permanently red and teach people to ignore it.
         drift = self._denom_drift()
-        if not drift:
+        sc_drift = [row for row in drift if abs(float(row[0]) - _SC_VALUE) < _EPSILON]
+        other_drift = [row for row in drift if row not in sc_drift]
+
+        if not sc_drift:
             out.append({
                 "check": "SCCOL_DENOM_CONSISTENT",
                 "status": "PASS",
-                "detail": "token_denom matches the actual count of Free rows",
+                "detail": (
+                    f"token_denom matches the actual count of Free rows at "
+                    f"denom={_SC_VALUE} (the denomination this suite spends)"
+                ),
             })
         else:
             detail = "; ".join(
-                f"denom={d} counter={c} actual={a} drift={dr}" for d, c, a, dr in drift
+                f"denom={d} counter={c} actual={a} drift={dr} [{self._status_breakdown(d)}]"
+                for d, c, a, dr in sc_drift
             )
             out.append({
                 "check": "SCCOL_DENOM_CONSISTENT",
                 "status": "FAIL",
-                "detail": f"token_denom drifted from actual Free rows: {detail}",
+                "detail": (
+                    f"token_denom drifted at the SC collateral denomination for "
+                    f"did={self.did_a}: {detail}"
+                ),
             })
 
+        out.append(self._report_ft_denom_drift(other_drift))
+
         return out
+
+    def _report_ft_denom_drift(self, other_drift: List[tuple]) -> Dict[str, str]:
+        """Report denom drift this suite did not cause, attributing each cause.
+
+        token_denom has never had an invariant check before this suite, and the
+        run surfaces two long-standing FT-side defects:
+
+          - FT minting flips whole RBT parents to BurntForFT
+            (core/wallet/token_chain.go, FTGenesisTxn -> UpdateTokenInfo) without
+            decrementing token_denom, so the counter keeps advertising burnt
+            tokens as spendable.
+          - PersistGenesisTokenRecord upserts token_denom keyed on
+            token.TokenValue, and an FT token carries value 0, creating a phantom
+            denom=0 row counting tokens that can never be selected.
+
+        This FAILS, deliberately. The drift is a real accounting defect: the
+        counter advertises tokens that cannot be selected, which is what produced
+        "lockSelectedTokens: no tokens provided" on the SC side. Recording it as
+        advisory would let it sit indefinitely. It stays red until the FT paths
+        decrement token_denom the way the RBT and SC paths now do.
+        """
+        if not other_drift:
+            return {
+                "check": "SCCOL_FT_DENOM_DRIFT",
+                "status": "PASS",
+                "detail": "no denom drift outside the SC collateral denomination",
+            }
+
+        parts: List[str] = []
+        for denom, counter, actual, drift in other_drift:
+            breakdown = self._status_breakdown(denom)
+            if abs(float(denom)) < _EPSILON:
+                cause = "phantom denom=0 row from FT genesis (FT tokens carry value 0)"
+            elif f"status={_STATUS_BURNT_FOR_FT}" in breakdown:
+                cause = "RBT burnt for FT minting, never decremented"
+            else:
+                cause = "unattributed — investigate"
+            parts.append(
+                f"denom={denom} counter={counter} actual={actual} drift={drift} "
+                f"[{breakdown}] -> {cause}"
+            )
+
+        return {
+            "check": "SCCOL_FT_DENOM_DRIFT",
+            "status": "FAIL",
+            "detail": (
+                f"denom drift not caused by SC deploys, did={self.did_a}: "
+                + "; ".join(parts)
+            ),
+        }
 
     def _check_repeated_fractional_deploys(self) -> List[Dict[str, str]]:
         """Three fractional deploys back to back must all succeed.


### PR DESCRIPTION
## Problem

`token_denom` — the counter `lockTokensForSplitOnce` reads to pick which
denominations to select — was left stale by two paths that move RBT out of Free,
so later selections asked for tokens that no longer were, failing with
`lockSelectedTokens: no tokens provided` and blaming whatever ran next.

## Fixes

- **FT mint denom** — `UpdateTokenInfo` incremented instead of decrementing, and
  keyed on a `TokenValue` never copied: a phantom `denom=0` row, real
  denomination missed.
- **`.dockerignore`** — `docker/data/` stopped matching after the harness moved.

## Tests

First `token_denom` invariant coverage: `ft_parts.py` (FTs minted from a parts-only wallet — the main FT suite mints
from `did_a`, whose whole tokens are selected first). Both auto-run under
`--run-all-tests`; `ft-parts` also gets a standalone CI job, because inside the
full matrix it skips itself once earlier phases have drained node A.
