### PR TITLE
fix(consensus): return the stored signature when a quorum receives the same consensus request twice

### DIFF
--- a/core/core.go
+++ b/core/core.go
@@ -269,6 +269,10 @@ func (c *Core) SetupCore() error {
 	if c.ipfsOps != nil {
 		c.w.SetIPFSOperations(NewWalletIPFSAdapter(c.ipfsOps))
 	}
+	// Release NFT/SC tokens left Locked by a crash or restart mid-transaction; the deferred cleanup in initiateTransaction never ran for them.
+	if _, err := c.w.ReleaseStaleNFTAndSCLocksOnStartup(c.Ctx); err != nil {
+		c.log.Error("Failed to release stale NFT/SC locks on startup", "err", err)
+	}
 	c.PingSetup()
 	c.CheckQuorumStatusSetup()
 	c.peerSetup()

--- a/core/quorum_initiator.go
+++ b/core/quorum_initiator.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"time"
@@ -9,7 +10,9 @@ import (
 	"github.com/rubixchain/rubixgoplatform/core/consensus"
 	"github.com/rubixchain/rubixgoplatform/core/wallet"
 	"github.com/rubixchain/rubixgoplatform/did"
+	"github.com/rubixchain/rubixgoplatform/types"
 	"github.com/rubixchain/rubixgoplatform/types/models"
+	"github.com/rubixchain/rubixgoplatform/util"
 	"github.com/rubixchain/rubixgoplatform/wrapper/ensweb"
 )
 
@@ -266,6 +269,20 @@ func (c *Core) initiateConsensusHandler(request *ensweb.Request) *ensweb.Result 
 		response.Message = "initiateConsensusHandler: failed to build transaction record"
 		return c.l.RenderJSON(request, response, http.StatusBadRequest)
 	}
+	// Idempotent replay: same txID means the initiator lost our reply and retried; re-validating would reject it as a chain-tip conflict and fork the chain.
+	if storedSig, ok := c.storedQuorumSignature(txn.ID, quorumDid, quorumDc, txnInfo); ok {
+		c.log.Info("initiateConsensusHandler: duplicate consensus request for already-committed transaction, replying with stored signature",
+			"txID", txn.ID, "quorumDID", quorumDid, "referenceID", consensusRequest.ReferenceId)
+		// Tokens are already Pledged; keep the abort guard from touching them.
+		pledgeCommitted = true
+		return c.l.RenderJSON(request, &models.ConsensusResponse{
+			ReferenceId:     consensusRequest.ReferenceId,
+			QuorumSignature: storedSig,
+			Message:         "Transaction already committed by this quorum. Returning stored consensus signature.",
+			Status:          true,
+		}, http.StatusOK)
+	}
+
 	syncTxChains := func(peerDID string, tokenIDs []string, prevTxIDs map[string]string, excludeTxIDs []string) error {
 		return c.SyncTransactionChainsFromPeer(peerDID, tokenIDs, prevTxIDs, excludeTxIDs, false, c.fullNode)
 	}
@@ -459,6 +476,30 @@ func (c *Core) initiateConsensusHandler(request *ensweb.Request) *ensweb.Result 
 	pledgeCommitted = true
 
 	return c.l.RenderJSON(request, &consensusResponse, http.StatusOK)
+}
+
+// storedQuorumSignature returns this quorum's stored, verified signature for txID; ok=false on any miss so the caller falls through to full validation.
+func (c *Core) storedQuorumSignature(txID, quorumDID string, quorumDc types.DIDCrypto, txnInfo *models.TransactionInfo) (string, bool) {
+	stored, err := c.w.GetTransactionByID(txID, false)
+	if err != nil || stored == nil {
+		return "", false
+	}
+	var sig models.Signature
+	if err := json.Unmarshal(stored.Signature, &sig); err != nil {
+		c.log.Warn("storedQuorumSignature: failed to unmarshal stored signature", "txID", txID, "err", err)
+		return "", false
+	}
+	for _, q := range sig.Quorums {
+		if q.Did != quorumDID || q.Signature == "" {
+			continue
+		}
+		if err := util.VerifySignature(quorumDc, txnInfo, q.Signature); err != nil {
+			c.log.Warn("storedQuorumSignature: stored signature does not verify against incoming transaction info", "txID", txID, "err", err)
+			return "", false
+		}
+		return q.Signature, true
+	}
+	return "", false
 }
 
 func (c *Core) SetupQuorum(didStr string, pwd string, pvtKeyPwd string) error {

--- a/core/transaction.go
+++ b/core/transaction.go
@@ -79,16 +79,12 @@ func (c *Core) initiateTransaction(reqID string, request *models.TransactionRequ
 			} else {
 				c.log.Info("InitiateTransaction: released locked FTs after failed transaction", "did", initiatorDID)
 			}
-			// Also release any locked NFT/SC tokens. These are locked by
-			// BuildTransactionInfoFromRequest via QueryAndLockForExecution + batch
-			// status UPDATE, but ReleaseAllLockedRBTTokensForDID only handles RBT.
-			// Without this, NFT/SC tokens remain permanently stuck in Locked status
-			// after a failed transaction (e.g. consensus rejection, insufficient
-			// quorum liquidity).
-			if released, releaseErr := c.w.ReleaseAllLockedNFTAndSCTokensForDID(ctx, initiatorDID); releaseErr != nil {
-				c.log.Error("InitiateTransaction: failed to release locked NFT/SC tokens after failure", "err", releaseErr, "did", initiatorDID)
-			} else if released > 0 {
-				c.log.Info("InitiateTransaction: released locked NFT/SC tokens after failed transaction", "did", initiatorDID, "count", released)
+			// Release NFT/SC tokens locked by BuildTransactionInfoFromRequest, which ReleaseAllLockedRBTTokensForDID does not cover.
+			// Keyed on reqID, not initiatorDID: an NFT held by subscription has a remote tokens.did and would otherwise stay Locked forever.
+			if released, releaseErr := c.w.ReleaseLockedNFTAndSCTokensByReference(ctx, reqID); releaseErr != nil {
+				c.log.Error("InitiateTransaction: failed to release locked NFT/SC tokens after failure", "err", releaseErr, "did", initiatorDID, "referenceID", reqID)
+			} else {
+				c.log.Info("InitiateTransaction: released locked NFT/SC tokens after failed transaction", "did", initiatorDID, "referenceID", reqID, "count", released)
 			}
 		} else {
 			c.log.Debug("InitiateTransaction: Transaction succeeded, tokens will be transferred", "did", initiatorDID)

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -434,17 +434,14 @@ func (w *Wallet) ReleaseAllLockedFTTokensForDID(ctx context.Context, ownerDID st
 	return err
 }
 
-// ReleaseAllLockedNFTAndSCTokensForDID resets all Locked NFT and SmartContract tokens for a DID
-// back to their correct executable status. Unlike RBT tokens (which return to Free), NFT/SC
-// tokens must return to Deployed or Executed depending on their latest role:
-//   - latest_role = Deploy (4) → Deployed
-//   - anything else (Execute, etc.) → Executed
-//
-// Called on transaction failure after BuildTransactionInfoFromRequest to prevent NFT/SC tokens
-// from staying permanently locked when the transaction does not complete.
-// Note: NFT/SC tokens are locked via a batch UPDATE in BuildTransactionInfoFromRequest without
-// setting lock_reference_id, so we match by DID + Locked status + token type only.
-func (w *Wallet) ReleaseAllLockedNFTAndSCTokensForDID(ctx context.Context, ownerDID string) (int64, error) {
+// ReleaseLockedNFTAndSCTokensByReference resets the Locked NFT/SC tokens locked under referenceID back to Deployed or Executed.
+// Matches by lock_reference_id, not owner DID: the lock in BuildTransactionInfoFromRequest has no ownership filter, so tokens.did may be a remote owner.
+// Restores Deployed when latest_role is Deploy, otherwise Executed, and clears lock_reference_id so no stale reference is left on the row.
+// Refuses an empty referenceID so it can never become an unscoped release.
+func (w *Wallet) ReleaseLockedNFTAndSCTokensByReference(ctx context.Context, referenceID string) (int64, error) {
+	if referenceID == "" {
+		return 0, fmt.Errorf("ReleaseLockedNFTAndSCTokensByReference: empty referenceID; refusing unscoped release")
+	}
 	deployRoleID := int16(models.GetTokenRoleID(constants.TokenRole_Deploy))
 	result, err := w.db.Pool().Exec(ctx,
 		`UPDATE tokens SET
@@ -452,15 +449,16 @@ func (w *Wallet) ReleaseAllLockedNFTAndSCTokensForDID(ctx context.Context, owner
 		     WHEN latest_role = $1 THEN $2::smallint
 		     ELSE $3::smallint
 		   END,
+		   lock_reference_id = NULL,
 		   updated_at = $4
-		 WHERE did = $5
+		 WHERE lock_reference_id = $5
 		   AND token_status = $6
 		   AND token_type IN (
 		     (SELECT id FROM token_type WHERE name = $7),
 		     (SELECT id FROM token_type WHERE name = $8)
 		   )`,
 		deployRoleID, int16(constants.TokenStatus_Deployed), int16(constants.TokenStatus_Executed),
-		time.Now(), ownerDID, int16(constants.TokenStatus_Locked),
+		time.Now(), referenceID, int16(constants.TokenStatus_Locked),
 		constants.TokenType_NFT, constants.TokenType_SmartContract,
 	)
 	if err != nil {

--- a/core/wallet/token.go
+++ b/core/wallet/token.go
@@ -467,6 +467,37 @@ func (w *Wallet) ReleaseLockedNFTAndSCTokensByReference(ctx context.Context, ref
 	return result.RowsAffected(), nil
 }
 
+// ReleaseStaleNFTAndSCLocksOnStartup resets every Locked NFT/SC token back to Deployed or Executed and clears its lock_reference_id.
+// Safe only at process start: no transaction survives a restart, so any Locked NFT/SC row at boot was orphaned by a crash or shutdown mid-transaction.
+// Deliberately unscoped by DID or reference so it also repairs rows left behind by builds that released by owner DID.
+func (w *Wallet) ReleaseStaleNFTAndSCLocksOnStartup(ctx context.Context) (int64, error) {
+	w.log.Info("STARTUP_LOCK_SWEEP: releasing stale NFT/SC locks")
+	deployRoleID := int16(models.GetTokenRoleID(constants.TokenRole_Deploy))
+	result, err := w.db.Pool().Exec(ctx,
+		`UPDATE tokens SET
+		   token_status = CASE
+		     WHEN latest_role = $1 THEN $2::smallint
+		     ELSE $3::smallint
+		   END,
+		   lock_reference_id = NULL,
+		   updated_at = $4
+		 WHERE token_status = $5
+		   AND token_type IN (
+		     (SELECT id FROM token_type WHERE name = $6),
+		     (SELECT id FROM token_type WHERE name = $7)
+		   )`,
+		deployRoleID, int16(constants.TokenStatus_Deployed), int16(constants.TokenStatus_Executed),
+		time.Now(), int16(constants.TokenStatus_Locked),
+		constants.TokenType_NFT, constants.TokenType_SmartContract,
+	)
+	if err != nil {
+		w.log.Error("STARTUP_LOCK_SWEEP: failed", "err", err)
+		return 0, fmt.Errorf("ReleaseStaleNFTAndSCLocksOnStartup: %w", err)
+	}
+	w.log.Info("STARTUP_LOCK_SWEEP: done", "released", result.RowsAffected())
+	return result.RowsAffected(), nil
+}
+
 // ReleaseNonSelectedLockedRBTTokensForDID resets all Locked RBT tokens for a DID back to Free,
 // EXCLUDING the specified selectedTokenIDs, scoped to the given referenceID so that concurrent
 // pledge requests for the same DID cannot accidentally free each other's locked tokens.

--- a/test/integration/clients/api_client.py
+++ b/test/integration/clients/api_client.py
@@ -186,6 +186,11 @@ class NodeClient:
         log.info("[%s] Adding quorum DID: %s", self.name, quorum_did)
         return self._post("/rubix/v1/quorums/add", {"did": quorum_did})
 
+    def remove_all_quorums(self) -> Dict[str, Any]:
+        """Clear this node's quorum list (quorum_manager). Pair with add_quorum to repoint."""
+        log.info("[%s] Removing all quorum DIDs", self.name)
+        return self._get("/rubix/v1/quorums/remove_all")
+
     def setup_quorum(self, did: str, password: str = "mypassword") -> Dict[str, Any]:
         """Set up this node AS a quorum member using *did*."""
         log.info("[%s] Setting up quorum for DID: %s", self.name, did)

--- a/test/integration/clients/db_validator.py
+++ b/test/integration/clients/db_validator.py
@@ -237,6 +237,16 @@ class DBValidator:
             result = cur.fetchone()[0]
         return float(result)
 
+    def get_token_lock_state(self, token_id: str) -> Optional[Tuple[int, Optional[str]]]:
+        """Return (token_status, lock_reference_id) for *token_id*, or None if the row is absent."""
+        sql = "SELECT token_status, lock_reference_id FROM tokens WHERE token_id = %s"
+        with self._connect() as conn, conn.cursor() as cur:
+            cur.execute(sql, (token_id,))
+            row = cur.fetchone()
+        if row is None:
+            return None
+        return int(row[0]), row[1]
+
     def get_free_token_ids(self) -> List[str]:
         """Return token_ids with token_status = 0 (FREE) on this node."""
         sql = "SELECT token_id FROM tokens WHERE token_status = 0"

--- a/test/integration/tests/happy_path.py
+++ b/test/integration/tests/happy_path.py
@@ -953,6 +953,8 @@ FROM tokens;
             did_a=self.did_a,
             did_b=self.did_b,
             password=self.cfg.password,
+            did_q=self.did_q,
+            db_b=self.db_b,
         )
         return engine.run()
 

--- a/test/integration/tests/negative.py
+++ b/test/integration/tests/negative.py
@@ -24,16 +24,24 @@ Cases (4 families):
   - FT over-transfer: transfer more FTs than the DID holds.
   - invalid inputs: unknown/malformed receiver DID; non-positive amount;
     malformed DID on the public-key lookup.
+  - locked-NFT release: a child-mint on a SUBSCRIBED parent fails at pledge
+    ("Quorum is not setup"); the parent must return to Deployed with no
+    lock reference, and the retry against the real quorum must succeed.
 """
 
 from __future__ import annotations
 
 import logging
+import time
 from typing import Any, Dict, List, Optional
 
 from test.integration.clients.api_client import NodeClient
+from test.integration.clients.db_validator import DBValidator
 
 log = logging.getLogger(__name__)
+
+# tokens.token_status values (constants.TokenStatus_*) the lock-release case asserts on.
+_STATUS_DEPLOYED = 10
 
 # Node enforces constants.MaxSupportedDecimalPlaces = 3, so anything with >3
 # decimal places (and any RBT amount below 0.001) must be rejected.
@@ -47,6 +55,7 @@ _REASON_DECIMAL = ["decimal places", "fractional", "precise"]
 _REASON_FT_INSUFFICIENT = ["insufficient", "queryandlockfts", "ft lock failed", "have 0"]
 _REASON_INVALID_DID = ["did", "invalid", "not found", "peer", "unknown"]
 _REASON_BAD_AMOUNT = ["amount", "invalid", "must be", "greater than", "positive"]
+_REASON_QUORUM_NOT_SETUP = ["quorum is not setup"]
 
 
 class NegativeEngine:
@@ -56,6 +65,10 @@ class NegativeEngine:
         node_a/node_b: NodeClient for the two transacting nodes.
         did_a/did_b:   their primary DIDs.
         password:      wallet password for completing transactions.
+        did_q:         the real (set-up) quorum DID, restored after the
+                       locked-NFT case repoints nodeB at a bogus quorum.
+        db_b:          DBValidator for nodeB, used to read the parent NFT's
+                       tokens row. The locked-NFT case is skipped without it.
     """
 
     def __init__(
@@ -65,12 +78,16 @@ class NegativeEngine:
         did_a: str,
         did_b: str,
         password: str = "mypassword",
+        did_q: Optional[str] = None,
+        db_b: Optional[DBValidator] = None,
     ) -> None:
         self.node_a = node_a
         self.node_b = node_b
         self.did_a = did_a
         self.did_b = did_b
         self.password = password
+        self.did_q = did_q
+        self.db_b = db_b
 
     # ------------------------------------------------------------------
     # Assertion helpers
@@ -146,9 +163,94 @@ class NegativeEngine:
         results.extend(self._decimal_precision())
         results.extend(self._ft_over_transfer())
         results.extend(self._invalid_inputs())
+        results.extend(self._locked_nft_release_on_quorum_failure())
         passed = sum(1 for r in results if r["status"] == "PASS")
         log.info("=== NEGATIVE TESTS: %d/%d passed ===", passed, len(results))
         return results
+
+    def _locked_nft_release_on_quorum_failure(self) -> List[Dict[str, str]]:
+        """A failed child-mint on a subscribed parent must not leave it Locked.
+
+        nodeA deploys an NFT and nodeB subscribes, so nodeB's tokens row for it
+        carries nodeA's DID. nodeB then repoints its quorum at did_a (which never
+        ran setup-quorum) and child-mints: the pledge is rejected with "Quorum is
+        not setup". BuildTransactionInfoFromRequest has already locked the parent
+        by then, so the failure path must release it by lock reference — a
+        release keyed on the initiator DID misses this row and strands it. A
+        retry against the real quorum then proves the parent is usable again.
+        nodeB's quorum is restored in all cases.
+        """
+        if self.db_b is None or not self.did_q:
+            log.warning("NEG_NFT_LOCK_RELEASE: skipped (db_b / did_q not provided)")
+            return []
+
+        from test.integration.engines.file_selector import select_nft_files
+
+        check = "NEG_NFT_LOCK_RELEASED_ON_QUORUM_FAILURE"
+        out: List[Dict[str, str]] = []
+
+        # Setup: deploy on nodeA, subscribe on nodeB, wait for the row to sync.
+        try:
+            metadata_path, artifact_path = select_nft_files()
+            parent = self.node_a.create_nft(self.did_a, metadata_path, artifact_path)["nft_id"]
+            self.node_a.transfer_nft(
+                sender_did=self.did_a, receiver_did=self.did_a, nft_id=parent,
+                data="negative: parent for lock-release case", password=self.password,
+            )
+            self.node_b.subscribe_nft(parent)
+            before = None
+            deadline = time.time() + 60
+            while time.time() < deadline:
+                before = self.db_b.get_token_lock_state(parent)
+                if before is not None:
+                    break
+                time.sleep(2)
+        except Exception as exc:  # noqa: BLE001
+            return [{"check": check, "status": "FAIL", "detail": f"setup failed: {str(exc)[:160]}"}]
+
+        if before is None:
+            return [{"check": check, "status": "FAIL",
+                     "detail": "parent NFT never appeared in nodeB's tokens table after subscribe"}]
+        if before != (_STATUS_DEPLOYED, None):
+            return [{"check": check, "status": "FAIL",
+                     "detail": f"unexpected parent state on nodeB before the case: {before}"}]
+
+        # Break nodeB's quorum: did_a is a valid peer but never ran setup-quorum.
+        try:
+            self.node_b.remove_all_quorums()
+            self.node_b.add_quorum(self.did_a)
+
+            out.append(self._expect_rejection(
+                check,
+                lambda: self.node_b.mint_nft_children(
+                    initiator_did=self.did_b, parent_nft_id=parent,
+                    number_of_children=1, password=self.password,
+                ),
+                _REASON_QUORUM_NOT_SETUP,
+                unchanged={"nodeB_parent_row": (lambda: self.db_b.get_token_lock_state(parent), before)},
+            ))
+        finally:
+            self.node_b.remove_all_quorums()
+            self.node_b.add_quorum(self.did_q)
+
+        # The symptom being guarded: later attempts must work once the quorum is right.
+        retry_check = "NEG_NFT_CHILD_MINT_RETRY_AFTER_QUORUM_FIX"
+        try:
+            res = self.node_b.mint_nft_children(
+                initiator_did=self.did_b, parent_nft_id=parent,
+                number_of_children=1, password=self.password,
+            )
+            kids = self.node_b.extract_minted_children(res)
+            if len(kids) == 1:
+                out.append({"check": retry_check, "status": "PASS",
+                            "detail": f"child minted on retry: {kids[0].get('childNFTId', '')[:12]}..."})
+            else:
+                out.append({"check": retry_check, "status": "FAIL",
+                            "detail": f"retry succeeded but minted {len(kids)} children (expected 1)"})
+        except Exception as exc:  # noqa: BLE001
+            out.append({"check": retry_check, "status": "FAIL",
+                        "detail": f"retry after quorum fix was rejected: {str(exc)[:160]}"})
+        return out
 
     def _balance_violations(self) -> List[Dict[str, str]]:
         out: List[Dict[str, str]] = []


### PR DESCRIPTION
## Problem
  
  When the initiator sends a consensus request, the quorum validates it, pledges,
  commits the block, and replies with its signature. If that reply is lost on the
  wire (we saw a libp2p stream reset returning EOF, but a sync panic or a restart
  has the same effect), the initiator's PeerManager retries the identical request.

  The quorum already has that block as its chain head, so TokenChainIntegrityCheck
  treats the retry as a conflicting block and rejects it with 400. The initiator
  then marks the transaction failed and never persists the block. From that point
  the initiator is one position behind the quorum, and every later transaction on
  that token is rejected with the same integrity error until an operator manually
  replays the missing block.

  This was seen on the YMCA reward contract on 9 Sep 2026 and in four earlier
  forks on the same deployment.

  ## Fix

  Before running full validation, initiateConsensusHandler looks up the incoming
  transaction id in the quorum's own transactions table. If a row exists carrying
  this quorum's signature, and that signature verifies against the incoming
  TransactionInfo, the handler returns the stored signature with status true and
  leaves the already-pledged tokens untouched. Any miss falls through to the
  existing validation path unchanged.

  The transaction id is a hash of the serialized TransactionInfo, so a retried
  request always carries the same id as the committed one, and a modified payload
  produces a different id and is validated normally.

  No initiator-side change is needed: the existing three-attempt retry in
  PeerManager now recovers the lost signature on its own.

  ## Verification

  On a local testnet node running as quorum:

  - Re-sending a consensus request the quorum had already committed returned 200
    with the identical stored signature. Token rows and tokenchain were unchanged
    and the abort-release guard did not fire.
  - The same request with a modified memo took the normal path and was rejected
    by full validation with 400.

  Fixes #742 